### PR TITLE
Http1.1 api change

### DIFF
--- a/kii/kii.h
+++ b/kii/kii.h
@@ -286,7 +286,6 @@ kii_code_t kii_upload_object_body(
 		const kii_bucket_t* bucket,
 		const char* object_id,
 		const char* body_content_type,
-        size_t body_content_length,
         const KII_CB_READ read_cb,
         void* userdata
 );
@@ -429,7 +428,6 @@ kii_code_t kii_ti_put_thing_type(
 
 kii_code_t kii_ti_put_state(
     kii_t* kii,
-    size_t content_length,
     KII_CB_READ state_read_cb,
     void* state_read_cb_data,
     const char* opt_content_type,

--- a/kii/kii_object.c
+++ b/kii/kii_object.c
@@ -180,7 +180,6 @@ kii_code_t kii_upload_object_body(
         const kii_bucket_t* bucket,
         const char* object_id,
         const char* body_content_type,
-        size_t body_content_length,
         const KII_CB_READ read_cb,
         void* userdata)
 {
@@ -188,7 +187,7 @@ kii_code_t kii_upload_object_body(
     _reset_buff(kii);
     khc_set_cb_read(&kii->_khc, read_cb, userdata);
 
-    kii_code_t ret = _upload_body(kii, bucket, object_id, body_content_type, body_content_length);
+    kii_code_t ret = _upload_body(kii, bucket, object_id, body_content_type);
     if (ret != KII_ERR_OK) {
         goto exit;
     }

--- a/kii/kii_object_impl.c
+++ b/kii/kii_object_impl.c
@@ -247,8 +247,7 @@ kii_code_t _upload_body(
         kii_t* kii,
         const kii_bucket_t* bucket,
         const char* object_id,
-        const char* body_content_type,
-        size_t body_content_length)
+        const char* body_content_type)
 {
     khc_set_host(&kii->_khc, kii->_app_host);
     khc_set_method(&kii->_khc, "PUT");
@@ -278,12 +277,6 @@ kii_code_t _upload_body(
     if (ret != KII_ERR_OK) {
         
         return ret;
-    }
-
-    ret = _set_content_length(kii, body_content_length);
-    if (ret != KII_ERR_OK) {
-        _req_headers_free_all(kii);
-        return KII_ERR_TOO_LARGE_DATA;
     }
 
     khc_set_req_headers(&kii->_khc, kii->_req_headers);

--- a/kii/kii_object_impl.h
+++ b/kii/kii_object_impl.h
@@ -60,8 +60,7 @@ kii_code_t _upload_body(
         kii_t* kii,
         const kii_bucket_t* bucket,
         const char* object_id,
-        const char* body_content_type,
-        size_t body_content_length);
+        const char* body_content_type);
 
 kii_code_t _download_body(
         kii_t* kii,

--- a/kii/kii_ti.c
+++ b/kii/kii_ti.c
@@ -44,11 +44,10 @@ kii_code_t kii_ti_get_firmware_version(
 
 kii_code_t kii_ti_put_state(
     kii_t* kii,
-    size_t content_length,
     KII_CB_READ state_read_cb,
     void* state_read_cb_data,
     const char* opt_content_type,
     const char* opt_normalizer_host)
 {
-    return _put_state(kii, content_length, state_read_cb, state_read_cb_data, opt_content_type, opt_normalizer_host);
+    return _put_state(kii, state_read_cb, state_read_cb_data, opt_content_type, opt_normalizer_host);
 }

--- a/kii/kii_ti_impl.c
+++ b/kii/kii_ti_impl.c
@@ -376,7 +376,6 @@ kii_code_t _get_firmware_version(
 
 kii_code_t _put_state(
         kii_t* kii,
-        size_t content_length,
         KII_CB_READ state_read_cb,
         void* state_read_cb_data,
         const char* opt_content_type,
@@ -417,12 +416,6 @@ kii_code_t _put_state(
         return ret;
     }
 
-    ret = _set_content_length(kii, content_length);
-    if (ret != KII_ERR_OK) {
-        _req_headers_free_all(kii);
-        return ret;
-    }
-
     khc_set_req_headers(&kii->_khc, kii->_req_headers);
     khc_set_cb_read(&kii->_khc, state_read_cb, state_read_cb_data);
     khc_code code = khc_perform(&kii->_khc);
@@ -439,6 +432,6 @@ kii_code_t _put_state(
         return KII_ERR_RESP_STATUS;
     }
 
-    return KII_ERR_OK;    
+    return KII_ERR_OK;
 }
 

--- a/kii/kii_ti_impl.h
+++ b/kii/kii_ti_impl.h
@@ -31,7 +31,6 @@ kii_code_t _get_firmware_version(
 
 kii_code_t _put_state(
         kii_t* kii,
-        size_t content_length,
         KII_CB_READ state_read_cb,
         void* state_read_cb_data,
         const char* opt_content_type,

--- a/tests/large_test/kii/object_test.cpp
+++ b/tests/large_test/kii/object_test.cpp
@@ -125,7 +125,7 @@ TEST_CASE("Object Tests")
                 };
                 kiiltest::RWFunc ctx;
                 ctx.on_read = on_read;
-                kii_code_t upload_res = kii_upload_object_body(&kii, &bucket, obj_id.id, "text/plain", body.length(), kiiltest::read_cb, &ctx);
+                kii_code_t upload_res = kii_upload_object_body(&kii, &bucket, obj_id.id, "text/plain", kiiltest::read_cb, &ctx);
                 REQUIRE( khc_get_status_code(&kii._khc) == 200 );
                 REQUIRE( upload_res == KII_ERR_OK );
 

--- a/tests/large_test/kii/ti_test.cpp
+++ b/tests/large_test/kii/ti_test.cpp
@@ -117,7 +117,7 @@ TEST_CASE("TI Tests")
             };
         kiiltest::RWFunc ctx;
         ctx.on_read = on_read;
-        res = kii_ti_put_state(&kii, body.length(), kiiltest::read_cb, &ctx, "application/json", NULL);
+        res = kii_ti_put_state(&kii, kiiltest::read_cb, &ctx, "application/json", NULL);
 
         REQUIRE( res == KII_ERR_OK );
         REQUIRE( khc_get_status_code(&kii._khc) == 204 );

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -254,7 +254,6 @@ static void* _update_state(void* data) {
         if (state_size > 0) {
             kii_code_t res = kii_ti_put_state(
                 &updater->_kii,
-                state_size,
                 updater->_state_reader,
                 updater->_state_reader_data,
                 NULL,


### PR DESCRIPTION
Removed content-length argument from APIs.

No need to give Content-Length beforehand since we're using chunked transfer encoding now.