### PR TITLE
Enable to use custom allocator of khc_slist.

### DIFF
--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -82,7 +82,7 @@ typedef khc_slist*(*KHC_SLIST_ALLOC_CB)(const char* str, size_t str_length, void
  * In this callback, implementation must free memory allocated by single khc_slist node.
  * Method must be corresponding to alloc method implemented in KHC_SLIST_ALLOC_CB.
 
- * \param [inout] node first node of the slist.
+ * \param [in] node of the slist.
  * \param [in] data Context data pointer.
  */
 typedef void(*KHC_SLIST_FREE_CB)(khc_slist* node, void* data);
@@ -118,7 +118,7 @@ khc_slist* khc_slist_append(khc_slist* slist, const char* string, size_t length)
 
  * This method uses custom memory allocator for constructing string copy and khc_slist.
  * khc_slist must be appended by this method and same allocator if the previous node is appended by this method.
- * khc_slist_free_all_using_free_cb(khc_slist*, KHC_SLIST_FREE_CB, void*) and maching free callback 
+ * khc_slist_free_all_using_free_cb(khc_slist*, KHC_SLIST_FREE_CB, void*) and matching free callback
  * must be used to free all memories used by the list.
  * You can't use different allocate/ free method specified by
  * khc_slist_append_using_alloc_cb(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)

--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -88,6 +88,16 @@ typedef khc_slist*(*KHC_SLIST_ALLOC_CB)(const char* str, size_t str_length, void
 typedef void(*KHC_SLIST_FREE_CB)(khc_slist* node, void* data);
 
 /**
+ * \brief Default implementation of KHC_SLIST_ALLOC_CB.
+ */
+khc_slist* khc_slist_alloc_cb(const char* str, size_t str_len, void* data);
+
+/**
+ * \brief Default implementation of KHC_SLIST_FREE_CB.
+ */
+void khc_slist_free_cb(khc_slist* slist, void* data);
+
+/**
  * \brief Add node to the linked list.
 
  * This method uses default memory allocator uses malloc() for constructing string copy and khc_slist.

--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -72,7 +72,7 @@ typedef struct khc_slist {
  * \param [in] str khc_slist content. String must be copied to khc_slist.data.
  * \param [in] str_length length of the string (exclude NULL termination).
  * \param [inout] data optional context data pointer. The pointer is given by
- * khc_slist_append_using_alloc_cb(khc_slist*, const char*, size_t, void*) method and could be NULL.
+ * khc_slist_append_using_alloc_cb(khc_slist*, const char*, size_t, KHC_SLIST_ALLOC_CB, void*) method and could be NULL.
  */
 typedef khc_slist*(*KHC_SLIST_ALLOC_CB)(const char* str, size_t str_length, void* data);
 

--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -69,7 +69,7 @@ typedef struct khc_slist {
  * In this allocator, you need to allocate memory of khc_slist struct and it's data char array.
  * data char array must be NULL terminated so it requires str_length + 1 as length.
 
- * \param [in] str khs_slist content. String must be copied to khc_slist.data.
+ * \param [in] str khc_slist content. String must be copied to khc_slist.data.
  * \param [in] str_length length of the string (exclude NULL termination).
  * \param [inout] data optional context data pointer. The pointer is given by
  * khc_slist_append_using_alloc_cb(khc_slist*, const char*, size_t, void*) method and could be NULL.

--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -60,25 +60,95 @@ typedef size_t (*KHC_CB_HEADER)(char *buffer, size_t size, size_t count, void *u
  */
 typedef struct khc_slist {
   char* data; /**< \brief Null terminated string */
-  struct khc_slist* next; /**< \brief Pointer to the next item. */
+  struct khc_slist* next; /**< \brief Pointer to the next node. */
 } khc_slist;
 
 /**
- * \brief Add item to the linked list.
- *
+ * \brief Custom khc_slist node allocator.
+
+ * In this allocator, you need to allocate memory of khc_slist struct and it's data char array.
+ * data char array must be NULL terminated so it requires str_length + 1 as length.
+
+ * \param [in] str khs_slist content. String must be copied to khc_slist.data.
+ * \param [in] str_length length of the string (exclude NULL termination).
+ * \param [inout] data optional context data pointer. The pointer is given by
+ * khc_slist_append_using_alloc_cb(khc_slist*, const char*, size_t, void*) method and could be NULL.
+ */
+typedef khc_slist*(*KHC_SLIST_ALLOC_CB)(const char* str, size_t str_length, void* data);
+
+/**
+ * \ brief free memory allocated by custom khc_slist node allocator.
+
+ * In this callback, implementation must free memory allocated by single khc_slist node.
+ * Method must be corresponding to alloc method implemented in KHC_SLIST_ALLOC_CB.
+
+ * \param [inout] node first node of the slist.
+ * \param [in] data Context data pointer.
+ */
+typedef void(*KHC_SLIST_FREE_CB)(khc_slist* node, void* data);
+
+/**
+ * \brief Add node to the linked list.
+
+ * This method uses default memory allocator uses malloc() for constructing string copy and khc_slist.
+ * khc_slist must be appended by this method if the previous node is appended by this method.
+ * khc_slist_free_all(khc_slist*) must be called to free all memories used by the list.
+ * You can't use different allocate/ free method specified by
+ * khc_slist_append_using_alloc_cb(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)
+ * in a single list.
  * \param [in, out] slist pointer to the linked list or NULL to create new linked list.
- * \param [in] string data to be appended.
+ * \param [in] string data to be appended. String is copied to new char array in slist.
  * \param [in] length of the string.
- * \returns pointer to the linked list (first item).
+ * \returns pointer to the linked list (first node).
  */
 khc_slist* khc_slist_append(khc_slist* slist, const char* string, size_t length);
 
 /**
+ * \brief Add node to the linked list. Node is allocated by specified allocator.
+
+ * This method uses custom memory allocator for constructing string copy and khc_slist.
+ * khc_slist must be appended by this method and same allocator if the previous node is appended by this method.
+ * khc_slist_free_all_using_free_cb(khc_slist*, KHC_SLIST_FREE_CB, void*) and maching free callback 
+ * must be used to free all memories used by the list.
+ * You can't use different allocate/ free method specified by
+ * khc_slist_append_using_alloc_cb(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)
+ * in a single list.
+ * \param [in, out] slist pointer to the linked list or NULL to create new linked list.
+ * \param [in] string data to be appended. String is copied to new char array in slist.
+ * \param [in] length of the string.
+ * \param [in] alloc_cb allocator callback function.
+ * \param [in] alloc_cb_data context data pointer passed to alloc_cb.
+ * \returns pointer to the linked list (first node).
+ */
+khc_slist* khc_slist_append_using_alloc_cb(
+  khc_slist* slist,
+  const char* string,
+  size_t length,
+  KHC_SLIST_ALLOC_CB alloc_cb,
+  void* alloc_cb_data);
+
+/**
  * \brief Free memory used for the entire linked list.
- *
- * \param [in, out] slist pointer to the linked list (first item).
+
+ * Linked list constructed by khc_slist_append(khc_slist*, const char*, size_t) must be freed by this method.
+ * \param [in, out] slist pointer to the linked list (first node).
  */
 void khc_slist_free_all(khc_slist* slist);
+
+/**
+ * \brief Free memory used for the entire linked list constructed by custom allocator.
+ *
+ * Linked list constructed by khc_slist_append_using_alloc_cb(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)
+ * must be freed by this method and matching free callback.
+
+ * \param [in, out] slist pointer to the linked list (first node).
+ * \param [in] free_cb free callback.
+ * \param [in] free_cb_data context object pointer passed to free_cb.
+ */
+void khc_slist_free_all_using_free_cb(
+  khc_slist* slist,
+  KHC_SLIST_FREE_CB free_cb,
+  void* free_cb_data);
 
 /**
  * \brief Indicate state of khc.

--- a/khc/src/khc.c
+++ b/khc/src/khc.c
@@ -5,32 +5,6 @@
 #include "khc_state_impl.h"
 #include "khc_socket_callback.h"
 
-khc_slist* khc_slist_append(khc_slist* slist, const char* string, size_t length) {
-  khc_slist* next;
-  next = (khc_slist*)malloc(sizeof(khc_slist));
-  if (next == NULL) {
-    return NULL;
-  }
-  next->next = NULL;
-  void* temp = malloc(length+1);
-  if (temp == NULL) {
-    free(next);
-    return NULL;
-  }
-  next->data = (char*)temp;
-  strncpy(next->data, string, length);
-  next->data[length] = '\0';
-  if (slist == NULL) {
-    return next;
-  }
-  khc_slist* end = slist;
-  while (end->next != NULL) {
-    end = end->next;
-  }
-  end->next = next;
-  return slist;
-}
-
 khc_code khc_set_resp_header_buff(khc* khc, char* buffer, size_t buff_size) {
   khc->_resp_header_buff = buffer;
   khc->_resp_header_buff_size = buff_size;
@@ -41,18 +15,6 @@ khc_code khc_set_stream_buff(khc* khc, char* buffer, size_t buff_size) {
   khc->_stream_buff = buffer;
   khc->_stream_buff_size = buff_size;
   return KHC_ERR_OK;
-}
-
-void khc_slist_free_all(khc_slist* slist) {
-  khc_slist *curr;
-  curr = slist;
-  while (curr != NULL) {
-    khc_slist *next = curr->next;
-    free(curr->data);
-    curr->data = NULL;
-    free(curr);
-    curr = next;
-  }
 }
 
 khc_code khc_perform(khc* khc) {

--- a/khc/src/khc_slist.c
+++ b/khc/src/khc_slist.c
@@ -1,7 +1,7 @@
 #include <string.h>
 #include "khc.h"
 
-khc_slist* _alloc_cb(const char* str, size_t str_len, void* data) {
+khc_slist* khc_slist_alloc_cb(const char* str, size_t str_len, void* data) {
   char* copy = malloc(str_len+1);
   if (copy == NULL) {
     return NULL;
@@ -18,13 +18,13 @@ khc_slist* _alloc_cb(const char* str, size_t str_len, void* data) {
   return node;
 }
 
-void _free_cb(khc_slist* slist, void* data) {
+void khc_slist_free_cb(khc_slist* slist, void* data) {
   free(slist->data);
   free(slist);
 }
 
 khc_slist* khc_slist_append(khc_slist* slist, const char* string, size_t length) {
-  return khc_slist_append_using_alloc_cb(slist, string, length, _alloc_cb, NULL);
+  return khc_slist_append_using_alloc_cb(slist, string, length, khc_slist_alloc_cb, NULL);
 }
 
 khc_slist* khc_slist_append_using_alloc_cb(
@@ -52,7 +52,7 @@ khc_slist* khc_slist_append_using_alloc_cb(
 }
 
 void khc_slist_free_all(khc_slist* slist) {
-  khc_slist_free_all_using_free_cb(slist, _free_cb, NULL);
+  khc_slist_free_all_using_free_cb(slist, khc_slist_free_cb, NULL);
 }
 
 void khc_slist_free_all_using_free_cb(

--- a/khc/src/khc_slist.c
+++ b/khc/src/khc_slist.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stdlib.h>
 #include "khc.h"
 
 khc_slist* khc_slist_alloc_cb(const char* str, size_t str_len, void* data) {

--- a/khc/src/khc_slist.c
+++ b/khc/src/khc_slist.c
@@ -1,0 +1,69 @@
+#include <string.h>
+#include "khc.h"
+
+khc_slist* _alloc_cb(const char* str, size_t str_len, void* data) {
+  char* copy = malloc(str_len+1);
+  if (copy == NULL) {
+    return NULL;
+  }
+  khc_slist* node = malloc(sizeof(khc_slist));
+  if (node == NULL) {
+    free(copy);
+    return NULL;
+  }
+  strncpy(copy, str, str_len);
+  copy[str_len] = '\0';
+  node->data = copy;
+  node->next = NULL;
+  return node;
+}
+
+void _free_cb(khc_slist* slist, void* data) {
+  free(slist->data);
+  free(slist);
+}
+
+khc_slist* khc_slist_append(khc_slist* slist, const char* string, size_t length) {
+  return khc_slist_append_using_alloc_cb(slist, string, length, _alloc_cb, NULL);
+}
+
+khc_slist* khc_slist_append_using_alloc_cb(
+  khc_slist* slist,
+  const char* string,
+  size_t length,
+  KHC_SLIST_ALLOC_CB alloc_cb,
+  void* alloc_cb_data) {
+  khc_slist* next;
+  next = alloc_cb(string, length, alloc_cb_data);
+  if (next == NULL) {
+    return NULL;
+  }
+  next->next = NULL;
+
+  if (slist == NULL) {
+    return next;
+  }
+  khc_slist* end = slist;
+  while (end->next != NULL) {
+    end = end->next;
+  }
+  end->next = next;
+  return slist;
+}
+
+void khc_slist_free_all(khc_slist* slist) {
+  khc_slist_free_all_using_free_cb(slist, _free_cb, NULL);
+}
+
+void khc_slist_free_all_using_free_cb(
+  khc_slist* slist,
+  KHC_SLIST_FREE_CB free_cb,
+  void* free_cb_data) {
+  khc_slist *curr;
+  curr = slist;
+  while (curr != NULL) {
+    khc_slist *next = curr->next;
+    free_cb(curr, free_cb_data);
+    curr = next;
+  }
+}

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -87,6 +87,10 @@ int kii_init(
     khc_set_cb_write(&kii->_khc, _cb_write_buff, kii);
     khc_set_cb_header(&kii->_khc, _cb_write_header, kii);
     kii->_etag[0] = '\0';
+    kii->_slist_alloc_cb = khc_slist_alloc_cb;
+    kii->_slist_free_cb = khc_slist_free_cb;
+    kii->_slist_alloc_cb_data = NULL;
+    kii->_slist_free_cb_data = NULL;
     return 0;
 }
 
@@ -169,6 +173,19 @@ kii_code_t kii_set_json_parser_resource_cb(
     return KII_ERR_OK;
 }
 
+kii_code_t kii_set_slist_resource_cb(
+    kii_t* kii,
+    KHC_SLIST_ALLOC_CB alloc_cb,
+    KHC_SLIST_FREE_CB free_cb,
+    void* alloc_cb_data,
+    void* free_cb_data) {
+    kii->_slist_alloc_cb = alloc_cb;
+    kii->_slist_free_cb = free_cb;
+    kii->_slist_alloc_cb_data = alloc_cb_data;
+    kii->_slist_free_cb_data = free_cb_data;
+    return KII_ERR_OK;
+}
+
 const char* kii_get_etag(kii_t* kii) {
     return kii->_etag;
 }
@@ -211,7 +228,7 @@ void _reset_buff(kii_t* kii) {
 }
 
 void _req_headers_free_all(kii_t* kii) {
-    khc_slist_free_all(kii->_req_headers);
+    khc_slist_free_all_using_free_cb(kii->_req_headers, kii->_slist_free_cb, kii->_slist_free_cb_data);
     kii->_req_headers = NULL;
 }
 

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -153,6 +153,10 @@ typedef struct kii_t {
     JKII_RESOURCE_ALLOC_CB _json_alloc_cb;
     JKII_RESOURCE_FREE_CB _json_free_cb;
 
+    KHC_SLIST_ALLOC_CB _slist_alloc_cb;
+    KHC_SLIST_FREE_CB _slist_free_cb;
+    void* _slist_alloc_cb_data;
+    void* _slist_free_cb_data;
 } kii_t;
 
 /** Initializes Kii SDK
@@ -541,6 +545,19 @@ kii_code_t kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
 kii_code_t kii_set_json_parser_resource_cb(kii_t* kii,
     JKII_RESOURCE_ALLOC_CB alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb);
+
+/**
+ * \brief Set khc_slist (linked list) resource allocators.
+
+ * If this method is not called, default allocators implemented with malloc/free is used to
+ * allocate linked list used to construct HTTP request headers.
+ */
+kii_code_t kii_set_slist_resource_cb(
+    kii_t* kii,
+    KHC_SLIST_ALLOC_CB alloc_cb,
+    KHC_SLIST_FREE_CB free_cb,
+    void* alloc_cb_data,
+    void* free_cb_data);
 
 const char* kii_get_etag(kii_t* kii);
 

--- a/kii/kii_api_call.c
+++ b/kii/kii_api_call.c
@@ -73,7 +73,7 @@ kii_code_t kii_api_call_append_header(kii_t* kii, const char* key, const char* v
         _req_headers_free_all(kii);
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append(kii->_req_headers, buff, header_len);
+    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }

--- a/kii/kii_req_impl.c
+++ b/kii/kii_req_impl.c
@@ -156,7 +156,7 @@ kii_code_t _set_content_type(
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append(kii->_req_headers, kii->_rw_buff, header_len);
+    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }
@@ -177,7 +177,7 @@ kii_code_t _set_object_content_type(
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append(kii->_req_headers, kii->_rw_buff, header_len);
+    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);;
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }
@@ -198,7 +198,7 @@ kii_code_t _set_object_body_content_type(
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append(kii->_req_headers, kii->_rw_buff, header_len);
+    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);;
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }
@@ -220,7 +220,7 @@ kii_code_t _set_content_length(
     if (header_len >= cl_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append(kii->_req_headers, cl_h, header_len);
+    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, cl_h, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }
@@ -238,7 +238,7 @@ kii_code_t _set_app_id_header(kii_t* kii)
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append(kii->_req_headers, kii->_rw_buff, header_len);
+    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);;
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }
@@ -256,7 +256,7 @@ kii_code_t _set_app_key_header(kii_t* kii)
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append(kii->_req_headers, kii->_rw_buff, header_len);
+    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);;
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }
@@ -280,7 +280,7 @@ kii_code_t _set_auth_bearer_token(kii_t* kii, const char* token)
         if (header_len >= kii->_rw_buff_size) {
             return KII_ERR_TOO_LARGE_DATA;
         }
