### PR TITLE
Specify content-type of put state.

### DIFF
--- a/kii/kii.h
+++ b/kii/kii.h
@@ -432,6 +432,7 @@ kii_code_t kii_ti_put_state(
     size_t content_length,
     KII_CB_READ state_read_cb,
     void* state_read_cb_data,
+    const char* opt_content_type,
     const char* opt_normalizer_host);
 
 /** start to create request for REST API.

--- a/kii/kii_ti.c
+++ b/kii/kii_ti.c
@@ -47,7 +47,8 @@ kii_code_t kii_ti_put_state(
     size_t content_length,
     KII_CB_READ state_read_cb,
     void* state_read_cb_data,
+    const char* opt_content_type,
     const char* opt_normalizer_host)
 {
-    return _put_state(kii, content_length, state_read_cb, state_read_cb_data, opt_normalizer_host);
+    return _put_state(kii, content_length, state_read_cb, state_read_cb_data, opt_content_type, opt_normalizer_host);
 }

--- a/kii/kii_ti_impl.c
+++ b/kii/kii_ti_impl.c
@@ -379,6 +379,7 @@ kii_code_t _put_state(
         size_t content_length,
         KII_CB_READ state_read_cb,
         void* state_read_cb_data,
+        const char* opt_content_type,
         const char* opt_normalizer_host)
 {
     kii_code_t ret = KII_ERR_FAIL;
@@ -405,7 +406,12 @@ kii_code_t _put_state(
         return ret;
     }
 
-    ret = _set_content_type(kii, "application/vnd.kii.MultipleTraitState+json");
+    if (opt_content_type != NULL) {
+        ret = _set_content_type(kii, opt_content_type);
+    } else {
+        ret = _set_content_type(kii, "application/vnd.kii.MultipleTraitState+json");
+    }
+
     if (ret != KII_ERR_OK) {
         _req_headers_free_all(kii);
         return ret;

--- a/kii/kii_ti_impl.h
+++ b/kii/kii_ti_impl.h
@@ -34,6 +34,7 @@ kii_code_t _put_state(
         size_t content_length,
         KII_CB_READ state_read_cb,
         void* state_read_cb_data,
+        const char* opt_content_type,
         const char* opt_normalizer_host);
 
 #endif

--- a/tests/large_test/kii/ti_test.cpp
+++ b/tests/large_test/kii/ti_test.cpp
@@ -117,7 +117,7 @@ TEST_CASE("TI Tests")
             };
         kiiltest::RWFunc ctx;
         ctx.on_read = on_read;
-        res = kii_ti_put_state(&kii, body.length(), kiiltest::read_cb, &ctx, NULL);
+        res = kii_ti_put_state(&kii, body.length(), kiiltest::read_cb, &ctx, "application/json", NULL);
 
         REQUIRE( res == KII_ERR_OK );
         REQUIRE( khc_get_status_code(&kii._khc) == 204 );

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -257,6 +257,7 @@ static void* _update_state(void* data) {
                 state_size,
                 updater->_state_reader,
                 updater->_state_reader_data,
+                NULL,
                 NULL);
             if (res != KII_ERR_OK) {
                 tio_code_t code = _tio_convert_code(res);


### PR DESCRIPTION
By default `kii_ti_put_state` handles multiple trait state. Enable to send non-trait state by specifying content-type (application/json)

The reason of not using boolean parameter to switch fixed content-type is foreseeing the introduction of new content-type as now we have normalizer which preprocess the state.