### PR TITLE
Introduced timeouts for recv/ send data from socket.

### DIFF
--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -181,6 +181,8 @@ typedef struct khc {
   void* _sock_ctx_send; /**< \private **/
   void* _sock_ctx_recv; /**< \private **/
   void* _sock_ctx_close; /**< \private **/
+  unsigned int _to_recv_in_seconds;  /**< \private **/
+  unsigned int _to_send_in_seconds;  /**< \private **/
 
   khc_slist* _current_req_header; /**< \private **/
 
@@ -316,11 +318,15 @@ khc_code khc_set_stream_buff(khc* khc, char* buffer, size_t buff_size);
  *
  * \param [out] khc instance.
  * \param [in] cb called when socket connection to the server is required.
+ * \param [in] to_recv_in_seconds timeout applied when receiving data from socket.
+ * \param [in] to_send_in_seconds timeout applied when sending data from socket.
  * \param [in] userdata context data of the callback.
  */
 khc_code khc_set_cb_sock_connect(
   khc* khc,
   KHC_CB_SOCK_CONNECT cb,
+  unsigned int to_recv_in_seconds,
+  unsigned int to_send_in_seconds,
   void* userdata);
 
 /**

--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -234,7 +234,7 @@ khc_code khc_set_zero(khc* khc);
  * \brief Set members of khc 0/NULL.
  * 
  * However, callbacks/ userdata set by 
- * khc_set_cb_sock_connect(khc*, KHC_CB_SOCK_CONNECT, void*),
+ * khc_set_cb_sock_connect(khc*, KHC_CB_SOCK_CONNECT, unsigned int, unsigned int, void*),
  * khc_set_cb_sock_send(khc*, KHC_CB_SOCK_SEND, void*),
  * khc_set_cb_sock_recv(khc*, KHC_CB_SOCK_RECV, void*),
  * khc_set_cb_sock_close(khc*, KHC_CB_SOCK_CLOSE, void*),

--- a/khc/include/khc_socket_callback.h
+++ b/khc/include/khc_socket_callback.h
@@ -34,11 +34,15 @@ typedef enum khc_sock_code_t {
  * @param [in] sock_ctx context object.
  * @param [in] host host name.
  * @param [in] port port number.
+ * @param [in] to_recv_in_seconds read timeout in seconds.
+ * @param [in] to_send_in_seconds read timeout in seconds.
  * @returns khc_sock_code_t
  */
 typedef khc_sock_code_t
     (*KHC_CB_SOCK_CONNECT)
-    (void* sock_ctx, const char* host, unsigned int port);
+    (void* sock_ctx, const char* host, unsigned int port,
+    unsigned int to_recv_in_seconds,
+    unsigned int to_send_in_seconds);
 
 /** \brief Callback function sends data to server.
  *

--- a/khc/src/khc.c
+++ b/khc/src/khc.c
@@ -84,6 +84,9 @@ khc_code khc_set_zero(khc* khc) {
   khc->_cb_sock_close = NULL;
   khc->_sock_ctx_close = NULL;
 
+  khc->_to_recv_in_seconds = 0;
+  khc->_to_send_in_seconds = 0;
+
   khc_set_zero_excl_cb(khc);
 
   return KHC_ERR_OK;

--- a/khc/src/khc_state_impl.c
+++ b/khc/src/khc_state_impl.c
@@ -9,10 +9,14 @@
 khc_code khc_set_cb_sock_connect(
   khc* khc,
   KHC_CB_SOCK_CONNECT cb,
+  unsigned int to_recv_in_seconds,
+  unsigned int to_send_in_seconds,
   void* userdata)
 {
   khc->_cb_sock_connect = cb;
   khc->_sock_ctx_connect = userdata;
+  khc->_to_recv_in_seconds = to_recv_in_seconds;
+  khc->_to_send_in_seconds = to_send_in_seconds;
   return KHC_ERR_OK;
 }
 
@@ -136,7 +140,7 @@ void khc_state_idle(khc* khc) {
 }
 
 void khc_state_connect(khc* khc) {
-  khc_sock_code_t con_res = khc->_cb_sock_connect(khc->_sock_ctx_connect, khc->_host, 443);
+  khc_sock_code_t con_res = khc->_cb_sock_connect(khc->_sock_ctx_connect, khc->_host, 443, khc->_to_recv_in_seconds, khc->_to_send_in_seconds);
   if (con_res == KHC_SOCK_OK) {
     khc->_state = KHC_STATE_REQ_LINE;
     return;

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -100,8 +100,8 @@ int kii_set_buff(kii_t* kii, char* buff, size_t buff_size) {
     return 0;
 }
 
-int kii_set_http_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata) {
-    khc_set_cb_sock_connect(&kii->_khc, cb, userdata);
+int kii_set_http_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds, void* userdata) {
+    khc_set_cb_sock_connect(&kii->_khc, cb, to_recv_in_seconds, to_send_in_seconds, userdata);
     return 0;
 }
 
@@ -120,9 +120,11 @@ int kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata)
     return 0;
 }
 
-int kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata) {
+int kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds, void* userdata) {
     kii->mqtt_sock_connect_cb = cb;
     kii->mqtt_sock_connect_ctx = userdata;
+    kii->_mqtt_to_recv_in_seconds = to_recv_in_seconds;
+    kii->_mqtt_to_send_in_seconds = to_send_in_seconds;
     return 0;
 }
 

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -123,6 +123,9 @@ typedef struct kii_t {
     KHC_CB_SOCK_RECV mqtt_sock_recv_cb;
     KHC_CB_SOCK_CLOSE mqtt_sock_close_cb;
 
+    unsigned int _mqtt_to_recv_in_seconds;
+    unsigned int _mqtt_to_send_in_seconds;
+
     KII_TASK_CREATE task_create_cb;
 
     KII_DELAY_MS delay_ms_cb;
@@ -509,12 +512,12 @@ kii_code_t kii_api_call_run(kii_t* kii);
 
 int kii_set_buff(kii_t* kii, char* buff, size_t buff_size);
 
-int kii_set_http_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);
+int kii_set_http_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds, void* userdata);
 int kii_set_http_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);
 int kii_set_http_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata);
 int kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata);
 
-int kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);
+int kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds, void* userdata);
 int kii_set_mqtt_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);
 int kii_set_mqtt_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata);
 int kii_set_mqtt_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata);

--- a/kii/kii_mqtt.c
+++ b/kii/kii_mqtt.c
@@ -434,6 +434,7 @@ void* _mqtt_start_recvmsg_task(void* sdata)
                 pushState = KII_MQTT_READY;
                 break;
             case KII_MQTT_READY:
+                // TODO: Fix the logic. Recv timeout is introduced.
                 if(_mqtt_recvmsg(kii, &endpoint) != 0)
                 {
                     /* Receiving notificaiton is failed. Retry subscribing. */

--- a/kii/kii_mqtt.c
+++ b/kii/kii_mqtt.c
@@ -67,7 +67,7 @@ int _mqtt_connect(kii_t* kii, kii_mqtt_endpoint_t* endpoint, unsigned short keep
 #else
     port = endpoint->port_tcp;
 #endif
-    sock_err = kii->mqtt_sock_connect_cb(kii->mqtt_sock_connect_ctx, endpoint->host, port);
+    sock_err = kii->mqtt_sock_connect_cb(kii->mqtt_sock_connect_ctx, endpoint->host, port, kii->_mqtt_to_recv_in_seconds, kii->_mqtt_to_send_in_seconds);
     if (sock_err != KHC_SOCK_OK) {
         M_KII_LOG("connecting socket is failed.\r\n");
         return -1;

--- a/tests/large_test/khc/get_test.cpp
+++ b/tests/large_test/khc/get_test.cpp
@@ -15,7 +15,7 @@ TEST_CASE( "HTTP Get" ) {
   khc_set_req_headers(&http, NULL);
 
   ebisu::ltest::ssl::SSLData s_ctx;
-  khc_set_cb_sock_connect(&http, ebisu::ltest::ssl::cb_connect, &s_ctx);
+  khc_set_cb_sock_connect(&http, ebisu::ltest::ssl::cb_connect, 15, 15, &s_ctx);
   khc_set_cb_sock_send(&http, ebisu::ltest::ssl::cb_send, &s_ctx);
   khc_set_cb_sock_recv(&http, ebisu::ltest::ssl::cb_recv, &s_ctx);
   khc_set_cb_sock_close(&http, ebisu::ltest::ssl::cb_close, &s_ctx);

--- a/tests/large_test/khc/post_test.cpp
+++ b/tests/large_test/khc/post_test.cpp
@@ -41,7 +41,7 @@ TEST_CASE( "HTTP Post" ) {
   khc_set_req_headers(&http, headers);
 
   ebisu::ltest::ssl::SSLData s_ctx;
-  khc_set_cb_sock_connect(&http, ebisu::ltest::ssl::cb_connect, &s_ctx);
+  khc_set_cb_sock_connect(&http, ebisu::ltest::ssl::cb_connect, 15, 15, &s_ctx);
   khc_set_cb_sock_send(&http, ebisu::ltest::ssl::cb_send, &s_ctx);
   khc_set_cb_sock_recv(&http, ebisu::ltest::ssl::cb_recv, &s_ctx);
   khc_set_cb_sock_close(&http, ebisu::ltest::ssl::cb_close, &s_ctx);

--- a/tests/large_test/kii/large_test.h
+++ b/tests/large_test/kii/large_test.h
@@ -24,12 +24,12 @@ inline void init(
 
     kii_set_buff(kii, buffer, buffer_size);
 
-    kii_set_http_cb_sock_connect(kii, ebisu::ltest::ssl::cb_connect, http_ssl_ctx);
+    kii_set_http_cb_sock_connect(kii, ebisu::ltest::ssl::cb_connect, 15, 15, http_ssl_ctx);
     kii_set_http_cb_sock_send(kii, ebisu::ltest::ssl::cb_send, http_ssl_ctx);
     kii_set_http_cb_sock_recv(kii, ebisu::ltest::ssl::cb_recv, http_ssl_ctx);
     kii_set_http_cb_sock_close(kii, ebisu::ltest::ssl::cb_close, http_ssl_ctx);
 
-    kii_set_mqtt_cb_sock_connect(kii, ebisu::ltest::ssl::cb_connect, mqtt_ssl_ctx);
+    kii_set_mqtt_cb_sock_connect(kii, ebisu::ltest::ssl::cb_connect, 15, 15, mqtt_ssl_ctx);
     kii_set_mqtt_cb_sock_send(kii, ebisu::ltest::ssl::cb_send, mqtt_ssl_ctx);
     kii_set_mqtt_cb_sock_recv(kii, ebisu::ltest::ssl::cb_recv, mqtt_ssl_ctx);
     kii_set_mqtt_cb_sock_close(kii, ebisu::ltest::ssl::cb_close, mqtt_ssl_ctx);

--- a/tests/large_test/secure_socket_impl.cpp
+++ b/tests/large_test/secure_socket_impl.cpp
@@ -47,15 +47,15 @@ khc_sock_code_t
         return KHC_SOCK_FAIL;
     }
 
-    // struct timeval recv_tv;
-    // recv_tv.tv_sec = to_recv_in_seconds;
-    // recv_tv.tv_usec = 0;
-    // setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&recv_tv, sizeof recv_tv);
+    struct timeval recv_tv;
+    recv_tv.tv_sec = to_recv_in_seconds;
+    recv_tv.tv_usec = 0;
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&recv_tv, sizeof recv_tv);
 
-    // struct timeval send_tv;
-    // send_tv.tv_sec = to_send_in_seconds;
-    // send_tv.tv_usec = 0;
-    // setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const char*)&send_tv, sizeof send_tv);
+    struct timeval send_tv;
+    send_tv.tv_sec = to_send_in_seconds;
+    send_tv.tv_usec = 0;
+    setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const char*)&send_tv, sizeof send_tv);
 
     if (connect(sock, (struct sockaddr*) &server, sizeof(server)) == -1 ){
         printf("failed to connect socket.\n");

--- a/tests/large_test/secure_socket_impl.cpp
+++ b/tests/large_test/secure_socket_impl.cpp
@@ -20,7 +20,7 @@
 
 khc_sock_code_t
     ebisu::ltest::ssl::cb_connect(void* sock_ctx, const char* host,
-            unsigned int port)
+            unsigned int port, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds)
 {
     int sock, ret;
     struct hostent *servhost;
@@ -46,6 +46,16 @@ khc_sock_code_t
         printf("failed to init socket.\n");
         return KHC_SOCK_FAIL;
     }
+
+    // struct timeval recv_tv;
+    // recv_tv.tv_sec = to_recv_in_seconds;
+    // recv_tv.tv_usec = 0;
+    // setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&recv_tv, sizeof recv_tv);
+
+    // struct timeval send_tv;
+    // send_tv.tv_sec = to_send_in_seconds;
+    // send_tv.tv_usec = 0;
+    // setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const char*)&send_tv, sizeof send_tv);
 
     if (connect(sock, (struct sockaddr*) &server, sizeof(server)) == -1 ){
         printf("failed to connect socket.\n");

--- a/tests/large_test/secure_socket_impl.h
+++ b/tests/large_test/secure_socket_impl.h
@@ -17,7 +17,7 @@ struct SSLData
 
 khc_sock_code_t
     cb_connect(void* socket_context, const char* host,
-            unsigned int port);
+            unsigned int port, unsigned int to_recv_in_secounds, unsigned int to_send_in_seconds);
 
 khc_sock_code_t
     cb_send(void* socket_context,

--- a/tests/small_test/khc/.gitignore
+++ b/tests/small_test/khc/.gitignore
@@ -2,3 +2,4 @@
 /testapp
 /test-results
 /build-khc
+/tmp_random_chunk_response.txt

--- a/tests/small_test/khc/response_chunk_test.cpp
+++ b/tests/small_test/khc/response_chunk_test.cpp
@@ -26,7 +26,7 @@ TEST_CASE( "HTTP chunked response test" ) {
   khc_set_req_headers(&http, NULL);
 
   khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, 15, 15, &s_ctx);
   khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
   khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
   khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
@@ -37,11 +37,13 @@ TEST_CASE( "HTTP chunked response test" ) {
   khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
   int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds) {
     ++on_connect_called;
     REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
     REQUIRE( strlen(host) == strlen("api.kii.com") );
     REQUIRE( port == 443 );
+    REQUIRE( to_recv_in_seconds == 15 );
+    REQUIRE( to_send_in_seconds == 15 );
     return KHC_SOCK_OK;
   };
 
@@ -137,7 +139,7 @@ TEST_CASE( "small buffer size test" ) {
   khc_set_stream_buff(&http, buff, buff_size);
 
   khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, 15, 15, &s_ctx);
   khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
   khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
   khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
@@ -148,11 +150,13 @@ TEST_CASE( "small buffer size test" ) {
   khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
   int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds) {
     ++on_connect_called;
     REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
     REQUIRE( strlen(host) == strlen("api.kii.com") );
     REQUIRE( port == 443 );
+    REQUIRE( to_recv_in_seconds == 15 );
+    REQUIRE( to_send_in_seconds == 15 );
     return KHC_SOCK_OK;
   };
 
@@ -248,7 +252,7 @@ TEST_CASE( "random buffer size test" ) {
   khc_set_stream_buff(&http, buff, buff_size);
 
   khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, 15, 15, &s_ctx);
   khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
   khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
   khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
@@ -259,11 +263,13 @@ TEST_CASE( "random buffer size test" ) {
   khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
   int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds) {
     ++on_connect_called;
     REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
     REQUIRE( strlen(host) == strlen("api.kii.com") );
     REQUIRE( port == 443 );
+    REQUIRE( to_recv_in_seconds == 15 );
+    REQUIRE( to_send_in_seconds == 15 );
     return KHC_SOCK_OK;
   };
 
@@ -361,7 +367,7 @@ TEST_CASE( "random chunk body test" ) {
   khc_set_req_headers(&http, NULL);
 
   khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, 15, 15, &s_ctx);
   khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
   khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
   khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
@@ -372,11 +378,13 @@ TEST_CASE( "random chunk body test" ) {
   khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
   int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds) {
     ++on_connect_called;
     REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
     REQUIRE( strlen(host) == strlen("api.kii.com") );
     REQUIRE( port == 443 );
+    REQUIRE( to_recv_in_seconds == 15 );
+    REQUIRE( to_send_in_seconds == 15 );
     return KHC_SOCK_OK;
   };
 

--- a/tests/small_test/khc/response_test.cpp
+++ b/tests/small_test/khc/response_test.cpp
@@ -24,7 +24,7 @@ TEST_CASE( "HTTP response test" ) {
   khc_set_req_headers(&http, NULL);
 
   khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, 15, 15, &s_ctx);
   khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
   khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
   khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
@@ -35,11 +35,13 @@ TEST_CASE( "HTTP response test" ) {
   khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
   int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds) {
     ++on_connect_called;
     REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
     REQUIRE( strlen(host) == strlen("api.kii.com") );
     REQUIRE( port == 443 );
+    REQUIRE( to_recv_in_seconds == 15 );
+    REQUIRE( to_send_in_seconds == 15 );
     return KHC_SOCK_OK;
   };
 

--- a/tests/small_test/khc/state_trans_test.cpp
+++ b/tests/small_test/khc/state_trans_test.cpp
@@ -23,7 +23,7 @@ TEST_CASE( "HTTP minimal" ) {
   khc_set_req_headers(&http, NULL);
 
   khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, 15, 15, &s_ctx);
   khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
   khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
   khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
@@ -38,11 +38,13 @@ TEST_CASE( "HTTP minimal" ) {
   REQUIRE( http._result == KHC_ERR_OK );
 
   bool called = false;
-  s_ctx.on_connect = [=, &called](void* socket_context, const char* host, unsigned int port) {
+  s_ctx.on_connect = [=, &called](void* socket_context, const char* host, unsigned int port, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds) {
     called = true;
     REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
     REQUIRE( strlen(host) == strlen("api.kii.com") );
     REQUIRE( port == 443 );
+    REQUIRE( to_recv_in_seconds == 15 );
+    REQUIRE( to_send_in_seconds == 15 );
     return KHC_SOCK_OK;
   };
 
@@ -278,7 +280,7 @@ TEST_CASE( "HTTP 1.1 chunked minimal" ) {
   khc_set_req_headers(&http, NULL);
 
   khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, 15, 15, &s_ctx);
   khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
   khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
   khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
@@ -293,11 +295,13 @@ TEST_CASE( "HTTP 1.1 chunked minimal" ) {
   REQUIRE( http._result == KHC_ERR_OK );
 
   bool called = false;
-  s_ctx.on_connect = [=, &called](void* socket_context, const char* host, unsigned int port) {
+  s_ctx.on_connect = [=, &called](void* socket_context, const char* host, unsigned int port, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds) {
     called = true;
     REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
     REQUIRE( strlen(host) == strlen("api.kii.com") );
     REQUIRE( port == 443 );
+    REQUIRE( to_recv_in_seconds == 15 );
+    REQUIRE( to_send_in_seconds == 15 );
     return KHC_SOCK_OK;
   };
 

--- a/tests/test_callbacks.h
+++ b/tests/test_callbacks.h
@@ -5,7 +5,7 @@ namespace khct {
 namespace cb {
 
 struct SockCtx {
-  std::function<khc_sock_code_t(void* socket_context, const char* host, unsigned int port)> on_connect;
+  std::function<khc_sock_code_t(void* socket_context, const char* host, unsigned int port, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds)> on_connect;
   std::function<khc_sock_code_t(void* socket_context, const char* buffer, size_t length)> on_send;
   std::function<khc_sock_code_t(void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length)> on_recv;
   std::function<khc_sock_code_t(void* socket_context)> on_close;
@@ -17,9 +17,9 @@ struct IOCtx {
   std::function<size_t(char *buffer, size_t size, size_t count, void *userdata)> on_write;
 };
 
-inline khc_sock_code_t mock_connect(void* socket_context, const char* host, unsigned int port) {
+inline khc_sock_code_t mock_connect(void* socket_context, const char* host, unsigned int port, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds) {
   SockCtx* ctx = (SockCtx*)socket_context;
-  return ctx->on_connect(socket_context, host, port);
+  return ctx->on_connect(socket_context, host, port, to_recv_in_seconds, to_send_in_seconds);
 }
 
 inline khc_sock_code_t mock_send (void* socket_context, const char* buffer, size_t length) {

--- a/tio/README.md
+++ b/tio/README.md
@@ -186,12 +186,12 @@ The full code can be checked [handler_init() in example.c](linux-sample/example.
     tio_handler_set_cb_task_create(handler, task_create_cb_impl);
     tio_handler_set_cb_delay_ms(handler, delay_ms_cb_impl);
 
-    tio_handler_set_cb_sock_connect_http(handler, sock_cb_connect, http_ssl_ctx);
+    tio_handler_set_cb_sock_connect_http(handler, sock_cb_connect, 15, 15, http_ssl_ctx);
     tio_handler_set_cb_sock_send_http(handler, sock_cb_send, http_ssl_ctx);
     tio_handler_set_cb_sock_recv_http(handler, sock_cb_recv, http_ssl_ctx);
     tio_handler_set_cb_sock_close_http(handler, sock_cb_close, http_ssl_ctx);
 
-    tio_handler_set_cb_sock_connect_mqtt(handler, sock_cb_connect, mqtt_ssl_ctx);
+    tio_handler_set_cb_sock_connect_mqtt(handler, sock_cb_connect, 15, 15, mqtt_ssl_ctx);
     tio_handler_set_cb_sock_send_mqtt(handler, sock_cb_send, mqtt_ssl_ctx);
     tio_handler_set_cb_sock_recv_mqtt(handler, sock_cb_recv, mqtt_ssl_ctx);
     tio_handler_set_cb_sock_close_mqtt(handler, sock_cb_close, mqtt_ssl_ctx);
@@ -237,14 +237,14 @@ If you application allocates memory/ resources for context data, application is 
 Different context objects named `http_ssl_ctx` and `mqtt_ssl_ctx` is used since the connection and it's life-cycle is different between them.
 
 ```c
-    tio_handler_set_cb_sock_connect_http(handler, sock_cb_connect, http_ssl_ctx);
+    tio_handler_set_cb_sock_connect_http(handler, sock_cb_connect, 15, 15, http_ssl_ctx);
     tio_handler_set_cb_sock_send_http(handler, sock_cb_send, http_ssl_ctx);
     tio_handler_set_cb_sock_recv_http(handler, sock_cb_recv, http_ssl_ctx);
     tio_handler_set_cb_sock_close_http(handler, sock_cb_close, http_ssl_ctx);
 ```
 
 ```c
-    tio_handler_set_cb_sock_connect_mqtt(handler, sock_cb_connect, mqtt_ssl_ctx);
+    tio_handler_set_cb_sock_connect_mqtt(handler, sock_cb_connect, 15, 15, mqtt_ssl_ctx);
     tio_handler_set_cb_sock_send_mqtt(handler, sock_cb_send, mqtt_ssl_ctx);
     tio_handler_set_cb_sock_recv_mqtt(handler, sock_cb_recv, mqtt_ssl_ctx);
     tio_handler_set_cb_sock_close_mqtt(handler, sock_cb_close, mqtt_ssl_ctx);

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -96,14 +96,14 @@ typedef struct tio_updater_t {
 
 void tio_handler_init(tio_handler_t* handler);
 
-void tio_handler_set_cb_sock_connect_http(tio_handler_t* handler, KHC_CB_SOCK_CONNECT cb_connect, void* userdata);
+void tio_handler_set_cb_sock_connect_http(tio_handler_t* handler, KHC_CB_SOCK_CONNECT cb_connect, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds, void* userdata);
 void tio_handler_set_cb_sock_send_http(tio_handler_t* handler, KHC_CB_SOCK_SEND cb_send, void* userdata);
 void tio_handler_set_cb_sock_recv_http(tio_handler_t* handler, KHC_CB_SOCK_RECV cb_recv, void* userdata);
 void tio_handler_set_cb_sock_close_http(tio_handler_t* handler, KHC_CB_SOCK_CLOSE cb_close, void* userdata);
 
 void tio_handler_set_http_buff(tio_handler_t* handler, char* buff, size_t buff_size);
 
-void tio_handler_set_cb_sock_connect_mqtt(tio_handler_t* handler, KHC_CB_SOCK_CONNECT cb_connect, void* userdata);
+void tio_handler_set_cb_sock_connect_mqtt(tio_handler_t* handler, KHC_CB_SOCK_CONNECT cb_connect, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds, void* userdata);
 void tio_handler_set_cb_sock_send_mqtt(tio_handler_t* handler, KHC_CB_SOCK_SEND cb_send, void* userdata);
 void tio_handler_set_cb_sock_recv_mqtt(tio_handler_t* handler, KHC_CB_SOCK_RECV cb_recv, void* userdata);
 void tio_handler_set_cb_sock_close_mqtt(tio_handler_t* handler, KHC_CB_SOCK_CLOSE cb_close, void* userdata);
@@ -148,7 +148,7 @@ tio_code_t tio_handler_start(
 
 void tio_updater_init(tio_updater_t* updater);
 
-void tio_updater_set_cb_sock_connect(tio_updater_t* updater, KHC_CB_SOCK_CONNECT cb_connect, void* userdata);
+void tio_updater_set_cb_sock_connect(tio_updater_t* updater, KHC_CB_SOCK_CONNECT cb_connect, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds, void* userdata);
 void tio_updater_set_cb_sock_send(tio_updater_t* updater, KHC_CB_SOCK_SEND cb_send, void* userdata);
 void tio_updater_set_cb_sock_recv(tio_updater_t* updater, KHC_CB_SOCK_RECV cb_recv, void* userdata);
 void tio_updater_set_cb_sock_close(tio_updater_t* updater, KHC_CB_SOCK_CLOSE cb_close, void* userdata);

--- a/tio/linux-sample/example.c
+++ b/tio/linux-sample/example.c
@@ -121,12 +121,12 @@ void handler_init(
     tio_handler_set_cb_task_create(handler, task_create_cb_impl);
     tio_handler_set_cb_delay_ms(handler, delay_ms_cb_impl);
 
-    tio_handler_set_cb_sock_connect_http(handler, sock_cb_connect, http_ssl_ctx);
+    tio_handler_set_cb_sock_connect_http(handler, sock_cb_connect, 15, 15, http_ssl_ctx);
     tio_handler_set_cb_sock_send_http(handler, sock_cb_send, http_ssl_ctx);
     tio_handler_set_cb_sock_recv_http(handler, sock_cb_recv, http_ssl_ctx);
     tio_handler_set_cb_sock_close_http(handler, sock_cb_close, http_ssl_ctx);
 
-    tio_handler_set_cb_sock_connect_mqtt(handler, sock_cb_connect, mqtt_ssl_ctx);
+    tio_handler_set_cb_sock_connect_mqtt(handler, sock_cb_connect, 15, 15, mqtt_ssl_ctx);
     tio_handler_set_cb_sock_send_mqtt(handler, sock_cb_send, mqtt_ssl_ctx);
     tio_handler_set_cb_sock_recv_mqtt(handler, sock_cb_recv, mqtt_ssl_ctx);
     tio_handler_set_cb_sock_close_mqtt(handler, sock_cb_close, mqtt_ssl_ctx);

--- a/tio/linux-sample/example.c
+++ b/tio/linux-sample/example.c
@@ -43,7 +43,7 @@ void updater_init(
 
     tio_updater_set_buff(updater, buffer, buffer_size);
 
-    tio_updater_set_cb_sock_connect(updater, sock_cb_connect, sock_ssl_ctx);
+    tio_updater_set_cb_sock_connect(updater, sock_cb_connect, 15, 15, sock_ssl_ctx);
     tio_updater_set_cb_sock_send(updater, sock_cb_send, sock_ssl_ctx);
     tio_updater_set_cb_sock_recv(updater, sock_cb_recv, sock_ssl_ctx);
     tio_updater_set_cb_sock_close(updater, sock_cb_close, sock_ssl_ctx);

--- a/tio/linux-sample/sock_cb_linux.c
+++ b/tio/linux-sample/sock_cb_linux.c
@@ -20,7 +20,7 @@
 
 khc_sock_code_t
     sock_cb_connect(void* sock_ctx, const char* host,
-            unsigned int port)
+            unsigned int port, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds)
 {
     int sock, ret;
     struct hostent *servhost;
@@ -46,6 +46,16 @@ khc_sock_code_t
         printf("failed to init socket.\n");
         return KHC_SOCK_FAIL;
     }
+
+    struct timeval recv_tv;
+    recv_tv.tv_sec = to_recv_in_seconds;
+    recv_tv.tv_usec = 0;
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&recv_tv, sizeof recv_tv);
+
+    struct timeval send_tv;
+    send_tv.tv_sec = to_send_in_seconds;
+    send_tv.tv_usec = 0;
+    setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const char*)&send_tv, sizeof send_tv);
 
     if (connect(sock, (struct sockaddr*) &server, sizeof(server)) == -1 ){
         printf("failed to connect socket.\n");

--- a/tio/linux-sample/sock_cb_linux.h
+++ b/tio/linux-sample/sock_cb_linux.h
@@ -16,7 +16,7 @@ typedef struct {
 
 khc_sock_code_t
     sock_cb_connect(void* sock_ctx, const char* host,
-            unsigned int port);
+            unsigned int port, unsigned int to_recv_in_seconds, unsigned int to_send_in_seconds);
 
 khc_sock_code_t
     sock_cb_send(void* sock_ctx,

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -16,9 +16,11 @@ void tio_handler_init(tio_handler_t* handler)
 void tio_handler_set_cb_sock_connect_http(
     tio_handler_t* handler,
     KHC_CB_SOCK_CONNECT cb_connect,
+    unsigned int to_recv_in_seconds,
+    unsigned int to_send_in_seconds,
     void* userdata)
 {
-    kii_set_http_cb_sock_connect(&handler->_kii, cb_connect, userdata);
+    kii_set_http_cb_sock_connect(&handler->_kii, cb_connect, to_recv_in_seconds, to_send_in_seconds, userdata);
 }
 
 void tio_handler_set_cb_sock_send_http(
@@ -56,9 +58,11 @@ void tio_handler_set_http_buff(
 void tio_handler_set_cb_sock_connect_mqtt(
     tio_handler_t* handler,
     KHC_CB_SOCK_CONNECT cb_connect,
+    unsigned int to_recv_in_seconds,
+    unsigned int to_send_in_seconds, 
     void* userdata)
 {
-    kii_set_mqtt_cb_sock_connect(&handler->_kii, cb_connect, userdata);
+    kii_set_mqtt_cb_sock_connect(&handler->_kii, cb_connect, to_recv_in_seconds, to_send_in_seconds, userdata);
 }
 
 void tio_handler_set_cb_sock_send_mqtt(

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -213,9 +213,11 @@ void tio_updater_init(tio_updater_t* updater)
 void tio_updater_set_cb_sock_connect(
     tio_updater_t* updater,
     KHC_CB_SOCK_CONNECT cb_connect,
+    unsigned int to_recv_in_seconds,
+    unsigned int to_send_in_seconds,
     void* userdata)
 {
-    kii_set_http_cb_sock_connect(&updater->_kii, cb_connect, userdata);
+    kii_set_http_cb_sock_connect(&updater->_kii, cb_connect, to_recv_in_seconds, to_send_in_seconds, userdata);
 }
 
 void tio_updater_set_cb_sock_send(


### PR DESCRIPTION
Enable to set socket timeout.

Aiming to fix #51, but it is not only for this.
Setting timeouts by clients should be allowed to control the maximum wait time.