### PR TITLE
[Do not merge] Unify tasks

### DIFF
--- a/kii/kii.h
+++ b/kii/kii.h
@@ -20,8 +20,7 @@ extern "C" {
 #define M_KII_LOG(...)
 #endif
 
-#define KII_TASK_NAME_RECV_MSG "recv_msg_task"
-#define KII_TASK_NAME_PING_REQ "ping_req_task"
+#define KII_TASK_NAME_MQTT "mqtt_task"
 
 typedef size_t (*KII_CB_WRITE)(char *ptr, size_t size, size_t count, void *userdata);
 typedef size_t (*KII_CB_READ)(char *buffer, size_t size, size_t count, void *userdata);

--- a/kii/kii_mqtt.c
+++ b/kii/kii_mqtt.c
@@ -362,7 +362,7 @@ int _mqtt_recvmsg(
     return 0;
 }
 
-void* _mqtt_start_recvmsg_task(void* sdata)
+void* _mqtt_start_task(void* sdata)
 {
     kii_t* kii;
     kii_mqtt_endpoint_t endpoint;

--- a/kii/kii_mqtt.c
+++ b/kii/kii_mqtt.c
@@ -371,8 +371,9 @@ void* _mqtt_start_recvmsg_task(void* sdata)
     memset(&endpoint, 0x00, sizeof(kii_mqtt_endpoint_t));
 
     kii = (kii_t*) sdata;
-    long total_waiting_time = 0;
+    long time_elapsed = 0;
     const int wait_time = 1000;
+    const int estimated_recv_time = 1000;
     const long keep_alive_interval = kii->_keep_alive_interval;
     for(;;)
     {
@@ -446,9 +447,9 @@ void* _mqtt_start_recvmsg_task(void* sdata)
                 kii->delay_ms_cb(wait_time);
                 // Assume that _mqtt_recvmsg takes less than 1 seconds
                 // Sending PingReq eariler than keep_alive_interval is OK.
-                total_waiting_time += wait_time * 2;
-                if (keep_alive_interval> 0 && total_waiting_time > keep_alive_interval) {
-                    total_waiting_time = 0;
+                time_elapsed += wait_time + estimated_recv_time;
+                if (keep_alive_interval > 0 && time_elapsed > keep_alive_interval * 1000) {
+                    time_elapsed = 0;
                     int ret = _mqtt_pingreq(kii);
                     if (ret != 0) {
                         kii->_mqtt_connected = 0;

--- a/kii/kii_mqtt.h
+++ b/kii/kii_mqtt.h
@@ -22,7 +22,6 @@ int _mqtt_recvmsg(
     kii_t* kii,
     kii_mqtt_endpoint_t* endpoint);
 void* _mqtt_start_recvmsg_task(void* sdata);
-void* _mqtt_start_pinreq_task(void* sdata);
 
 #endif
 /* vim:set ts=4 sts=4 sw=4 et fenc=UTF-8 ff=unix: */

--- a/kii/kii_mqtt.h
+++ b/kii/kii_mqtt.h
@@ -21,7 +21,7 @@ int _mqtt_pingreq(kii_t* kii);
 int _mqtt_recvmsg(
     kii_t* kii,
     kii_mqtt_endpoint_t* endpoint);
-void* _mqtt_start_recvmsg_task(void* sdata);
+void* _mqtt_start_task(void* sdata);
 
 #endif
 /* vim:set ts=4 sts=4 sw=4 et fenc=UTF-8 ff=unix: */

--- a/kii/kii_push.c
+++ b/kii/kii_push.c
@@ -251,7 +251,7 @@ kii_code_t kii_start_push_routine(kii_t* kii, unsigned int keep_alive_interval, 
     kii->push_received_cb = callback;
     kii->_push_data = userdata;
     kii->task_create_cb(KII_TASK_NAME_RECV_MSG,
-        _mqtt_start_recvmsg_task,
+        _mqtt_start_task,
         (void*)kii);
     return KII_ERR_OK;
 }

--- a/kii/kii_push.c
+++ b/kii/kii_push.c
@@ -253,11 +253,6 @@ kii_code_t kii_start_push_routine(kii_t* kii, unsigned int keep_alive_interval, 
     kii->task_create_cb(KII_TASK_NAME_RECV_MSG,
         _mqtt_start_recvmsg_task,
         (void*)kii);
-    if (keep_alive_interval > 0) {
-        kii->task_create_cb(KII_TASK_NAME_PING_REQ,
-            _mqtt_start_pinreq_task,
-            (void*)kii);
-    }
     return KII_ERR_OK;
 }
 /* vim:set ts=4 sts=4 sw=4 et fenc=UTF-8 ff=unix: */

--- a/kii/kii_push.c
+++ b/kii/kii_push.c
@@ -250,7 +250,7 @@ kii_code_t kii_start_push_routine(kii_t* kii, unsigned int keep_alive_interval, 
     kii->_keep_alive_interval = keep_alive_interval;
     kii->push_received_cb = callback;
     kii->_push_data = userdata;
-    kii->task_create_cb(KII_TASK_NAME_RECV_MSG,
+    kii->task_create_cb(KII_TASK_NAME_MQTT,
         _mqtt_start_task,
         (void*)kii);
     return KII_ERR_OK;

--- a/tio/README.md
+++ b/tio/README.md
@@ -501,7 +501,7 @@ The name of tasks executed by `tio_handler_t` and `tio_updater_t` listed bellow.
 
     The task creation is requested once when the `tio_handler_start()` method is invoked.
 
-    This task is responsible for getting MQTT endpoint information thru REST API and connect, receive message from MQTT and propagate message to app by the `TIO_CB_ACTION` callback.
+    This task is responsible for getting MQTT endpoint information thru REST API and connect, receive message from MQTT and propagate message to app by the `TIO_CB_ACTION` callback. This task also sends PingReq message to server if the Keep Alive interval is set to larger than 0.
 
     This task executes callbacks set by following APIs.
 
@@ -525,21 +525,7 @@ The name of tasks executed by `tio_handler_t` and `tio_updater_t` listed bellow.
     - `tio_handler_set_http_buff()`
     - `tio_handler_set_mqtt_buff()`
 
-    Those two buffers must be separated and have no overlaps.
-
-- `KII_TASK_NAME_PING_REQ` is a name of the task defined at `kii.h` and passed as argument when `tio_handler_set_cb_task_create()` is called to create task/ thread.
-
-    The task creation is requested once when the `tio_handler_start()` method is invoked.
-
-    This task is responsible for sending MQTT `PingReq` message periodically in specified Keep Alive interval.
-
-    This task executes callbacks set by following APIs.
-
-    - `tio_handler_set_cb_sock_send_mqtt()`
-    - `tio_handler_set_cb_delay_ms()`
-
-    This task doesn't use buffers given by APIs.
-    (MQTT PingResp is handled in `KII_TASK_NAME_MQTT` task.)
+    Those buffers must be separated and have no overlaps.
 
 ## Tasks executed by `tio_updater_t`.
 
@@ -566,8 +552,12 @@ The name of tasks executed by `tio_handler_t` and `tio_updater_t` listed bellow.
 
     - `tio_updater_set_buff()`
 
+    Those buffers must be separated and have no overlaps with buffers used by `tio_handler_t`.
+
 ## Avoiding race condtion
 
-- Above 3 tasks `KII_TASK_NAME_MQTT`, `KII_TASK_NAME_PING_REQ`, `TIO_TASK_NAME_UPDATE_STATE` would be executed in parallel. Therefore, if the callback implementation shares the resource that need exclusive access, you need to implement access controll mechanism.
+- Above 2 tasks `KII_TASK_NAME_MQTT` and `TIO_TASK_NAME_UPDATE_STATE` would be executed in parallel. Therefore, if the callback implementation shares the resource that need exclusive access, you need to implement access controll mechanism.
 
 - You must prepare independent buffers which does not have overlaps.
+
+- `tio_handler_t` and `tio_updater_t` instance is referenced/ changed by the task. Application must not reference to or change those instance after the `tio_handler_start()` / `tio_updater_start()` method is invoked.

--- a/tio/README.md
+++ b/tio/README.md
@@ -497,7 +497,7 @@ The name of tasks executed by `tio_handler_t` and `tio_updater_t` listed bellow.
 
 ## Tasks executed by `tio_handler_t`.
 
-- `KII_TASK_NAME_MQTT` is a name of the task defined at `kii.h` and passed as argument when `tio_handler_set_cb_task_create()` is called to create task/ thread.
+- `KII_TASK_NAME_MQTT` is a name of the task defined at `kii.h` and passed as argument when `cb_task_create` callback function pointer (passed to `tio_handler_set_cb_task_create()`) is called to create task/ thread.
 
     The task creation is requested once when the `tio_handler_start()` method is invoked.
 
@@ -529,7 +529,7 @@ The name of tasks executed by `tio_handler_t` and `tio_updater_t` listed bellow.
 
 ## Tasks executed by `tio_updater_t`.
 
-- `TIO_TASK_NAME_UPDATE_STATE` is a name of the task defined at `kii.h` and passed as argument when `tio_handler_set_cb_task_create()` is called to create task/ thread.
+- `TIO_TASK_NAME_UPDATE_STATE` is a name of the task defined at `kii.h` and passed as argument when `cb_task_create` callback function pointer (passed to `tio_updater_set_cb_task_create()`) is called to create task/ thread.
 
     The task creation is requested once when the `tio_updater_start()` method is invoked.
 

--- a/tio/README.md
+++ b/tio/README.md
@@ -353,7 +353,7 @@ Now, it's ready to start `tio_handler_t` module.
   Passing NULL since we don't use context object in this example.
 
 This call results to execute asynchronous tasks created by [Task callbacks](#task-callbacks).
-The name of tasks initiated by this call is exporte as macro `KII_TASK_NAME_RECV_MSG` and `KII_TASK_NAME_PING_REQ` defined in `kii.h`.
+The name of tasks initiated by this call is exporte as macro `KII_TASK_NAME_MQTT` and `KII_TASK_NAME_PING_REQ` defined in `kii.h`.
 
 # Use `tio_updater_t`
 
@@ -497,7 +497,7 @@ The name of tasks executed by `tio_handler_t` and `tio_updater_t` listed bellow.
 
 ## Tasks executed by `tio_handler_t`.
 
-- `KII_TASK_NAME_RECV_MSG` is a name of the task defined at `kii.h` and passed as argument when `tio_handler_set_cb_task_create()` is called to create task/ thread.
+- `KII_TASK_NAME_MQTT` is a name of the task defined at `kii.h` and passed as argument when `tio_handler_set_cb_task_create()` is called to create task/ thread.
 
     The task creation is requested once when the `tio_handler_start()` method is invoked.
 
@@ -539,7 +539,7 @@ The name of tasks executed by `tio_handler_t` and `tio_updater_t` listed bellow.
     - `tio_handler_set_cb_delay_ms()`
 
     This task doesn't use buffers given by APIs.
-    (MQTT PingResp is handled in `KII_TASK_NAME_RECV_MSG` task.)
+    (MQTT PingResp is handled in `KII_TASK_NAME_MQTT` task.)
 
 ## Tasks executed by `tio_updater_t`.
 
@@ -568,6 +568,6 @@ The name of tasks executed by `tio_handler_t` and `tio_updater_t` listed bellow.
 
 ## Avoiding race condtion
 
-- Above 3 tasks `KII_TASK_NAME_RECV_MSG`, `KII_TASK_NAME_PING_REQ`, `TIO_TASK_NAME_UPDATE_STATE` would be executed in parallel. Therefore, if the callback implementation shares the resource that need exclusive access, you need to implement access controll mechanism.
+- Above 3 tasks `KII_TASK_NAME_MQTT`, `KII_TASK_NAME_PING_REQ`, `TIO_TASK_NAME_UPDATE_STATE` would be executed in parallel. Therefore, if the callback implementation shares the resource that need exclusive access, you need to implement access controll mechanism.
 
 - You must prepare independent buffers which does not have overlaps.


### PR DESCRIPTION
Unifying task proposed in #51.

Failed to unify. It was not possible to `estimate` how long `reading` from MQTT stream takes.
If there's no message, it takes long but it takes very short if there's message or `PingResp`.
Also the time varies depending on if the socket is non-bloking mode.

To unify the task, we need new system callbacks asking time of the system.