-        khc_slist* list = khc_slist_append(kii->_req_headers, kii->_rw_buff, header_len);
+        khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);;
         if (list == NULL) {
             return KII_ERR_ALLOCATION;
         }
@@ -306,7 +306,7 @@ kii_code_t _set_if_match(kii_t* kii, const char* etag)
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append(kii->_req_headers, kii->_rw_buff, header_len);
+    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);;
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }

--- a/tests/small_test/khc/slist_test.cpp
+++ b/tests/small_test/khc/slist_test.cpp
@@ -26,3 +26,55 @@ TEST_CASE( "slist append (2)" ) {
   REQUIRE( next->next == NULL );
   khc_slist_free_all(appended);
 }
+
+typedef struct {
+  const char* alloc_requested_str;
+  size_t alloc_requested_str_len;
+  khc_slist* free_requested_node;
+} slist_alloc_ctx;
+
+khc_slist* alloc_cb(const char* str, size_t len, void* data) {
+  slist_alloc_ctx* ctx = (slist_alloc_ctx*)data;
+  ctx->alloc_requested_str = str;
+  ctx->alloc_requested_str_len = len;
+
+  char* copy = (char*)malloc(len + 1);
+  if (copy == NULL) {
+    return NULL;
+  }
+  khc_slist* node = (khc_slist*)malloc(sizeof(khc_slist));
+  if (node == NULL) {
+    free(copy);
+    return NULL;
+  }
+  strncpy(copy, str, len);
+  copy[len] = '\0';
+  node->data = copy;
+  node->next = NULL;
+  return node;
+}
+
+void free_cb(khc_slist* node, void* data) {
+  slist_alloc_ctx* ctx = (slist_alloc_ctx*)data;
+  ctx->free_requested_node = node;
+  free(node->data);
+  free(node);
+}
+
+TEST_CASE( "slist append (3)" ) {
+  khc_slist* list = NULL;
+  slist_alloc_ctx ctx;
+  memset(&ctx, 0, sizeof(slist_alloc_ctx));
+  const char str[] = "aaaaa";
+  khc_slist* appended = khc_slist_append_using_alloc_cb(list, str, 5, alloc_cb, &ctx);
+  REQUIRE( appended != NULL );
+  REQUIRE( strlen(appended->data) == 5 );
+  REQUIRE( strncmp(appended->data, str, 5) == 0 );
+  REQUIRE ( appended->next == NULL );
+
+  REQUIRE( ctx.alloc_requested_str == str );
+  REQUIRE( ctx.alloc_requested_str_len == 5 );
+
+  khc_slist_free_all_using_free_cb(appended, free_cb, &ctx);
+  REQUIRE( ctx.free_requested_node == appended );
+}

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -129,6 +129,22 @@ void tio_handler_set_json_parser_resource_cb(
     JKII_RESOURCE_ALLOC_CB alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb);
 
