### PR TITLE
change setter return type to void.

### DIFF
--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -309,7 +309,7 @@ typedef struct khc {
  * \param [out] khc instance.
  * \see khc_set_zero_excl_cb(khc*)
  */
-khc_code khc_set_zero(khc* khc);
+void khc_set_zero(khc* khc);
 
 /**
  * \brief Set members of khc 0/NULL.
@@ -327,7 +327,7 @@ khc_code khc_set_zero(khc* khc);
  * \param [out] khc instance.
  * \see khc_set_zero(khc*)
  */
-khc_code khc_set_zero_excl_cb(khc* khc);
+void khc_set_zero_excl_cb(khc* khc);
 
 /**
  * \brief Perform the HTTP session
@@ -400,7 +400,7 @@ khc_code khc_set_req_headers(khc* khc, khc_slist* headers);
  * \param [in] buffer pointer to the buffer.
  * \param [in] buff_size size of the buffer.
  */
-khc_code khc_set_resp_header_buff(khc* khc, char* buffer, size_t buff_size);
+void khc_set_resp_header_buff(khc* khc, char* buffer, size_t buff_size);
 
 /**
  * \brief Set stream buffer.
@@ -422,7 +422,7 @@ khc_code khc_set_resp_header_buff(khc* khc, char* buffer, size_t buff_size);
  * \param [in] buffer pointer to the buffer.
  * \param [in] buff_size size of the buffer.
  */
-khc_code khc_set_stream_buff(khc* khc, char* buffer, size_t buff_size);
+void khc_set_stream_buff(khc* khc, char* buffer, size_t buff_size);
 
 /**
  * \brief Set socket connect callback.

--- a/khc/src/khc.c
+++ b/khc/src/khc.c
@@ -5,16 +5,14 @@
 #include "khc_state_impl.h"
 #include "khc_socket_callback.h"
 
-khc_code khc_set_resp_header_buff(khc* khc, char* buffer, size_t buff_size) {
+void khc_set_resp_header_buff(khc* khc, char* buffer, size_t buff_size) {
   khc->_resp_header_buff = buffer;
   khc->_resp_header_buff_size = buff_size;
-  return KHC_ERR_OK;
 }
 
-khc_code khc_set_stream_buff(khc* khc, char* buffer, size_t buff_size) {
+void khc_set_stream_buff(khc* khc, char* buffer, size_t buff_size) {
   khc->_stream_buff = buffer;
   khc->_stream_buff_size = buff_size;
-  return KHC_ERR_OK;
 }
 
 khc_code khc_perform(khc* khc) {
@@ -29,7 +27,7 @@ khc_code khc_perform(khc* khc) {
   return res;
 }
 
-khc_code khc_set_zero(khc* khc) {
+void khc_set_zero(khc* khc) {
   // Callbacks.
   khc->_cb_write = NULL;
   khc->_write_data = NULL;
@@ -53,11 +51,9 @@ khc_code khc_set_zero(khc* khc) {
   khc->_sock_ctx_close = NULL;
 
   khc_set_zero_excl_cb(khc);
-
-  return KHC_ERR_OK;
 }
 
-khc_code khc_set_zero_excl_cb(khc* khc) {
+void khc_set_zero_excl_cb(khc* khc) {
   khc->_req_headers = NULL;
   khc->_host[0] = '\0';
   khc->_path[0] = '\0';
@@ -92,7 +88,6 @@ khc_code khc_set_zero_excl_cb(khc* khc) {
   khc->_stream_buff = NULL;
   khc->_stream_buff_size = 0;
   khc->_stream_buff_allocated = 0;
-  return KHC_ERR_OK;
 }
 
 int khc_get_status_code(

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -47,7 +47,7 @@ size_t _cb_write_header(char *buffer, size_t size, void *userdata)
     return size;
 }
 
-int kii_init(kii_t* kii)
+void kii_init(kii_t* kii)
 {
     memset(kii, 0x00, sizeof(kii_t));
     kii->_sdk_info = KII_SDK_INFO;
@@ -69,10 +69,9 @@ int kii_init(kii_t* kii)
     kii->_task_exit_data = NULL;
     kii->delay_ms_cb = NULL;
     kii->_delay_ms_data = NULL;
-    return 0;
 }
 
-int kii_set_site(
+void kii_set_site(
         kii_t* kii,
         const char* site)
 {
@@ -103,95 +102,79 @@ int kii_set_site(
         host = (char*)site;
     }
     strncpy(kii->_app_host, host, sizeof(kii->_app_host) * sizeof(char));
-    return 0;
 }
 
-int kii_set_app_id(
+void kii_set_app_id(
         kii_t* kii,
         const char* app_id)
 {
     strncpy(kii->_app_id, app_id, sizeof(kii->_app_id) * sizeof(char));
-    return 0;
 }
 
-int kii_set_buff(kii_t* kii, char* buff, size_t buff_size) {
+void kii_set_buff(kii_t* kii, char* buff, size_t buff_size) {
     kii->_rw_buff = buff;
     kii->_rw_buff_size = buff_size;
     kii->_rw_buff_read = 0;
     kii->_rw_buff_written = 0;
     khc_set_cb_read(&kii->_khc, _cb_read_buff, kii);
     khc_set_cb_write(&kii->_khc, _cb_write_buff, kii);
-    return 0;
 }
 
-int kii_set_stream_buff(kii_t* kii, char* buff, size_t buff_size) {
+void kii_set_stream_buff(kii_t* kii, char* buff, size_t buff_size) {
     khc_set_stream_buff(&kii->_khc, buff, buff_size);
-    return 0;
 }
 
-int kii_set_resp_header_buff(kii_t* kii, char* buff, size_t buff_size) {
+void kii_set_resp_header_buff(kii_t* kii, char* buff, size_t buff_size) {
     khc_set_resp_header_buff(&kii->_khc, buff, buff_size);
-    return 0;
 }
 
-int kii_set_http_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata) {
+void kii_set_http_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata) {
     khc_set_cb_sock_connect(&kii->_khc, cb, userdata);
-    return 0;
 }
 
-int kii_set_http_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata) {
+void kii_set_http_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata) {
     khc_set_cb_sock_send(&kii->_khc, cb, userdata);
-    return 0;
 }
 
-int kii_set_http_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata) {
+void kii_set_http_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata) {
     khc_set_cb_sock_recv(&kii->_khc, cb, userdata);
-    return 0;
 }
 
-int kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata) {
+void kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata) {
     khc_set_cb_sock_close(&kii->_khc, cb, userdata);
-    return 0;
 }
 
-int kii_set_mqtt_buff(kii_t* kii, char* buff, size_t buff_size) {
+void kii_set_mqtt_buff(kii_t* kii, char* buff, size_t buff_size) {
     kii->mqtt_buffer = buff;
     kii->mqtt_buffer_size = buff_size;
-    return 0;
 }
 
-int kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata) {
+void kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata) {
     kii->mqtt_sock_connect_cb = cb;
     kii->mqtt_sock_connect_ctx = userdata;
-    return 0;
 }
 
-int kii_set_mqtt_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata) {
+void kii_set_mqtt_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata) {
     kii->mqtt_sock_send_cb = cb;
     kii->mqtt_sock_send_ctx = userdata;
-    return 0;
 }
 
-int kii_set_mqtt_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata) {
+void kii_set_mqtt_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata) {
     kii->mqtt_sock_recv_cb = cb;
     kii->mqtt_sock_recv_ctx = userdata;
-    return 0;
 }
 
-int kii_set_mqtt_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata) {
+void kii_set_mqtt_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata) {
     kii->mqtt_sock_close_cb = cb;
     kii->mqtt_sock_close_ctx = userdata;
-    return 0;
 }
 
-int kii_set_mqtt_to_sock_recv(kii_t* kii, unsigned int to_sock_recv_sec) {
+void kii_set_mqtt_to_sock_recv(kii_t* kii, unsigned int to_sock_recv_sec) {
     kii->_mqtt_to_recv_sec = to_sock_recv_sec;
-    return 0;
 }
 
-int kii_set_mqtt_to_sock_send(kii_t* kii, unsigned int to_sock_send_sec) {
+void kii_set_mqtt_to_sock_send(kii_t* kii, unsigned int to_sock_send_sec) {
     kii->_mqtt_to_send_sec = to_sock_send_sec;
-    return 0;
 }
 
 void kii_set_task_create_cb(kii_t* kii, KII_TASK_CREATE cb, void* userdata) {
@@ -214,22 +197,20 @@ void kii_set_delay_ms_cb(kii_t* kii, KII_DELAY_MS cb, void* userdata) {
     kii->_delay_ms_data = userdata;
 }
 
-kii_code_t kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource) {
+void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource) {
     kii->_json_resource = resource;
-    return KII_ERR_OK;
 }
 
-kii_code_t kii_set_json_parser_resource_cb(
+void kii_set_json_parser_resource_cb(
     kii_t* kii,
     JKII_RESOURCE_ALLOC_CB alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb)
 {
     kii->_json_alloc_cb = alloc_cb;
     kii->_json_free_cb = free_cb;
-    return KII_ERR_OK;
 }
 
-kii_code_t kii_set_slist_resource_cb(
+void kii_set_slist_resource_cb(
     kii_t* kii,
     KHC_SLIST_ALLOC_CB alloc_cb,
     KHC_SLIST_FREE_CB free_cb,
@@ -239,7 +220,6 @@ kii_code_t kii_set_slist_resource_cb(
     kii->_slist_free_cb = free_cb;
     kii->_slist_alloc_cb_data = alloc_cb_data;
     kii->_slist_free_cb_data = free_cb_data;
-    return KII_ERR_OK;
 }
 
 const char* kii_get_etag(kii_t* kii) {

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -162,27 +162,24 @@ typedef struct kii_t {
 
 /** Initializes Kii SDK
  *  \param [inout] kii sdk instance.
- *  \return 0 OK. (FIXME: change to void return.)
  */
-int kii_init(
+void kii_init(
 		kii_t* kii);
 
 /** \brief Set site name.
  *  \param [inout] kii sdk instance.
  *  \param [in] site the input of site name,
  *  should be one of "CN", "CN3", "JP", "US", "SG" or "EU"
- *  \return 0 OK. (FIXME: change to void return.)
  */
-int kii_set_site(
+void kii_set_site(
 		kii_t* kii,
 		const char* site);
 
 /** \brief Set Application ID.
  *  \param [inout] kii sdk instance.
  *  \param [in] app_id the input of Application ID
- *  \return 0 OK. (FIXME: change to void return.)
  */
-int kii_set_app_id(
+void kii_set_app_id(
 		kii_t* kii,
 		const char* app_id);
 
@@ -192,7 +189,7 @@ int kii_set_app_id(
  *  \param [inout] kii sdk instance.
  *  \param [in] vendor_thing_id the thing identifier given by vendor.
  *  \param [in] password the password of the thing given by vendor.
- *  \return 0:success, -1: failure
+ *  \return kii_code_t.
  */
 kii_code_t kii_auth_thing(
 		kii_t* kii,
@@ -574,9 +571,8 @@ kii_code_t kii_api_call_run(kii_t* kii);
  * \param [out] kii instance.
  * \param [in] buffer pointer to the buffer.
  * \param [in] buff_size size of the buffer.
- * \return 0 OK. (FIXME: change to void return.)
  */
-int kii_set_buff(kii_t* kii, char* buff, size_t buff_size);
+void kii_set_buff(kii_t* kii, char* buff, size_t buff_size);
 
 /**
  * \brief Set stream buffer.
@@ -600,9 +596,8 @@ int kii_set_buff(kii_t* kii, char* buff, size_t buff_size);
  * \param [out] kii instance.
  * \param [in] buffer pointer to the buffer.
  * \param [in] buff_size size of the buffer.
- * \return 0 OK. (FIXME: change to void return.)
  */
-int kii_set_stream_buff(kii_t* kii, char* buff, size_t buff_size);
+void kii_set_stream_buff(kii_t* kii, char* buff, size_t buff_size);
 
 /**
  * \brief Set response header buffer.
@@ -623,14 +618,13 @@ int kii_set_stream_buff(kii_t* kii, char* buff, size_t buff_size);
  * \param [out] kii instance.
  * \param [in] buffer pointer to the buffer.
  * \param [in] buff_size size of the buffer.
- * \return 0 OK. (FIXME: change to void return.)
  */
-int kii_set_resp_header_buff(kii_t* kii, char* buff, size_t buff_size);
+void kii_set_resp_header_buff(kii_t* kii, char* buff, size_t buff_size);
 
-int kii_set_http_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);
-int kii_set_http_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);
-int kii_set_http_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata);
-int kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata);
+void kii_set_http_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);
+void kii_set_http_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);
+void kii_set_http_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata);
+void kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata);
 
 /**
  * \brief Set buffer used to parse MQTT message.
@@ -648,17 +642,16 @@ int kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata)
  * \param [out] kii instance.
  * \param [in] buffer pointer to the buffer.
  * \param [in] buff_size size of the buffer.
- * \return 0 OK. (FIXME: change to void return.)
  */
