### PR TITLE
Stream/ Header buff setters

### DIFF
--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -387,7 +387,15 @@ khc_code khc_set_req_headers(khc* khc, khc_slist* headers);
  * If this method is not called or set NULL to the buffer,
  * khc allocates memory of response header buffer when the HTTP session started
  * and free when the HTTP session ends.
- *
+ * The buffer allocated by the khc is 256 bytes.
+
+ * The buffer is used to store single HTTP response header.
+ * If header is larger than the buffer, the header is skipped and KHC_CB_HEADER is not called.
+ * khc needs to parse Status Line, Content-Length, Transfer-Encoding header to process HTTP message.
+ * The buffer must have enough size to store those headers. 256 bytes would be enough.
+ * If you set the buffer by the method, the method must be called befor khc_perform(khc*)
+ * and memory used by the buffer can be safely freed after khc_perform(khc*) returned.
+
  * \param [out] khc instance.
  * \param [in] buffer pointer to the buffer.
  * \param [in] buff_size size of the buffer.
@@ -401,6 +409,14 @@ khc_code khc_set_resp_header_buff(khc* khc, char* buffer, size_t buff_size);
  * If this method is not called or set NULL to the buffer,
  * khc allocates memory of stream buffer when the HTTP session started
  * and free when the HTTP session ends.
+ * The buffer allocated by khc is 1024 bytes.
+
+ * You can change the size of buffer depending on your request/ response size.
+ * It must be enough large to store size line in chunked encoded message.
+ * However, you may use much larger buffer since size line might require very small buffer
+ * as it consists of HEX size and CRLF for the better performance.
+ * If you set the buffer by the method, the method must be called befor khc_perform(khc*)
+ * and memory used by the buffer can be safely freed after khc_perform(khc*) returned.
  *
  * \param [out] khc instance.
  * \param [in] buffer pointer to the buffer.

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -104,6 +104,16 @@ int kii_set_buff(kii_t* kii, char* buff, size_t buff_size) {
     return 0;
 }
 
+int kii_set_stream_buff(kii_t* kii, char* buff, size_t buff_size) {
+    khc_set_stream_buff(&kii->_khc, buff, buff_size);
+    return 0;
+}
+
+int kii_set_resp_header_buff(kii_t* kii, char* buff, size_t buff_size) {
+    khc_set_resp_header_buff(&kii->_khc, buff, buff_size);
+    return 0;
+}
+
 int kii_set_http_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata) {
     khc_set_cb_sock_connect(&kii->_khc, cb, userdata);
     return 0;
@@ -122,6 +132,11 @@ int kii_set_http_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata) {
 int kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata) {
     khc_set_cb_sock_close(&kii->_khc, cb, userdata);
     return 0;
+}
+
+int kii_set_mqtt_buff(kii_t* kii, char* buff, size_t buff_size) {
+    kii->mqtt_buffer = buff;
+    kii->mqtt_buffer_size = buff_size;
 }
 
 int kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata) {

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -137,6 +137,7 @@ int kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata)
 int kii_set_mqtt_buff(kii_t* kii, char* buff, size_t buff_size) {
     kii->mqtt_buffer = buff;
     kii->mqtt_buffer_size = buff_size;
+    return 0;
 }
 
 int kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata) {

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -532,7 +532,7 @@ kii_code_t kii_api_call_run(kii_t* kii);
 
  * You can change the size of buffer depending on the request/ response size.
  * It must be enough large to store whole request/ response except for method listed above.
- * Typically, 4K is enough. However it varies depending on your data schema used to define
+ * Typically, 4096 bytes is enough. However it varies depending on your data schema used to define
  * object or thing. If object becomes large, consider putting them in object body.
 
  * \param [out] kii instance.
@@ -596,6 +596,24 @@ int kii_set_http_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);
 int kii_set_http_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata);
 int kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata);
 