+/**
+ * \brief Set custom memory allocator for the linked list used to constuct request headers of HTTP.
+
+ * If this method is not called, default memory allocator using malloc/ free is used.
+ * Notice: You need to call this method after
+ * tio_handler_set_app(tio_handler_t*, const char*, const char*) since the
+ * tio_handler_set_app() method has side effect resetting to default memory allocator.
+ */
+void tio_handler_set_slist_resource_cb(
+    tio_handler_t* handler,
+    KHC_SLIST_ALLOC_CB alloc_cb,
+    KHC_SLIST_FREE_CB free_cb,
+    void* alloc_cb_data,
+    void* free_cb_data
+);
+
 tio_code_t tio_handler_onboard(
     tio_handler_t* handler,
     const char* vendor_thing_id,
@@ -173,6 +189,22 @@ void tio_updater_set_json_parser_resource_cb(
     tio_updater_t* updater,
     JKII_RESOURCE_ALLOC_CB alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb);
+
+/**
+ * \brief Set custom memory allocator for the linked list used to constuct request headers of HTTP.
+
+ * If this method is not called, default memory allocator using malloc/ free is used.
+ * Notice: You need to call this method after
+ * tio_updater_set_app(tio_updater_t*, const char*, const char*) since the
+ * tio_updater_set_app() method has side effect resetting to default memory allocator.
+ */
+void tio_updater_set_slist_resource_cb(
+    tio_updater_t* updater,
+    KHC_SLIST_ALLOC_CB alloc_cb,
+    KHC_SLIST_FREE_CB free_cb,
+    void* alloc_cb_data,
+    void* free_cb_data
+);
 
 tio_code_t tio_updater_onboard(
     tio_updater_t* updater,

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -167,6 +167,16 @@ void tio_handler_set_json_parser_resource_cb(
     kii_set_json_parser_resource_cb(&handler->_kii, alloc_cb, free_cb);
 }
 
+void tio_handler_set_slist_resource_cb(
+    tio_handler_t* handler,
+    KHC_SLIST_ALLOC_CB alloc_cb,
+    KHC_SLIST_FREE_CB free_cb,
+    void* alloc_cb_data,
+    void* free_cb_data)
+{
+    kii_set_slist_resource_cb(&handler->_kii, alloc_cb, free_cb, alloc_cb_data, free_cb_data);
+}
+
 tio_code_t tio_handler_onboard(
     tio_handler_t* handler,
     const char* vendor_thing_id,
@@ -333,6 +343,16 @@ void tio_updater_set_json_parser_resource_cb(
     JKII_RESOURCE_FREE_CB free_cb)
 {
     kii_set_json_parser_resource_cb(&updater->_kii, alloc_cb, free_cb);
+}
+
+void tio_updater_set_slist_resource_cb(
+    tio_updater_t* updater,
+    KHC_SLIST_ALLOC_CB alloc_cb,
+    KHC_SLIST_FREE_CB free_cb,
+    void* alloc_cb_data,
+    void* free_cb_data)
+{
+    kii_set_slist_resource_cb(&updater->_kii, alloc_cb, free_cb, alloc_cb_data, free_cb_data);
 }
 
 tio_code_t tio_updater_onboard(


### PR DESCRIPTION
Fixed #42

`void tio_handler_set_slist_resource_cb()` , `void tio_updater_set_slist_resource_cb()` 
がそれぞれ `tio_handler_set_app()`, `tio_updater_set_app()` の後にコールする必要がある問題は、別のPRで対処する。

https://github.com/KiiPlatform/ebisu/issues/65