-int kii_set_mqtt_buff(kii_t* kii, char* buff, size_t buff_size);
+void kii_set_mqtt_buff(kii_t* kii, char* buff, size_t buff_size);
 
-int kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);
-int kii_set_mqtt_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);
-int kii_set_mqtt_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata);
-int kii_set_mqtt_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata);
+void kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);
+void kii_set_mqtt_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);
+void kii_set_mqtt_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata);
+void kii_set_mqtt_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata);
 
-int kii_set_mqtt_to_sock_recv(kii_t* kii, unsigned int to_sock_recv_sec);
-int kii_set_mqtt_to_sock_send(kii_t* kii, unsigned int to_sock_send_sec);
+void kii_set_mqtt_to_sock_recv(kii_t* kii, unsigned int to_sock_recv_sec);
+void kii_set_mqtt_to_sock_send(kii_t* kii, unsigned int to_sock_send_sec);
 
 void kii_set_task_create_cb(kii_t* kii, KII_TASK_CREATE create_cb, void* userdata);
 
@@ -721,7 +714,7 @@ void kii_set_delay_ms_cb(kii_t* kii, KII_DELAY_MS delay_cb, void* userdata);
  * If you need to parse large object or allocate exact size of memory used,
  * see kii_set_json_parser_resource_cb(kii_t, JKII_RESOURCE_ALLOC_CB, JKII_RESOURCE_FREE_CB)
  */