+/**
+ * \brief Set buffer used to parse MQTT message.
+
+ * This method must be called and set valid buffer before calling method
+ * kii_start_push_routine()
+ * The buffer is used to parse MQTT message.
+
+ * You can change the size of buffer depending on the request/ response size.
+ * It must be enough large to store whole message send by MQTT.
+ * Typically, 1024 bytes is enough.
+ * However it varies depending on your data schema used to define Commands.
+ * Avoid defining large Commands.
+
+ * \param [out] kii instance.
+ * \param [in] buffer pointer to the buffer.
+ * \param [in] buff_size size of the buffer.
+ * \return 0 OK. (FIXME: change to void return.)
+ */
 int kii_set_mqtt_buff(kii_t* kii, char* buff, size_t buff_size);
 
 int kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -512,9 +512,83 @@ kii_api_call_append_header(
  */
 kii_code_t kii_api_call_run(kii_t* kii);
 
+/**
+ * \brief Set buffer used to construct/ parse HTTP request/ response.
+
+ * This method must be called and set valid buffer before calling method initiate HTTP session
+ * such as kii_auth_thing(), kii_post_object(), etc.
+ * The buffer is used to serialize/ deserialize JSON.
+
+ * When handling request body which could be large in following APIs,
+ * - kii_upload_object_body(),
+ * - kii_ti_put_state()
+ * The buffer is not used. Stream based KII_CB_READ is used instead.
+ * You don't have to take account the buffer size used by those request.
+
+ * Similary when handling response body which could be large in following APIs,
+ * kii_download_object_body()
+ * The buffer is not used. Stream based KII_CB_WRITE is used instead.
+ * You don't have to take account the buffer size used by those response.
+
+ * You can change the size of buffer depending on the request/ response size.
+ * It must be enough large to store whole request/ response except for method listed above.
+ * Typically, 4K is enough. However it varies depending on your data schema used to define
+ * object or thing. If object becomes large, consider putting them in object body.
+
+ * \param [out] kii instance.
+ * \param [in] buffer pointer to the buffer.
+ * \param [in] buff_size size of the buffer.
+ * \return 0 OK. (FIXME: change to void return.)
+ */
 int kii_set_buff(kii_t* kii, char* buff, size_t buff_size);
 
+/**
+ * \brief Set stream buffer.
+ * Stream buffer is used store part of HTTP body when
+ * reading/ writing it from the network.
+
+ * If this method is not called or set NULL to the buffer,
+ * kii allocates memory of stream buffer when the HTTP session started
+ * and free when the HTTP session ends.
+ * The buffer allocated by kii is 1024 bytes.
+
+ * You can change the size of buffer depending on your request/ response size.
+ * It must be enough large to store size line in chunked encoded message.
+ * However, you may use much larger buffer since size line might require very small buffer
+ * as it consists of HEX size and CRLF for the better performance.
+
+ * If you set the buffer by the method, the method must be called before calling method initiate HTTP session
+ * such as kii_auth_thing(), kii_post_object(), etc.
+ * and memory used by the buffer can be safely freed after the method returned.
+
+ * \param [out] kii instance.
+ * \param [in] buffer pointer to the buffer.
+ * \param [in] buff_size size of the buffer.
+ * \return 0 OK. (FIXME: change to void return.)
+ */
 int kii_set_stream_buff(kii_t* kii, char* buff, size_t buff_size);
+
+/**
+ * \brief Set response header buffer.
+
+ * The buffer is used to store single HTTP response header.
+ * If this method is not called or set NULL to the buffer,
+ * khc allocates memory of response header buffer when the HTTP session started
+ * and free when the HTTP session ends.
+ * The buffer allocated by kii is 256 bytes.
+
+ * If header is larger than the buffer, the header is skipped and not parsed.
+ * kii needs to parse Status Line, Content-Length, Transfer-Encoding and ETag header.
+ * The buffer must have enough size to store those headers. 256 bytes would be enough.
+ * If you set the buffer by the method, the method must be called before calling method initiate HTTP session
+ * such as kii_auth_thing(), kii_post_object(), etc.
+ * and memory used by the buffer can be safely freed after the method returned.
+
+ * \param [out] kii instance.
+ * \param [in] buffer pointer to the buffer.
+ * \param [in] buff_size size of the buffer.
+ * \return 0 OK. (FIXME: change to void return.)
+ */
 int kii_set_resp_header_buff(kii_t* kii, char* buff, size_t buff_size);
 
 int kii_set_http_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -514,10 +514,15 @@ kii_code_t kii_api_call_run(kii_t* kii);
 
 int kii_set_buff(kii_t* kii, char* buff, size_t buff_size);
 
+int kii_set_stream_buff(kii_t* kii, char* buff, size_t buff_size);
+int kii_set_resp_header_buff(kii_t* kii, char* buff, size_t buff_size);
+
 int kii_set_http_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);
 int kii_set_http_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);
 int kii_set_http_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata);
 int kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata);
