### PR TITLE
Fixed Read Callback handling

### DIFF
--- a/khc/src/khc_impl.c
+++ b/khc/src/khc_impl.c
@@ -269,14 +269,11 @@ void khc_state_req_header_end(khc* khc) {
 
 void khc_state_req_body_read(khc* khc) {
   khc->_read_size = khc->_cb_read(khc->_stream_buff, 1, khc->_stream_buff_size, khc->_read_data);
-  // TODO: handle read failure. let return signed value?
-  if (khc->_read_size > 0) {
-    khc->_state = KHC_STATE_REQ_BODY_SEND;
-  } else {
-    khc->_state = KHC_STATE_RESP_HEADERS_ALLOC;
-  }
-  if (khc->_read_size < khc->_stream_buff_size) {
+  if (khc->_read_size == 0) {
     khc->_read_req_end = 1;
+    khc->_state = KHC_STATE_RESP_HEADERS_ALLOC;
+  } else if (khc->_read_size > 0) {
+    khc->_state = KHC_STATE_REQ_BODY_SEND;
   }
   return;
 }

--- a/tests/large_test/khc/post_test.cpp
+++ b/tests/large_test/khc/post_test.cpp
@@ -54,10 +54,10 @@ TEST_CASE( "HTTP Post" ) {
   khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
   int on_read_called = 0;
-  io_ctx.on_read = [=, &on_read_called, &req_body](char *buffer, size_t size, size_t count, void *userdata) {
+  std::istringstream iss(req_body);
+  io_ctx.on_read = [=, &on_read_called, &iss](char *buffer, size_t size, size_t count, void *userdata) {
     ++on_read_called;
-    memcpy(buffer, req_body.c_str(), body_len);
-    return body_len;
+    return iss.read(buffer, size*count).gcount();
   };
 
   int on_header_called = 0;
@@ -94,7 +94,7 @@ TEST_CASE( "HTTP Post" ) {
   REQUIRE ( !access_token.get<std::string>().empty() );
   
   REQUIRE( res == KHC_ERR_OK );
-  REQUIRE( on_read_called == 1 );
+  REQUIRE( on_read_called == 2 );
   REQUIRE( on_header_called > 1 );
   REQUIRE( on_write_called == 1 );
 }

--- a/tests/small_test/khc/minimal_test.cpp
+++ b/tests/small_test/khc/minimal_test.cpp
@@ -94,7 +94,7 @@ TEST_CASE( "HTTP minimal" ) {
   khc_state_req_body_read(&http);
   REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND );
   REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( http._read_req_end == 1 );
+  REQUIRE( http._read_req_end == 0 );
   REQUIRE( called );
 
   called = false;
@@ -106,8 +106,21 @@ TEST_CASE( "HTTP minimal" ) {
     return KHC_SOCK_OK;
   };
   khc_state_req_body_send(&http);
+  REQUIRE( http._state == KHC_STATE_REQ_BODY_READ );
+  REQUIRE( http._result == KHC_ERR_OK );
+  REQUIRE( called );
+
+  called = false;
+  io_ctx.on_read = [=, &called](char *buffer, size_t size, size_t count, void *userdata) {
+    called = true;
+    REQUIRE( size == 1);
+    REQUIRE( count == buff_size);
+    return 0;
+  };
+  khc_state_req_body_read(&http);
   REQUIRE( http._state == KHC_STATE_RESP_HEADERS_ALLOC );
   REQUIRE( http._result == KHC_ERR_OK );
+  REQUIRE( http._read_req_end == 1 );
   REQUIRE( called );
 
   khc_state_resp_headers_alloc(&http);


### PR DESCRIPTION
Call `KHC_CB_READ` until it returns 0.
Expecting requested size to be read at once was wrong assumption in general. (ex. Data source is socket.)

Ref: https://curl.haxx.se/libcurl/c/CURLOPT_READFUNCTION.html