-kii_code_t kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
+void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
 
 /** Set JSON paraser resource allocators.
  *  To use Allocator instead of fixed size memory given by kii_set_json_parser_resource(kii_t, jkii_resource_t),
@@ -730,7 +723,7 @@ kii_code_t kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
  * @param [in] alloc_cb allocator callback.
  * @param [in] free_cb free callback should free memories allocated in alloc_cb.
  */
-kii_code_t kii_set_json_parser_resource_cb(kii_t* kii,
+void kii_set_json_parser_resource_cb(kii_t* kii,
     JKII_RESOURCE_ALLOC_CB alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb);
 
@@ -740,7 +733,7 @@ kii_code_t kii_set_json_parser_resource_cb(kii_t* kii,
  * If this method is not called, default allocators implemented with malloc/free is used to
  * allocate linked list used to construct HTTP request headers.
  */
-kii_code_t kii_set_slist_resource_cb(
+void kii_set_slist_resource_cb(
     kii_t* kii,
     KHC_SLIST_ALLOC_CB alloc_cb,
     KHC_SLIST_FREE_CB free_cb,


### PR DESCRIPTION
`kii` `khc` のセッターで値を返す必要のないものを修正しました。
`jkii` `tio` では対象はありませんでした。

一部ドックコメントでreturn typeが間違っていたのがあったので合わせて修正しています。

注意: PR: #79 マージ後、ベースブランチを `http1.1` に変更が必要。

Issue: #69 