### PR TITLE
thing-if module renewal

### DIFF
--- a/kii/kii.h
+++ b/kii/kii.h
@@ -427,6 +427,12 @@ kii_code_t kii_ti_put_thing_type(
     kii_t* kii,
     const char* thing_type);
 
+kii_code_t kii_ti_put_state(
+    kii_t* kii,
+    size_t content_length,
+    KII_CB_READ state_read_cb,
+    kii_bool_t send_to_normalizer);
+
 /** start to create request for REST API.
  *
  * Between this function and kii_api_call_run(kii_t*), you can call
@@ -535,6 +541,8 @@ kii_code_t kii_set_json_parser_resource_cb(kii_t* kii,
 const char* kii_get_etag(kii_t* kii);
 
 int kii_get_resp_status(kii_t* kii);
+
+void kii_ti_set_normalizer_site(kii_t* kii, const char* normalizer_site);
 
 #ifdef __cplusplus
 }

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -402,6 +402,31 @@ kii_code_t kii_execute_server_code(
 		const char* endpoint_name,
 		const char* params);
 
+kii_code_t kii_ti_onboard(
+    kii_t* kii,
+    const char* vendor_thing_id,
+    const char* password,
+    const char* thing_type,
+    const char* firmware_version,
+    const char* layout_position,
+    const char* thing_properties);
+
+kii_code_t kii_ti_put_firmware_version(
+    kii_t* kii,
+    const char* firmware_version);
+
+typedef struct kii_ti_firmware_version_t {
+    char firmware_version[128];
+} kii_ti_firmware_version_t;
+
+kii_code_t kii_ti_get_firmware_version(
+    kii_t* kii,
+    kii_ti_firmware_version_t* version);
+
+kii_code_t kii_ti_put_thing_type(
+    kii_t* kii,
+    const char* thing_type);
+
 /** start to create request for REST API.
  *
  * Between this function and kii_api_call_run(kii_t*), you can call

--- a/kii/kii_ti.c
+++ b/kii/kii_ti.c
@@ -44,5 +44,4 @@ void kii_ti_set_normalizer_site(
     const char* normalizer_site)
 {
     // TODO: implement it.
-    return KII_ERR_FAIL;
 }

--- a/kii/kii_ti.c
+++ b/kii/kii_ti.c
@@ -1,0 +1,48 @@
+#include "kii.h"
+
+kii_code_t kii_ti_onboard(
+    kii_t* kii,
+    const char* vendor_thing_id,
+    const char* password,
+    const char* thing_type,
+    const char* firmware_version,
+    const char* layout_position,
+    const char* thing_properties)
+{
+    // TODO: implement it.
+    return KII_ERR_FAIL;
+}
+
+kii_code_t kii_ti_put_firmware_version(
+    kii_t* kii,
+    const char* firmware_version)
+{
+    // TODO: implement it.
+    return KII_ERR_FAIL;
+}
+
+kii_code_t kii_ti_get_firmware_version(
+    kii_t* kii,
+    kii_ti_firmware_version_t* version)
+{
+    // TODO: implement it.
+    return KII_ERR_FAIL;
+}
+
+kii_code_t kii_ti_put_state(
+    kii_t* kii,
+    size_t content_length,
+    KII_CB_READ state_read_cb,
+    kii_bool_t send_to_normalizer)
+{
+    // TODO: implement it.
+    return KII_ERR_FAIL;
+}
+
+void kii_ti_set_normalizer_site(
+    kii_t* kii,
+    const char* normalizer_site)
+{
+    // TODO: implement it.
+    return KII_ERR_FAIL;
+}

--- a/tio/include/tio2.h
+++ b/tio/include/tio2.h
@@ -98,7 +98,7 @@ void tio_updater_set_app(tio_updater_t* updater, const char* app_id, const char*
 
 void tio_updater_set_interval(tio_updater_t* updater, size_t update_interval);
 
-tio_code_t tio_updater_start_with_author(
+tio_code_t tio_updater_start(
     tio_updater_t* updater,
     const tio_author_t* author,
     TIO_CB_READ state_reader,

--- a/tio/include/tio2.h
+++ b/tio/include/tio2.h
@@ -56,15 +56,6 @@ typedef struct tio_author_t {
     char token[64];
 } tio_author_t;
 
-typedef struct tio_onboard_req_t {
-    const char* vendor_thing_id;
-    const char* password;
-    const char* thing_type;
-    const char* firmware_version;
-    const char* layout_position;
-    const char* thing_properties;
-} tio_onboard_req_t;
-
 void tio_handler_set_cb_sock_connect_http(tio_handler_t* handler, KHC_CB_SOCK_CONNECT cb_connect, void* userdata);
 void tio_handler_set_cb_sock_send_http(tio_handler_t* handler, KHC_CB_SOCK_SEND cb_send, void* userdata);
 void tio_handler_set_cb_sock_recv_http(tio_handler_t* handler, KHC_CB_SOCK_RECV cb_recv, void* userdata);

--- a/tio/include/tio2.h
+++ b/tio/include/tio2.h
@@ -72,6 +72,9 @@ void tio_handler_set_cb_sock_send_mqtt(tio_handler_t* handler, KHC_CB_SOCK_SEND 
 void tio_handler_set_cb_sock_recv_mqtt(tio_handler_t* handler, KHC_CB_SOCK_RECV cb_recv, void* userdata);
 void tio_handler_set_cb_sock_close_mqtt(tio_handler_t* handler, KHC_CB_SOCK_CLOSE cb_close, void* userdata);
 
+void tio_handler_set_cb_task_create(tio_handler_t* handler, KII_TASK_CREATE cb_task_create);
+void tio_hadler_set_cb_delay_ms(tio_handler_t* handler, KII_DELAY_MS cb_delay_ms);
+
 void tio_handler_set_mqtt_buff(tio_handler_t* handler, char* buff, size_t buff_size);
 
 void tio_handler_set_keep_alive_interval(tio_handler_t* handler, size_t keep_alive_interval);
@@ -95,6 +98,9 @@ void tio_updater_set_cb_sock_connect(tio_updater_t* updater, KHC_CB_SOCK_CONNECT
 void tio_updater_set_cb_sock_send(tio_updater_t* updater, KHC_CB_SOCK_SEND cb_send, void* userdata);
 void tio_updater_set_cb_sock_recv(tio_updater_t* updater, KHC_CB_SOCK_RECV cb_recv, void* userdata);
 void tio_updater_set_cb_sock_close(tio_updater_t* updater, KHC_CB_SOCK_CLOSE cb_close, void* userdata);
+
+void tio_updater_set_cb_task_create(tio_updater_t* updater, KII_TASK_CREATE cb_task_create);
+void tio_updater_set_cb_delay_ms(tio_updater_t* updater, KII_DELAY_MS cb_delay_ms);
 
 void tio_updater_set_buff(tio_updater_t* updater, char* buff, size_t buff_size);
 

--- a/tio/include/tio2.h
+++ b/tio/include/tio2.h
@@ -74,7 +74,12 @@ void tio_handler_set_keep_alive_interval(tio_handler_t* handler, size_t keep_ali
 
 void tio_handler_set_app(tio_handler_t* handler, const char* app_id, const char* host);
 
-tio_code_t tio_handler_start(tio_handler_t* handler, const tio_author_t* author, TIO_CB_ACTION cb_action, void* userdata);
+tio_code_t tio_handler_start(
+    tio_handler_t* handler,
+    const tio_author_t* author,
+    const kii_mqtt_endpoint_t* endpoint,
+    TIO_CB_ACTION cb_action,
+    void* userdata);
 
 typedef struct tio_updater_t {
     TIO_CB_READ _state_reader;
@@ -96,7 +101,6 @@ void tio_updater_set_interval(tio_updater_t* updater, size_t update_interval);
 tio_code_t tio_updater_start_with_author(
     tio_updater_t* updater,
     const tio_author_t* author,
-    const kii_mqtt_endpoint_t* endpoint,
     TIO_CB_READ state_reader,
     void* userdata);
 

--- a/tio/include/tio2.h
+++ b/tio/include/tio2.h
@@ -83,9 +83,7 @@ void tio_handler_set_keep_alive_interval(tio_handler_t* handler, size_t keep_ali
 
 void tio_handler_set_app(tio_handler_t* handler, const char* app_id, const char* host);
 
-tio_code_t tio_handler_start_with_author(tio_handler_t* handler, const tio_author_t* author, TIO_CB_ACTION cb_action);
-
-tio_code_t tio_handelr_start(tio_handler_t* handler, const tio_onboard_req_t* onboard_req, TIO_CB_ACTION cb_action, tio_author_t* out_author, void* userdata);
+tio_code_t tio_handler_start(tio_handler_t* handler, const tio_author_t* author, TIO_CB_ACTION cb_action, void* userdata);
 
 typedef struct tio_updater_t {
     TIO_CB_READ _state_reader;
@@ -93,17 +91,22 @@ typedef struct tio_updater_t {
     size_t _update_interval;
 } tio_updater_t;
 
-void tio_updater_set_cb_sock_connect_mqtt(tio_updater_t* updater, KHC_CB_SOCK_CONNECT cb_connect, void* userdata);
-void tio_updater_set_cb_sock_send_mqtt(tio_updater_t* updater, KHC_CB_SOCK_SEND cb_send, void* userdata);
-void tio_updater_set_cb_sock_recv_mqtt(tio_updater_t* updater, KHC_CB_SOCK_RECV cb_recv, void* userdata);
-void tio_updater_set_cb_sock_close_mqtt(tio_updater_t* updater, KHC_CB_SOCK_CLOSE cb_close, void* userdata);
+void tio_updater_set_cb_sock_connect(tio_updater_t* updater, KHC_CB_SOCK_CONNECT cb_connect, void* userdata);
+void tio_updater_set_cb_sock_send(tio_updater_t* updater, KHC_CB_SOCK_SEND cb_send, void* userdata);
+void tio_updater_set_cb_sock_recv(tio_updater_t* updater, KHC_CB_SOCK_RECV cb_recv, void* userdata);
+void tio_updater_set_cb_sock_close(tio_updater_t* updater, KHC_CB_SOCK_CLOSE cb_close, void* userdata);
 
-void tio_updater_set_mqtt_buff(tio_updater_t* updater, char* buff, size_t buff_size);
+void tio_updater_set_buff(tio_updater_t* updater, char* buff, size_t buff_size);
 
 void tio_updater_set_app(tio_updater_t* updater, const char* app_id, const char* host);
 
 void tio_updater_set_interval(tio_updater_t* updater, size_t update_interval);
 
-tio_code_t tio_updater_start_with_author(tio_updater_t* updater, const tio_author_t* author, TIO_CB_READ state_reader, void* userdata);
+tio_code_t tio_updater_start_with_author(
+    tio_updater_t* updater,
+    const tio_author_t* author,
+    const kii_mqtt_endpoint_t* endpoint,
+    TIO_CB_READ state_reader,
+    void* userdata);
 
 #endif

--- a/tio/include/tio2.h
+++ b/tio/include/tio2.h
@@ -33,8 +33,12 @@ typedef struct tio_action_t {
     tio_action_params_t action_params;
 } tio_action_t;
 
+typedef struct tio_action_error_t {
+    const char error_message[64];
+} tio_action_error_t;
+
 typedef size_t (*TIO_CB_READ)(char *buffer, size_t size, size_t count, void *userdata);
-typedef tio_bool_t (*TIO_CB_ACTION)(tio_action_t action, void* userdata);
+typedef tio_bool_t (*TIO_CB_ACTION)(tio_action_t action, tio_action_error_t* error, void* userdata);
 
 typedef enum tio_code_t {
     TIO_ERR_OK,

--- a/tio/include/tio2.h
+++ b/tio/include/tio2.h
@@ -1,0 +1,109 @@
+#ifndef __tio2__
+#define __tio2__
+
+#include "kii.h"
+#include "khc.h"
+
+typedef kii_bool_t tio_bool_t;
+
+typedef enum tio_data_type_t {
+    TIO_TYPE_NULL,
+    TIO_TYPE_BOOLEAN,
+    TIO_TYPE_NUMBER,
+    TIO_TYPE_STRING,
+    TIO_TYPE_OBJECT,
+    TIO_TYPE_ARRAY
+} tio_data_type_t;
+
+typedef struct tio_action_params_t {
+    tio_data_type_t type;
+    union {
+        long long_value;
+        double double_value;
+        tio_bool_t bool_value;
+        const char *string_value;
+        const char *object_value;
+        const char *array_value;
+    } param;
+} tio_action_params_t;
+
+typedef struct tio_action_t {
+    const char* alias;
+    const char* action_name;
+    tio_action_params_t action_params;
+} tio_action_t;
+
+typedef size_t (*TIO_CB_READ)(char *buffer, size_t size, size_t count, void *userdata);
+typedef tio_bool_t (*TIO_CB_ACTION)(tio_action_t action, void* userdata);
+
+typedef enum tio_code_t {
+    TIO_ERR_OK,
+    TIO_ERR_FAIL
+} tio_code_t;
+
+typedef struct tio_handler_t {
+    TIO_CB_ACTION _cb_action;
+    kii_t _kii;
+    char* _http_buff;
+    size_t _http_buff_size;
+    char* _mqtt_buff;
+    size_t _mqtt_buff_size;
+    size_t _keep_alive_interval;
+} tio_handler_t;
+
+typedef struct tio_author_t {
+    char id[64];
+    char token[64];
+} tio_author_t;
+
+typedef struct tio_onboard_req_t {
+    const char* vendor_thing_id;
+    const char* password;
+    const char* thing_type;
+    const char* firmware_version;
+    const char* layout_position;
+    const char* thing_properties;
+} tio_onboard_req_t;
+
+void tio_handler_set_cb_sock_connect_http(tio_handler_t* handler, KHC_CB_SOCK_CONNECT cb_connect, void* userdata);
+void tio_handler_set_cb_sock_send_http(tio_handler_t* handler, KHC_CB_SOCK_SEND cb_send, void* userdata);
+void tio_handler_set_cb_sock_recv_http(tio_handler_t* handler, KHC_CB_SOCK_RECV cb_recv, void* userdata);
+void tio_handler_set_cb_sock_close_http(tio_handler_t* handler, KHC_CB_SOCK_CLOSE cb_close, void* userdata);
+
+void tio_handler_set_http_buff(tio_handler_t* handler, char* buff, size_t buff_size);
+
+void tio_handler_set_cb_sock_connect_mqtt(tio_handler_t* handler, KHC_CB_SOCK_CONNECT cb_connect, void* userdata);
+void tio_handler_set_cb_sock_send_mqtt(tio_handler_t* handler, KHC_CB_SOCK_SEND cb_send, void* userdata);
+void tio_handler_set_cb_sock_recv_mqtt(tio_handler_t* handler, KHC_CB_SOCK_RECV cb_recv, void* userdata);
+void tio_handler_set_cb_sock_close_mqtt(tio_handler_t* handler, KHC_CB_SOCK_CLOSE cb_close, void* userdata);
+
+void tio_handler_set_mqtt_buff(tio_handler_t* handler, char* buff, size_t buff_size);
+
+void tio_handler_set_keep_alive_interval(tio_handler_t* handler, size_t keep_alive_interval);
+
+void tio_handler_set_app(tio_handler_t* handler, const char* app_id, const char* host);
+
+tio_code_t tio_handler_start_with_author(tio_handler_t* handler, const tio_author_t* author, TIO_CB_ACTION cb_action);
+
+tio_code_t tio_handelr_start(tio_handler_t* handler, const tio_onboard_req_t* onboard_req, TIO_CB_ACTION cb_action, tio_author_t* out_author, void* userdata);
+
+typedef struct tio_updater_t {
+    TIO_CB_READ _state_reader;
+    kii_t _kii;
+    size_t _update_interval;
+} tio_updater_t;
+
+void tio_updater_set_cb_sock_connect_mqtt(tio_updater_t* updater, KHC_CB_SOCK_CONNECT cb_connect, void* userdata);
+void tio_updater_set_cb_sock_send_mqtt(tio_updater_t* updater, KHC_CB_SOCK_SEND cb_send, void* userdata);
+void tio_updater_set_cb_sock_recv_mqtt(tio_updater_t* updater, KHC_CB_SOCK_RECV cb_recv, void* userdata);
+void tio_updater_set_cb_sock_close_mqtt(tio_updater_t* updater, KHC_CB_SOCK_CLOSE cb_close, void* userdata);
+
+void tio_updater_set_mqtt_buff(tio_updater_t* updater, char* buff, size_t buff_size);
+
+void tio_updater_set_app(tio_updater_t* updater, const char* app_id, const char* host);
+
+void tio_updater_set_interval(tio_updater_t* updater, size_t update_interval);
+
+tio_code_t tio_updater_start_with_author(tio_updater_t* updater, const tio_author_t* author, TIO_CB_READ state_reader, void* userdata);
+
+#endif


### PR DESCRIPTION
# thing-if Thing SDK からの主な変更点

- モジュールの名前空間の変更: `kii_thing_if` -> `tio`

- `Command handler`と`State updater`を`thing_if_t`にまとめていたが、`thing_if_t`を廃止して別々のモジュールとして表現するようにした。

  - `Command handler`だけ実行, `State updater`だけ実行、両方実行する等の制御が可能。
  - 分けることでAPIが明快になった

- thing-ifのAPIを実行する機能を`kii`モジュール に移行した。
  - cloud/ thing-ifのREST APIは共通部分が多いので同じモジュールのほうが良い。