+
+int kii_set_mqtt_buff(kii_t* kii, char* buff, size_t buff_size);
 
 int kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);
 int kii_set_mqtt_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -573,7 +573,7 @@ int kii_set_stream_buff(kii_t* kii, char* buff, size_t buff_size);
 
  * The buffer is used to store single HTTP response header.
  * If this method is not called or set NULL to the buffer,
- * khc allocates memory of response header buffer when the HTTP session started
+ * kii allocates memory of response header buffer when the HTTP session started
  * and free when the HTTP session ends.
  * The buffer allocated by kii is 256 bytes.
 

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -154,7 +154,7 @@ void tio_handler_set_stream_buff(tio_handler_t* handler, char* buff, size_t buff
  * The buffer allocated by tio_handler is 256 bytes.
 
  * If header is larger than the buffer, the header is skipped and not parsed.
- * tio_handler needs to parse Status Line, Content-Length, Transfer-Encoding and ETag header.
+ * tio_handler needs to parse Status Line, Content-Length and Transfer-Encoding header.
  * The buffer must have enough size to store those headers. 256 bytes would be enough.
  * If you set the buffer by the method, the method must be called before calling tio_handler_start()
  * and memory used by the buffer can be safely freed after you've terminated tio_handler task.
@@ -258,9 +258,69 @@ void tio_updater_set_cb_delay_ms(tio_updater_t* updater, KII_DELAY_MS cb_delay_m
 
 void tio_updater_set_cb_error(tio_updater_t* updater, TIO_CB_ERR cb_err, void* userdata);
 
+/**
+ * \brief Set buffer used to construct/ parse HTTP request/ response.
+
+ * This method must be called and set valid buffer before calling method before calling 
+ * tio_updater_start().
+ * The buffer is used to serialize/ deserialize JSON.
+
+ * You can change the size of buffer depending on the request/ response size.
+ * Typically, 1024 bytes is enough.
+ * Not that for uploading state, the buffer is not used and stream based TIO_CB_READ callback is used.
+ * You don't have to take account into the size of the state.
+
+ * Memory used by the buffer can be safely freed after you've terminated tio_updater task.
+
+ * \param [out] updater instance.
+ * \param [in] buffer pointer to the buffer.
+ * \param [in] buff_size size of the buffer.
+ */
 void tio_updater_set_buff(tio_updater_t* updater, char* buff, size_t buff_size);
 
+/**
+ * \brief Set stream buffer.
+ * Stream buffer is used store part of HTTP body when
+ * reading/ writing it from the network.
+
+ * If this method is not called or set NULL to the buffer,
+ * tio_updater allocates memory of stream buffer when the HTTP session started
+ * and free when the HTTP session ends.
+ * The buffer allocated by tio_updater is 1024 bytes.
+
+ * You can change the size of buffer depending on your request/ response size.
+ * It must be enough large to store size line in chunked encoded message.
+ * However, you may use much larger buffer since size line might require very small buffer
+ * as it consists of HEX size and CRLF for the better performance.
+
+ * If you set the buffer by the method, the method must be called before tio_updater_start().
+ * and memory used by the buffer can be safely freed after you've terminated tio_updater task.
+
+ * \param [out] updater instance.
+ * \param [in] buffer pointer to the buffer.
+ * \param [in] buff_size size of the buffer.
+ */
 void tio_updater_set_stream_buff(tio_updater_t* updater, char* buff, size_t buff_size);
+
+/**
+ * \brief Set response header buffer.
+
+ * The buffer is used to store single HTTP response header.
+ * If this method is not called or set NULL to the buffer,
+ * tio_updater allocates memory of response header buffer when the HTTP session started
+ * and free when the HTTP session ends.
+ * The buffer allocated by tio_updater is 256 bytes.
+
+ * If header is larger than the buffer, the header is skipped and not parsed.
+ * tio_handler needs to parse Status Line, Content-Length and Transfer-Encoding header.
+ * The buffer must have enough size to store those headers. 256 bytes would be enough.
+ * If you set the buffer by the method, the method must be called before calling tio_updater_start()
+ * and memory used by the buffer can be safely freed after you've terminated tio_updater task.
+
+ * \param [out] updater instance.
+ * \param [in] buffer pointer to the buffer.
+ * \param [in] buff_size size of the buffer.
+ */
 void tio_updater_set_resp_header_buff(tio_updater_t* updater, char* buff, size_t buff_size);
 
 void tio_updater_set_app(tio_updater_t* updater, const char* app_id, const char* host);

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -103,6 +103,9 @@ void tio_handler_set_cb_sock_close_http(tio_handler_t* handler, KHC_CB_SOCK_CLOS
 
 void tio_handler_set_http_buff(tio_handler_t* handler, char* buff, size_t buff_size);
 
+void tio_handler_set_stream_buff(tio_handler_t* handler, char* buff, size_t buff_size);
+void tio_handler_set_resp_header_buff(tio_handler_t* handler, char* buff, size_t buff_size);
+
 void tio_handler_set_cb_sock_connect_mqtt(tio_handler_t* handler, KHC_CB_SOCK_CONNECT cb_connect, void* userdata);
 void tio_handler_set_cb_sock_send_mqtt(tio_handler_t* handler, KHC_CB_SOCK_SEND cb_send, void* userdata);
 void tio_handler_set_cb_sock_recv_mqtt(tio_handler_t* handler, KHC_CB_SOCK_RECV cb_recv, void* userdata);
@@ -178,6 +181,9 @@ void tio_updater_set_cb_delay_ms(tio_updater_t* updater, KII_DELAY_MS cb_delay_m
 void tio_updater_set_cb_error(tio_updater_t* updater, TIO_CB_ERR cb_err, void* userdata);
 
 void tio_updater_set_buff(tio_updater_t* updater, char* buff, size_t buff_size);
+
+void tio_updater_set_stream_buff(tio_updater_t* updater, char* buff, size_t buff_size);
+void tio_updater_set_resp_header_buff(tio_updater_t* updater, char* buff, size_t buff_size);
 
 void tio_updater_set_app(tio_updater_t* updater, const char* app_id, const char* host);
 

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -101,9 +101,68 @@ void tio_handler_set_cb_sock_send_http(tio_handler_t* handler, KHC_CB_SOCK_SEND 
 void tio_handler_set_cb_sock_recv_http(tio_handler_t* handler, KHC_CB_SOCK_RECV cb_recv, void* userdata);
 void tio_handler_set_cb_sock_close_http(tio_handler_t* handler, KHC_CB_SOCK_CLOSE cb_close, void* userdata);
 
+/**
+ * \brief Set buffer used to construct/ parse HTTP request/ response.
+
+ * This method must be called and set valid buffer before calling method before calling 
+ * tio_handler_start().
+ * The buffer is used to serialize/ deserialize JSON.
+
+ * You can change the size of buffer depending on the request/ response size.
+ * Typically, 1024 bytes is enough. However it varies depending on your data schema used to define
+ * thing properties/ command. Avoid defining large thing properties/ command if you need to reduce memory usage.
+
+ * Memory used by the buffer can be safely freed after you've terminated tio_handler task.
+
+ * \param [out] handler instance.
+ * \param [in] buffer pointer to the buffer.
+ * \param [in] buff_size size of the buffer.
+ */
 void tio_handler_set_http_buff(tio_handler_t* handler, char* buff, size_t buff_size);
 
+/**
+ * \brief Set stream buffer.
+ * Stream buffer is used store part of HTTP body when
+ * reading/ writing it from the network.
+
+ * If this method is not called or set NULL to the buffer,
+ * tio_handler allocates memory of stream buffer when the HTTP session started
+ * and free when the HTTP session ends.
+ * The buffer allocated by tio_handler is 1024 bytes.
+
+ * You can change the size of buffer depending on your request/ response size.
+ * It must be enough large to store size line in chunked encoded message.
+ * However, you may use much larger buffer since size line might require very small buffer
+ * as it consists of HEX size and CRLF for the better performance.
+
+ * If you set the buffer by the method, the method must be called before tio_handler_start().
+ * and memory used by the buffer can be safely freed after you've terminated tio_handler task.
+
+ * \param [out] handler instance.
+ * \param [in] buffer pointer to the buffer.
+ * \param [in] buff_size size of the buffer.
+ */
 void tio_handler_set_stream_buff(tio_handler_t* handler, char* buff, size_t buff_size);
+
+/**
+ * \brief Set response header buffer.
+
+ * The buffer is used to store single HTTP response header.
+ * If this method is not called or set NULL to the buffer,
+ * tio_handler allocates memory of response header buffer when the HTTP session started
+ * and free when the HTTP session ends.
+ * The buffer allocated by tio_handler is 256 bytes.
+
+ * If header is larger than the buffer, the header is skipped and not parsed.
+ * tio_handler needs to parse Status Line, Content-Length, Transfer-Encoding and ETag header.
+ * The buffer must have enough size to store those headers. 256 bytes would be enough.
+ * If you set the buffer by the method, the method must be called before calling tio_handler_start()
+ * and memory used by the buffer can be safely freed after you've terminated tio_handler task.
+
+ * \param [out] handler instance.
+ * \param [in] buffer pointer to the buffer.
+ * \param [in] buff_size size of the buffer.
+ */
 void tio_handler_set_resp_header_buff(tio_handler_t* handler, char* buff, size_t buff_size);
 
 void tio_handler_set_cb_sock_connect_mqtt(tio_handler_t* handler, KHC_CB_SOCK_CONNECT cb_connect, void* userdata);
@@ -119,6 +178,25 @@ void tio_handler_set_cb_delay_ms(tio_handler_t* handler, KII_DELAY_MS cb_delay_m
 
 void tio_handler_set_cb_err(tio_handler_t* handler, TIO_CB_ERR cb_err, void* userdata);
 
+/**
+ * \brief Set buffer used to parse MQTT message.
+
+ * This method must be called and set valid buffer before calling method
+ * tio_handler_start()
+ * The buffer is used to parse MQTT message.
+
+ * You can change the size of buffer depending on the request/ response size.
+ * It must be enough large to store whole message send by MQTT.
+ * Typically, 1024 bytes is enough.
+ * However it varies depending on your data schema used to define Commands.
+ * Avoid defining large Commands.
+
+ * Memory used by the buffer can be safely freed after you've terminated tio_handler task.
+
+ * \param [out] handler instance.
+ * \param [in] buffer pointer to the buffer.
+ * \param [in] buff_size size of the buffer.
+ */
 void tio_handler_set_mqtt_buff(tio_handler_t* handler, char* buff, size_t buff_size);
 
 void tio_handler_set_keep_alive_interval(tio_handler_t* handler, size_t keep_alive_interval);

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -54,6 +54,14 @@ void tio_handler_set_http_buff(
     kii_set_buff(&handler->_kii, buff, buff_size);
 }
 
+void tio_handler_set_stream_buff(tio_handler_t* handler, char* buff, size_t buff_size) {
+    kii_set_stream_buff(&handler->_kii, buff, buff_size);
+}
+
+void tio_handler_set_resp_header_buff(tio_handler_t* handler, char* buff, size_t buff_size) {
+    kii_set_resp_header_buff(&handler->_kii, buff, buff_size);
+}
+
 void tio_handler_set_cb_sock_connect_mqtt(
     tio_handler_t* handler,
     KHC_CB_SOCK_CONNECT cb_connect,
@@ -124,9 +132,7 @@ void tio_handler_set_mqtt_buff(
     char* buff,
     size_t buff_size)
 {
-    //FIXME: Kii should provide setter API.
-    handler->_kii.mqtt_buffer = buff;
-    handler->_kii.mqtt_buffer_size =buff_size;
+    kii_set_mqtt_buff(&handler->_kii, buff, buff_size);
 }
 
 void tio_handler_set_keep_alive_interval(
@@ -290,6 +296,14 @@ void tio_updater_set_buff(
     size_t buff_size)
 {
     kii_set_buff(&updater->_kii, buff, buff_size);
+}
+
+void tio_updater_set_stream_buff(tio_updater_t* updater, char* buff, size_t buff_size) {
+    kii_set_stream_buff(&updater->_kii, buff, buff_size);
+}
+
+void tio_updater_set_resp_header_buff(tio_updater_t* updater, char* buff, size_t buff_size) {
+    kii_set_resp_header_buff(&updater->_kii, buff, buff_size);
 }
 
 void tio_updater_set_app(


### PR DESCRIPTION
kii/ tio にStream/ Header用のバッファを設定するAPIを追加しました。 (#42)

- Stream/ Header用のバッファの設定は任意のままとし、設定が無い場合はmallocする処理は残しました。
これは設定を強制にすると設定が必要なバッファ(JSONの構築・パース用、MQTTのメッセージパース用、Stream, Header)が多くなってしまい、malloc/freeが許容できる環境では煩雑となるためです。

- tio のバッファの開放についてはtaskを安全にterminateする手段が必要ですが、その手段の提供は #47 で行います。
