### PR TITLE
Renamed callback related APIs

### DIFF
--- a/jkii/include/jkii.h
+++ b/jkii/include/jkii.h
@@ -32,7 +32,7 @@ typedef struct jkii_resource_t {
  * \return jkii_resource_t instance of NULL if failed to allocate resource.
  */
 typedef jkii_resource_t*
-    (*JKII_RESOURCE_ALLOC_CB)(
+    (*JKII_CB_RESOURCE_ALLOC)(
         size_t required_size);
 
 typedef void (*JKII_RESOURCE_FREE_CB)(
@@ -343,7 +343,7 @@ jkii_parse_err_t jkii_parse_with_allocator(
     const char* json_string,
     size_t json_string_len,
     jkii_field_t* fields,
-    JKII_RESOURCE_ALLOC_CB alloc_cb,
+    JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb);
 
 #ifdef __cplusplus

--- a/jkii/include/jkii.h
+++ b/jkii/include/jkii.h
@@ -336,15 +336,16 @@ jkii_parse_err_t jkii_parse(
  *  \param [in] pointer of JSON string.
  *  \param [in] length of JSON string.
  *  \param [inout] field of kii JSON parser.
- *  \param [in] resource of parser.
+ *  \param [in] cb_alloc allocate resource
+ *  \param [in] cb_free free resource
  *  \return parse JSON result.
  */
 jkii_parse_err_t jkii_parse_with_allocator(
     const char* json_string,
     size_t json_string_len,
     jkii_field_t* fields,
-    JKII_CB_RESOURCE_ALLOC alloc_cb,
-    JKII_CB_RESOURCE_FREE free_cb);
+    JKII_CB_RESOURCE_ALLOC cb_alloc,
+    JKII_CB_RESOURCE_FREE cb_free);
 
 #ifdef __cplusplus
 }

--- a/jkii/include/jkii.h
+++ b/jkii/include/jkii.h
@@ -35,7 +35,7 @@ typedef jkii_resource_t*
     (*JKII_CB_RESOURCE_ALLOC)(
         size_t required_size);
 
-typedef void (*JKII_RESOURCE_FREE_CB)(
+typedef void (*JKII_CB_RESOURCE_FREE)(
     jkii_resource_t* resource);
 
 /** Boolean type */
@@ -344,7 +344,7 @@ jkii_parse_err_t jkii_parse_with_allocator(
     size_t json_string_len,
     jkii_field_t* fields,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
-    JKII_RESOURCE_FREE_CB free_cb);
+    JKII_CB_RESOURCE_FREE free_cb);
 
 #ifdef __cplusplus
 }

--- a/jkii/src/jkii.c
+++ b/jkii/src/jkii.c
@@ -889,12 +889,12 @@ jkii_parse_err_t jkii_parse_with_allocator(
     size_t json_string_len,
     jkii_field_t* fields,
     JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE free_cb)
+    JKII_CB_RESOURCE_FREE cb_free)
 {
     M_JKII_ASSERT(json_string != NULL);
     M_JKII_ASSERT(json_string_len > 0);
     M_JKII_ASSERT(cb_alloc != NULL);
-    M_JKII_ASSERT(free_cb != NULL);
+    M_JKII_ASSERT(cb_free != NULL);
 
     jkii_resource_t *resource;
     int required = _calculate_required_token_num(json_string, json_string_len);
@@ -910,18 +910,18 @@ jkii_parse_err_t jkii_parse_with_allocator(
 
     jkii_parse_err_t res = _kii_jsmn_get_tokens(json_string, json_string_len, resource);
     if (res != JKII_ERR_OK) {
-        free_cb(resource);
+        cb_free(resource);
         return res;
     }
 
     jsmntype_t type = resource->tokens[0].type;
     if (type != JSMN_ARRAY && type != JSMN_OBJECT) {
-        free_cb(resource);
+        cb_free(resource);
         return JKII_ERR_INVALID_INPUT;
     }
     res = _jkii_parse_fields(json_string, json_string_len, fields, resource);
 
-    free_cb(resource);
+    cb_free(resource);
     return res;
 }
 

--- a/jkii/src/jkii.c
+++ b/jkii/src/jkii.c
@@ -889,7 +889,7 @@ jkii_parse_err_t jkii_parse_with_allocator(
     size_t json_string_len,
     jkii_field_t* fields,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
-    JKII_RESOURCE_FREE_CB free_cb)
+    JKII_CB_RESOURCE_FREE free_cb)
 {
     M_JKII_ASSERT(json_string != NULL);
     M_JKII_ASSERT(json_string_len > 0);

--- a/jkii/src/jkii.c
+++ b/jkii/src/jkii.c
@@ -888,7 +888,7 @@ jkii_parse_err_t jkii_parse_with_allocator(
     const char* json_string,
     size_t json_string_len,
     jkii_field_t* fields,
-    JKII_RESOURCE_ALLOC_CB alloc_cb,
+    JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb)
 {
     M_JKII_ASSERT(json_string != NULL);

--- a/jkii/src/jkii.c
+++ b/jkii/src/jkii.c
@@ -888,18 +888,18 @@ jkii_parse_err_t jkii_parse_with_allocator(
     const char* json_string,
     size_t json_string_len,
     jkii_field_t* fields,
-    JKII_CB_RESOURCE_ALLOC alloc_cb,
+    JKII_CB_RESOURCE_ALLOC cb_alloc,
     JKII_CB_RESOURCE_FREE free_cb)
 {
     M_JKII_ASSERT(json_string != NULL);
     M_JKII_ASSERT(json_string_len > 0);
-    M_JKII_ASSERT(alloc_cb != NULL);
+    M_JKII_ASSERT(cb_alloc != NULL);
     M_JKII_ASSERT(free_cb != NULL);
 
     jkii_resource_t *resource;
     int required = _calculate_required_token_num(json_string, json_string_len);
     if (required > 0) {
-        resource = alloc_cb(required);
+        resource = cb_alloc(required);
         if (resource == NULL)
         {
             return JKII_ERR_ALLOCATION;

--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -69,7 +69,7 @@ typedef struct khc_slist {
  * \param [in] str khc_slist content. String must be copied to khc_slist.data.
  * \param [in] str_length length of the string (exclude NULL termination).
  * \param [inout] data optional context data pointer. The pointer is given by
- * khc_slist_append_using_alloc_cb(khc_slist*, const char*, size_t, KHC_SLIST_ALLOC_CB, void*) method and could be NULL.
+ * khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t, KHC_SLIST_ALLOC_CB, void*) method and could be NULL.
  */
 typedef khc_slist*(*KHC_SLIST_ALLOC_CB)(const char* str, size_t str_length, void* data);
 
@@ -87,7 +87,7 @@ typedef void(*KHC_SLIST_FREE_CB)(khc_slist* node, void* data);
 /**
  * \brief Default implementation of KHC_SLIST_ALLOC_CB.
  */
-khc_slist* khc_slist_alloc_cb(const char* str, size_t str_len, void* data);
+khc_slist* khc_slist_cb_alloc(const char* str, size_t str_len, void* data);
 
 /**
  * \brief Default implementation of KHC_SLIST_FREE_CB.
@@ -101,7 +101,7 @@ void khc_slist_free_cb(khc_slist* slist, void* data);
  * khc_slist must be appended by this method if the previous node is appended by this method.
  * khc_slist_free_all(khc_slist*) must be called to free all memories used by the list.
  * You can't use different allocate/ free method specified by
- * khc_slist_append_using_alloc_cb(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)
+ * khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)
  * in a single list.
  * \param [in, out] slist pointer to the linked list or NULL to create new linked list.
  * \param [in] string data to be appended. String is copied to new char array in slist.
@@ -118,21 +118,21 @@ khc_slist* khc_slist_append(khc_slist* slist, const char* string, size_t length)
  * khc_slist_free_all_using_free_cb(khc_slist*, KHC_SLIST_FREE_CB, void*) and matching free callback
  * must be used to free all memories used by the list.
  * You can't use different allocate/ free method specified by
- * khc_slist_append_using_alloc_cb(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)
+ * khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)
  * in a single list.
  * \param [in, out] slist pointer to the linked list or NULL to create new linked list.
  * \param [in] string data to be appended. String is copied to new char array in slist.
  * \param [in] length of the string.
- * \param [in] alloc_cb allocator callback function.
- * \param [in] alloc_cb_data context data pointer passed to alloc_cb.
+ * \param [in] cb_alloc allocator callback function.
+ * \param [in] cb_alloc_data context data pointer passed to cb_alloc.
  * \returns pointer to the linked list (first node).
  */
-khc_slist* khc_slist_append_using_alloc_cb(
+khc_slist* khc_slist_append_using_cb_alloc(
   khc_slist* slist,
   const char* string,
   size_t length,
-  KHC_SLIST_ALLOC_CB alloc_cb,
-  void* alloc_cb_data);
+  KHC_SLIST_ALLOC_CB cb_alloc,
+  void* cb_alloc_data);
 
 /**
  * \brief Free memory used for the entire linked list.
@@ -145,7 +145,7 @@ void khc_slist_free_all(khc_slist* slist);
 /**
  * \brief Free memory used for the entire linked list constructed by custom allocator.
  *
- * Linked list constructed by khc_slist_append_using_alloc_cb(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)
+ * Linked list constructed by khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)
  * must be freed by this method and matching free callback.
 
  * \param [in, out] slist pointer to the linked list (first node).

--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -82,7 +82,7 @@ typedef khc_slist*(*KHC_CB_SLIST_ALLOC)(const char* str, size_t str_length, void
  * \param [in] node of the slist.
  * \param [in] data Context data pointer.
  */
-typedef void(*KHC_SLIST_FREE_CB)(khc_slist* node, void* data);
+typedef void(*KHC_CB_SLIST_FREE)(khc_slist* node, void* data);
 
 /**
  * \brief Default implementation of KHC_CB_SLIST_ALLOC.
@@ -90,7 +90,7 @@ typedef void(*KHC_SLIST_FREE_CB)(khc_slist* node, void* data);
 khc_slist* khc_slist_cb_alloc(const char* str, size_t str_len, void* data);
 
 /**
- * \brief Default implementation of KHC_SLIST_FREE_CB.
+ * \brief Default implementation of KHC_CB_SLIST_FREE.
  */
 void khc_slist_cb_free(khc_slist* slist, void* data);
 
@@ -115,7 +115,7 @@ khc_slist* khc_slist_append(khc_slist* slist, const char* string, size_t length)
 
  * This method uses custom memory allocator for constructing string copy and khc_slist.
  * khc_slist must be appended by this method and same allocator if the previous node is appended by this method.
- * khc_slist_free_all_using_cb_free(khc_slist*, KHC_SLIST_FREE_CB, void*) and matching free callback
+ * khc_slist_free_all_using_cb_free(khc_slist*, KHC_CB_SLIST_FREE, void*) and matching free callback
  * must be used to free all memories used by the list.
  * You can't use different allocate/ free method specified by
  * khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t length, KHC_CB_SLIST_ALLOC, void*)
@@ -154,7 +154,7 @@ void khc_slist_free_all(khc_slist* slist);
  */
 void khc_slist_free_all_using_cb_free(
   khc_slist* slist,
-  KHC_SLIST_FREE_CB cb_free,
+  KHC_CB_SLIST_FREE cb_free,
   void* cb_free_data);
 
 /**

--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -92,7 +92,7 @@ khc_slist* khc_slist_cb_alloc(const char* str, size_t str_len, void* data);
 /**
  * \brief Default implementation of KHC_SLIST_FREE_CB.
  */
-void khc_slist_free_cb(khc_slist* slist, void* data);
+void khc_slist_cb_free(khc_slist* slist, void* data);
 
 /**
  * \brief Add node to the linked list.
@@ -115,7 +115,7 @@ khc_slist* khc_slist_append(khc_slist* slist, const char* string, size_t length)
 
  * This method uses custom memory allocator for constructing string copy and khc_slist.
  * khc_slist must be appended by this method and same allocator if the previous node is appended by this method.
- * khc_slist_free_all_using_free_cb(khc_slist*, KHC_SLIST_FREE_CB, void*) and matching free callback
+ * khc_slist_free_all_using_cb_free(khc_slist*, KHC_SLIST_FREE_CB, void*) and matching free callback
  * must be used to free all memories used by the list.
  * You can't use different allocate/ free method specified by
  * khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)
@@ -149,13 +149,13 @@ void khc_slist_free_all(khc_slist* slist);
  * must be freed by this method and matching free callback.
 
  * \param [in, out] slist pointer to the linked list (first node).
- * \param [in] free_cb free callback.
- * \param [in] free_cb_data context object pointer passed to free_cb.
+ * \param [in] cb_free free callback.
+ * \param [in] cb_free_data context object pointer passed to cb_free.
  */
-void khc_slist_free_all_using_free_cb(
+void khc_slist_free_all_using_cb_free(
   khc_slist* slist,
-  KHC_SLIST_FREE_CB free_cb,
-  void* free_cb_data);
+  KHC_SLIST_FREE_CB cb_free,
+  void* cb_free_data);
 
 /**
  * \brief Indicate state of khc.

--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -69,15 +69,15 @@ typedef struct khc_slist {
  * \param [in] str khc_slist content. String must be copied to khc_slist.data.
  * \param [in] str_length length of the string (exclude NULL termination).
  * \param [inout] data optional context data pointer. The pointer is given by
- * khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t, KHC_SLIST_ALLOC_CB, void*) method and could be NULL.
+ * khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t, KHC_CB_SLIST_ALLOC, void*) method and could be NULL.
  */
-typedef khc_slist*(*KHC_SLIST_ALLOC_CB)(const char* str, size_t str_length, void* data);
+typedef khc_slist*(*KHC_CB_SLIST_ALLOC)(const char* str, size_t str_length, void* data);
 
 /**
  * \ brief free memory allocated by custom khc_slist node allocator.
 
  * In this callback, implementation must free memory allocated by single khc_slist node.
- * Method must be corresponding to alloc method implemented in KHC_SLIST_ALLOC_CB.
+ * Method must be corresponding to alloc method implemented in KHC_CB_SLIST_ALLOC.
 
  * \param [in] node of the slist.
  * \param [in] data Context data pointer.
@@ -85,7 +85,7 @@ typedef khc_slist*(*KHC_SLIST_ALLOC_CB)(const char* str, size_t str_length, void
 typedef void(*KHC_SLIST_FREE_CB)(khc_slist* node, void* data);
 
 /**
- * \brief Default implementation of KHC_SLIST_ALLOC_CB.
+ * \brief Default implementation of KHC_CB_SLIST_ALLOC.
  */
 khc_slist* khc_slist_cb_alloc(const char* str, size_t str_len, void* data);
 
@@ -101,7 +101,7 @@ void khc_slist_cb_free(khc_slist* slist, void* data);
  * khc_slist must be appended by this method if the previous node is appended by this method.
  * khc_slist_free_all(khc_slist*) must be called to free all memories used by the list.
  * You can't use different allocate/ free method specified by
- * khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)
+ * khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t length, KHC_CB_SLIST_ALLOC, void*)
  * in a single list.
  * \param [in, out] slist pointer to the linked list or NULL to create new linked list.
  * \param [in] string data to be appended. String is copied to new char array in slist.
@@ -118,7 +118,7 @@ khc_slist* khc_slist_append(khc_slist* slist, const char* string, size_t length)
  * khc_slist_free_all_using_cb_free(khc_slist*, KHC_SLIST_FREE_CB, void*) and matching free callback
  * must be used to free all memories used by the list.
  * You can't use different allocate/ free method specified by
- * khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)
+ * khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t length, KHC_CB_SLIST_ALLOC, void*)
  * in a single list.
  * \param [in, out] slist pointer to the linked list or NULL to create new linked list.
  * \param [in] string data to be appended. String is copied to new char array in slist.
@@ -131,7 +131,7 @@ khc_slist* khc_slist_append_using_cb_alloc(
   khc_slist* slist,
   const char* string,
   size_t length,
-  KHC_SLIST_ALLOC_CB cb_alloc,
+  KHC_CB_SLIST_ALLOC cb_alloc,
   void* cb_alloc_data);
 
 /**
@@ -145,7 +145,7 @@ void khc_slist_free_all(khc_slist* slist);
 /**
  * \brief Free memory used for the entire linked list constructed by custom allocator.
  *
- * Linked list constructed by khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t length, KHC_SLIST_ALLOC_CB, void*)
+ * Linked list constructed by khc_slist_append_using_cb_alloc(khc_slist*, const char*, size_t length, KHC_CB_SLIST_ALLOC, void*)
  * must be freed by this method and matching free callback.
 
  * \param [in, out] slist pointer to the linked list (first node).

--- a/khc/src/khc_slist.c
+++ b/khc/src/khc_slist.c
@@ -19,7 +19,7 @@ khc_slist* khc_slist_cb_alloc(const char* str, size_t str_len, void* data) {
   return node;
 }
 
-void khc_slist_free_cb(khc_slist* slist, void* data) {
+void khc_slist_cb_free(khc_slist* slist, void* data) {
   free(slist->data);
   free(slist);
 }
@@ -53,18 +53,18 @@ khc_slist* khc_slist_append_using_cb_alloc(
 }
 
 void khc_slist_free_all(khc_slist* slist) {
-  khc_slist_free_all_using_free_cb(slist, khc_slist_free_cb, NULL);
+  khc_slist_free_all_using_cb_free(slist, khc_slist_cb_free, NULL);
 }
 
-void khc_slist_free_all_using_free_cb(
+void khc_slist_free_all_using_cb_free(
   khc_slist* slist,
-  KHC_SLIST_FREE_CB free_cb,
-  void* free_cb_data) {
+  KHC_SLIST_FREE_CB cb_free,
+  void* cb_free_data) {
   khc_slist *curr;
   curr = slist;
   while (curr != NULL) {
     khc_slist *next = curr->next;
-    free_cb(curr, free_cb_data);
+    cb_free(curr, cb_free_data);
     curr = next;
   }
 }

--- a/khc/src/khc_slist.c
+++ b/khc/src/khc_slist.c
@@ -32,7 +32,7 @@ khc_slist* khc_slist_append_using_cb_alloc(
   khc_slist* slist,
   const char* string,
   size_t length,
-  KHC_SLIST_ALLOC_CB cb_alloc,
+  CB_KHC_SLIST_ALLOC cb_alloc,
   void* cb_alloc_data) {
   khc_slist* next;
   next = cb_alloc(string, length, cb_alloc_data);

--- a/khc/src/khc_slist.c
+++ b/khc/src/khc_slist.c
@@ -32,7 +32,7 @@ khc_slist* khc_slist_append_using_cb_alloc(
   khc_slist* slist,
   const char* string,
   size_t length,
-  CB_KHC_SLIST_ALLOC cb_alloc,
+  KHC_CB_SLIST_ALLOC cb_alloc,
   void* cb_alloc_data) {
   khc_slist* next;
   next = cb_alloc(string, length, cb_alloc_data);
@@ -58,7 +58,7 @@ void khc_slist_free_all(khc_slist* slist) {
 
 void khc_slist_free_all_using_cb_free(
   khc_slist* slist,
-  KHC_SLIST_FREE_CB cb_free,
+  KHC_CB_SLIST_FREE cb_free,
   void* cb_free_data) {
   khc_slist *curr;
   curr = slist;

--- a/khc/src/khc_slist.c
+++ b/khc/src/khc_slist.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include "khc.h"
 
-khc_slist* khc_slist_alloc_cb(const char* str, size_t str_len, void* data) {
+khc_slist* khc_slist_cb_alloc(const char* str, size_t str_len, void* data) {
   char* copy = malloc(str_len+1);
   if (copy == NULL) {
     return NULL;
@@ -25,17 +25,17 @@ void khc_slist_free_cb(khc_slist* slist, void* data) {
 }
 
 khc_slist* khc_slist_append(khc_slist* slist, const char* string, size_t length) {
-  return khc_slist_append_using_alloc_cb(slist, string, length, khc_slist_alloc_cb, NULL);
+  return khc_slist_append_using_cb_alloc(slist, string, length, khc_slist_cb_alloc, NULL);
 }
 
-khc_slist* khc_slist_append_using_alloc_cb(
+khc_slist* khc_slist_append_using_cb_alloc(
   khc_slist* slist,
   const char* string,
   size_t length,
-  KHC_SLIST_ALLOC_CB alloc_cb,
-  void* alloc_cb_data) {
+  KHC_SLIST_ALLOC_CB cb_alloc,
+  void* cb_alloc_data) {
   khc_slist* next;
-  next = alloc_cb(string, length, alloc_cb_data);
+  next = cb_alloc(string, length, cb_alloc_data);
   if (next == NULL) {
     return NULL;
   }

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -57,9 +57,9 @@ void kii_init(kii_t* kii)
     khc_set_cb_header(&kii->_khc, _cb_write_header, kii);
     kii->_etag[0] = '\0';
     kii->_slist_cb_alloc = khc_slist_cb_alloc;
-    kii->_slist_free_cb = khc_slist_free_cb;
+    kii->_slist_cb_free = khc_slist_cb_free;
     kii->_slist_cb_alloc_data = NULL;
-    kii->_slist_free_cb_data = NULL;
+    kii->_slist_cb_free_data = NULL;
     kii->_sdk_info = KII_SDK_INFO;
     kii->task_create_cb = NULL;
     kii->_task_create_data = NULL;
@@ -204,22 +204,22 @@ void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource) {
 void kii_set_cb_json_parser_resource(
     kii_t* kii,
     JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE free_cb)
+    JKII_CB_RESOURCE_FREE cb_free)
 {
     kii->_json_cb_alloc = cb_alloc;
-    kii->_json_free_cb = free_cb;
+    kii->_json_cb_free = cb_free;
 }
 
 void kii_set_slist_resource_cb(
     kii_t* kii,
     KHC_SLIST_ALLOC_CB cb_alloc,
-    KHC_SLIST_FREE_CB free_cb,
+    KHC_SLIST_FREE_CB cb_free,
     void* cb_alloc_data,
-    void* free_cb_data) {
+    void* cb_free_data) {
     kii->_slist_cb_alloc = cb_alloc;
-    kii->_slist_free_cb = free_cb;
+    kii->_slist_cb_free = cb_free;
     kii->_slist_cb_alloc_data = cb_alloc_data;
-    kii->_slist_free_cb_data = free_cb_data;
+    kii->_slist_cb_free_data = cb_free_data;
 }
 
 const char* kii_get_etag(kii_t* kii) {
@@ -264,7 +264,7 @@ void _reset_buff(kii_t* kii) {
 }
 
 void _req_headers_free_all(kii_t* kii) {
-    khc_slist_free_all_using_free_cb(kii->_req_headers, kii->_slist_free_cb, kii->_slist_free_cb_data);
+    khc_slist_free_all_using_cb_free(kii->_req_headers, kii->_slist_cb_free, kii->_slist_cb_free_data);
     kii->_req_headers = NULL;
 }
 

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -192,7 +192,7 @@ void kii_set_task_exit_cb(kii_t* kii, KII_TASK_EXIT cb, void* userdata) {
     kii->_task_exit_data = userdata;
 }
 
-void kii_set_delay_ms_cb(kii_t* kii, KII_DELAY_MS cb, void* userdata) {
+void kii_set_delay_ms_cb(kii_t* kii, KII_CB_DELAY_MS cb, void* userdata) {
     kii->delay_ms_cb = cb;
     kii->_delay_ms_data = userdata;
 }

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -187,12 +187,12 @@ void kii_set_cb_task_continue(kii_t* kii, KII_CB_TASK_CONTINUE cb, void* userdat
     kii->_task_continue_data = userdata;
 }
 
-void kii_set_task_exit_cb(kii_t* kii, KII_CB_TASK_EXIT cb, void* userdata) {
+void kii_set_cb_task_exit(kii_t* kii, KII_CB_TASK_EXIT cb, void* userdata) {
     kii->_task_exit_cb = cb;
     kii->_task_exit_data = userdata;
 }
 
-void kii_set_delay_ms_cb(kii_t* kii, KII_CB_DELAY_MS cb, void* userdata) {
+void kii_set_cb_delay_ms(kii_t* kii, KII_CB_DELAY_MS cb, void* userdata) {
     kii->delay_ms_cb = cb;
     kii->_delay_ms_data = userdata;
 }

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -210,7 +210,7 @@ void kii_set_cb_json_parser_resource(
     kii->_json_cb_free = cb_free;
 }
 
-void kii_set_slist_resource_cb(
+void kii_set_cb_slist_resource(
     kii_t* kii,
     KHC_CB_SLIST_ALLOC cb_alloc,
     KHC_CB_SLIST_FREE cb_free,

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -182,7 +182,7 @@ void kii_set_cb_task_create(kii_t* kii, KII_CB_TASK_CREATE cb, void* userdata) {
     kii->_task_create_data = userdata;
 }
 
-void kii_set_task_continue_cb(kii_t* kii, KII_CB_TASK_CONTINUE cb, void* userdata) {
+void kii_set_cb_task_continue(kii_t* kii, KII_CB_TASK_CONTINUE cb, void* userdata) {
     kii->_task_continue_cb = cb;
     kii->_task_continue_data = userdata;
 }

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -56,9 +56,9 @@ void kii_init(kii_t* kii)
     khc_set_cb_write(&kii->_khc, _cb_write_buff, kii);
     khc_set_cb_header(&kii->_khc, _cb_write_header, kii);
     kii->_etag[0] = '\0';
-    kii->_slist_alloc_cb = khc_slist_alloc_cb;
+    kii->_slist_cb_alloc = khc_slist_cb_alloc;
     kii->_slist_free_cb = khc_slist_free_cb;
-    kii->_slist_alloc_cb_data = NULL;
+    kii->_slist_cb_alloc_data = NULL;
     kii->_slist_free_cb_data = NULL;
     kii->_sdk_info = KII_SDK_INFO;
     kii->task_create_cb = NULL;
@@ -203,22 +203,22 @@ void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource) {
 
 void kii_set_cb_json_parser_resource(
     kii_t* kii,
-    JKII_CB_RESOURCE_ALLOC alloc_cb,
+    JKII_CB_RESOURCE_ALLOC cb_alloc,
     JKII_CB_RESOURCE_FREE free_cb)
 {
-    kii->_json_alloc_cb = alloc_cb;
+    kii->_json_cb_alloc = cb_alloc;
     kii->_json_free_cb = free_cb;
 }
 
 void kii_set_slist_resource_cb(
     kii_t* kii,
-    KHC_SLIST_ALLOC_CB alloc_cb,
+    KHC_SLIST_ALLOC_CB cb_alloc,
     KHC_SLIST_FREE_CB free_cb,
-    void* alloc_cb_data,
+    void* cb_alloc_data,
     void* free_cb_data) {
-    kii->_slist_alloc_cb = alloc_cb;
+    kii->_slist_cb_alloc = cb_alloc;
     kii->_slist_free_cb = free_cb;
-    kii->_slist_alloc_cb_data = alloc_cb_data;
+    kii->_slist_cb_alloc_data = cb_alloc_data;
     kii->_slist_free_cb_data = free_cb_data;
 }
 

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -128,19 +128,19 @@ void kii_set_resp_header_buff(kii_t* kii, char* buff, size_t buff_size) {
     khc_set_resp_header_buff(&kii->_khc, buff, buff_size);
 }
 
-void kii_set_http_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata) {
+void kii_set_cb_http_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata) {
     khc_set_cb_sock_connect(&kii->_khc, cb, userdata);
 }
 
-void kii_set_http_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata) {
+void kii_set_cb_http_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata) {
     khc_set_cb_sock_send(&kii->_khc, cb, userdata);
 }
 
-void kii_set_http_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata) {
+void kii_set_cb_http_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata) {
     khc_set_cb_sock_recv(&kii->_khc, cb, userdata);
 }
 
-void kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata) {
+void kii_set_cb_http_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata) {
     khc_set_cb_sock_close(&kii->_khc, cb, userdata);
 }
 
@@ -149,22 +149,22 @@ void kii_set_mqtt_buff(kii_t* kii, char* buff, size_t buff_size) {
     kii->mqtt_buffer_size = buff_size;
 }
 
-void kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata) {
+void kii_set_cb_mqtt_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata) {
     kii->mqtt_sock_connect_cb = cb;
     kii->mqtt_sock_connect_ctx = userdata;
 }
 
-void kii_set_mqtt_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata) {
+void kii_set_cb_mqtt_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata) {
     kii->mqtt_sock_send_cb = cb;
     kii->mqtt_sock_send_ctx = userdata;
 }
 
-void kii_set_mqtt_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata) {
+void kii_set_cb_mqtt_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata) {
     kii->mqtt_sock_recv_cb = cb;
     kii->mqtt_sock_recv_ctx = userdata;
 }
 
-void kii_set_mqtt_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata) {
+void kii_set_cb_mqtt_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata) {
     kii->mqtt_sock_close_cb = cb;
     kii->mqtt_sock_close_ctx = userdata;
 }

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -203,7 +203,7 @@ void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource) {
 
 void kii_set_json_parser_resource_cb(
     kii_t* kii,
-    JKII_RESOURCE_ALLOC_CB alloc_cb,
+    JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb)
 {
     kii->_json_alloc_cb = alloc_cb;

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -212,8 +212,8 @@ void kii_set_cb_json_parser_resource(
 
 void kii_set_slist_resource_cb(
     kii_t* kii,
-    CB_KHC_SLIST_ALLOC cb_alloc,
-    KHC_SLIST_FREE_CB cb_free,
+    KHC_CB_SLIST_ALLOC cb_alloc,
+    KHC_CB_SLIST_FREE cb_free,
     void* cb_alloc_data,
     void* cb_free_data) {
     kii->_slist_cb_alloc = cb_alloc;

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -182,7 +182,7 @@ void kii_set_task_create_cb(kii_t* kii, KII_CB_TASK_CREATE cb, void* userdata) {
     kii->_task_create_data = userdata;
 }
 
-void kii_set_task_continue_cb(kii_t* kii, KII_TASK_CONTINUE cb, void* userdata) {
+void kii_set_task_continue_cb(kii_t* kii, KII_CB_TASK_CONTINUE cb, void* userdata) {
     kii->_task_continue_cb = cb;
     kii->_task_continue_data = userdata;
 }

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -204,7 +204,7 @@ void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource) {
 void kii_set_json_parser_resource_cb(
     kii_t* kii,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
-    JKII_RESOURCE_FREE_CB free_cb)
+    JKII_CB_RESOURCE_FREE free_cb)
 {
     kii->_json_alloc_cb = alloc_cb;
     kii->_json_free_cb = free_cb;

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -212,7 +212,7 @@ void kii_set_cb_json_parser_resource(
 
 void kii_set_slist_resource_cb(
     kii_t* kii,
-    KHC_SLIST_ALLOC_CB cb_alloc,
+    CB_KHC_SLIST_ALLOC cb_alloc,
     KHC_SLIST_FREE_CB cb_free,
     void* cb_alloc_data,
     void* cb_free_data) {

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -201,7 +201,7 @@ void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource) {
     kii->_json_resource = resource;
 }
 
-void kii_set_json_parser_resource_cb(
+void kii_set_cb_json_parser_resource(
     kii_t* kii,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_CB_RESOURCE_FREE free_cb)

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -187,7 +187,7 @@ void kii_set_task_continue_cb(kii_t* kii, KII_TASK_CONTINUE cb, void* userdata) 
     kii->_task_continue_data = userdata;
 }
 
-void kii_set_task_exit_cb(kii_t* kii, KII_TASK_EXIT cb, void* userdata) {
+void kii_set_task_exit_cb(kii_t* kii, KII_CB_TASK_EXIT cb, void* userdata) {
     kii->_task_exit_cb = cb;
     kii->_task_exit_data = userdata;
 }

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -177,7 +177,7 @@ void kii_set_mqtt_to_sock_send(kii_t* kii, unsigned int to_sock_send_sec) {
     kii->_mqtt_to_send_sec = to_sock_send_sec;
 }
 
-void kii_set_task_create_cb(kii_t* kii, KII_CB_TASK_CREATE cb, void* userdata) {
+void kii_set_cb_task_create(kii_t* kii, KII_CB_TASK_CREATE cb, void* userdata) {
     kii->task_create_cb = cb;
     kii->_task_create_data = userdata;
 }

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -177,7 +177,7 @@ void kii_set_mqtt_to_sock_send(kii_t* kii, unsigned int to_sock_send_sec) {
     kii->_mqtt_to_send_sec = to_sock_send_sec;
 }
 
-void kii_set_task_create_cb(kii_t* kii, KII_TASK_CREATE cb, void* userdata) {
+void kii_set_task_create_cb(kii_t* kii, KII_CB_TASK_CREATE cb, void* userdata) {
     kii->task_create_cb = cb;
     kii->_task_create_data = userdata;
 }

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -676,7 +676,7 @@ void kii_set_cb_task_create(kii_t* kii, KII_CB_TASK_CREATE create_cb, void* user
  * task_info argument type of the continue_cb function (defined as void* in KII_CB_TASK_EXIT) is kii_mqtt_task_info*.
  * \param userdata [in] Context data pointer passed as second argument when continue_cb is called.
  */
-void kii_set_task_continue_cb(kii_t* kii, KII_CB_TASK_CONTINUE continue_cb, void* userdata);
+void kii_set_cb_task_continue(kii_t* kii, KII_CB_TASK_CONTINUE continue_cb, void* userdata);
 
 /**
  * \brief Callback called right before exit of MQTT task.
@@ -690,7 +690,7 @@ void kii_set_task_continue_cb(kii_t* kii, KII_CB_TASK_CONTINUE continue_cb, void
  * - kii_set_cb_mqtt_sock_connect()
  * - kii_set_cb_mqtt_sock_recv()
  * - kii_set_cb_mqtt_sock_close()
- * - kii_set_task_continue_cb()
+ * - kii_set_cb_task_continue()
  * - kii_set_task_exit_cb()
 
  * In addition, you may need to call task/ thread termination API.

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -123,7 +123,7 @@ typedef struct kii_t {
     KII_TASK_CONTINUE _task_continue_cb;
     void* _task_continue_data;
 
-    KII_TASK_EXIT _task_exit_cb;
+    KII_CB_TASK_EXIT _task_exit_cb;
     void* _task_exit_data;
 
     KII_CB_DELAY_MS delay_ms_cb;
@@ -666,14 +666,14 @@ void kii_set_task_create_cb(kii_t* kii, KII_CB_TASK_CREATE create_cb, void* user
  * In case checking cancellation flag in continue_cb, the flag might be set by other task/ thread.
  * Implementation must ensure consistency of the flag by using Mutex, etc.
 
- * If un-recoverble error occurs, task exits the infinite loop and immediately calls KII_TASK_EXIT callback if set.
+ * If un-recoverble error occurs, task exits the infinite loop and immediately calls KII_CB_TASK_EXIT callback if set.
  * In this case KII_TASK_CONTINUE callback is not called.
 
  * \param kii [out] kii instance
  * \param continue_cb [in] Callback determines whether to continue or discontinue task.
  * If continue_cb returns KII_TRUE, task continues. Otherwise the task exits the infinite loop
- * and calls KII_TASK_EXIT callback if set.
- * task_info argument type of the continue_cb function (defined as void* in KII_TASK_EXIT) is kii_mqtt_task_info*.
+ * and calls KII_CB_TASK_EXIT callback if set.
+ * task_info argument type of the continue_cb function (defined as void* in KII_CB_TASK_EXIT) is kii_mqtt_task_info*.
  * \param userdata [in] Context data pointer passed as second argument when continue_cb is called.
  */
 void kii_set_task_continue_cb(kii_t* kii, KII_TASK_CONTINUE continue_cb, void* userdata);
@@ -702,10 +702,10 @@ void kii_set_task_continue_cb(kii_t* kii, KII_TASK_CONTINUE continue_cb, void* u
 
  * \param kii instance
  * \param exit_cb Called right before the exit.
- * task_info argument type of exit_cb (defined as void* in KII_TASK_EXIT) is kii_mqtt_task_info*.
+ * task_info argument type of exit_cb (defined as void* in KII_CB_TASK_EXIT) is kii_mqtt_task_info*.
  * \param userdata [in] Context data pointer passed as second argument when exit_cb is called.
  */
-void kii_set_task_exit_cb(kii_t* kii, KII_TASK_EXIT exit_cb, void* userdata);
+void kii_set_task_exit_cb(kii_t* kii, KII_CB_TASK_EXIT exit_cb, void* userdata);
 void kii_set_delay_ms_cb(kii_t* kii, KII_CB_DELAY_MS delay_cb, void* userdata);
 
 /** Set JSON paraser resource

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -733,7 +733,7 @@ void kii_set_cb_json_parser_resource(kii_t* kii,
  * If this method is not called, default allocators implemented with malloc/free is used to
  * allocate linked list used to construct HTTP request headers.
  */
-void kii_set_slist_resource_cb(
+void kii_set_cb_slist_resource(
     kii_t* kii,
     KHC_CB_SLIST_ALLOC cb_alloc,
     KHC_CB_SLIST_FREE cb_free,

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -151,7 +151,7 @@ typedef struct kii_t {
 
     jkii_resource_t* _json_resource;
 
-    JKII_RESOURCE_ALLOC_CB _json_alloc_cb;
+    JKII_CB_RESOURCE_ALLOC _json_alloc_cb;
     JKII_RESOURCE_FREE_CB _json_free_cb;
 
     KHC_SLIST_ALLOC_CB _slist_alloc_cb;
@@ -712,7 +712,7 @@ void kii_set_cb_delay_ms(kii_t* kii, KII_CB_DELAY_MS delay_cb, void* userdata);
  * @param [inout] kii SDK instance.
  * @param [in] resource to be used parse JSON. 256 tokens_num might be enough for almost all usecases.
  * If you need to parse large object or allocate exact size of memory used,
- * see kii_set_json_parser_resource_cb(kii_t, JKII_RESOURCE_ALLOC_CB, JKII_RESOURCE_FREE_CB)
+ * see kii_set_json_parser_resource_cb(kii_t, JKII_CB_RESOURCE_ALLOC, JKII_RESOURCE_FREE_CB)
  */
 void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
 
@@ -724,7 +724,7 @@ void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
  * @param [in] free_cb free callback should free memories allocated in alloc_cb.
  */
 void kii_set_json_parser_resource_cb(kii_t* kii,
-    JKII_RESOURCE_ALLOC_CB alloc_cb,
+    JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb);
 
 /**

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -653,7 +653,7 @@ void kii_set_cb_mqtt_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata
 void kii_set_mqtt_to_sock_recv(kii_t* kii, unsigned int to_sock_recv_sec);
 void kii_set_mqtt_to_sock_send(kii_t* kii, unsigned int to_sock_send_sec);
 
-void kii_set_task_create_cb(kii_t* kii, KII_CB_TASK_CREATE create_cb, void* userdata);
+void kii_set_cb_task_create(kii_t* kii, KII_CB_TASK_CREATE create_cb, void* userdata);
 
 /**
  * \brief set callback determines whether to continue or discontinue task.

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -117,7 +117,7 @@ typedef struct kii_t {
     unsigned int _mqtt_to_recv_sec;
     unsigned int _mqtt_to_send_sec;
 
-    KII_TASK_CREATE task_create_cb;
+    KII_CB_TASK_CREATE task_create_cb;
     void* _task_create_data;
 
     KII_TASK_CONTINUE _task_continue_cb;
@@ -653,7 +653,7 @@ void kii_set_mqtt_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata
 void kii_set_mqtt_to_sock_recv(kii_t* kii, unsigned int to_sock_recv_sec);
 void kii_set_mqtt_to_sock_send(kii_t* kii, unsigned int to_sock_send_sec);
 
-void kii_set_task_create_cb(kii_t* kii, KII_TASK_CREATE create_cb, void* userdata);
+void kii_set_task_create_cb(kii_t* kii, KII_CB_TASK_CREATE create_cb, void* userdata);
 
 /**
  * \brief set callback determines whether to continue or discontinue task.

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -621,10 +621,10 @@ void kii_set_stream_buff(kii_t* kii, char* buff, size_t buff_size);
  */
 void kii_set_resp_header_buff(kii_t* kii, char* buff, size_t buff_size);
 
-void kii_set_http_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);
-void kii_set_http_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);
-void kii_set_http_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata);
-void kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata);
+void kii_set_cb_http_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);
+void kii_set_cb_http_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);
+void kii_set_cb_http_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata);
+void kii_set_cb_http_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata);
 
 /**
  * \brief Set buffer used to parse MQTT message.
@@ -645,10 +645,10 @@ void kii_set_http_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata
  */
 void kii_set_mqtt_buff(kii_t* kii, char* buff, size_t buff_size);
 
-void kii_set_mqtt_cb_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);
-void kii_set_mqtt_cb_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);
-void kii_set_mqtt_cb_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata);
-void kii_set_mqtt_cb_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata);
+void kii_set_cb_mqtt_sock_connect(kii_t* kii, KHC_CB_SOCK_CONNECT cb, void* userdata);
+void kii_set_cb_mqtt_sock_send(kii_t* kii, KHC_CB_SOCK_SEND cb, void* userdata);
+void kii_set_cb_mqtt_sock_recv(kii_t* kii, KHC_CB_SOCK_RECV cb, void* userdata);
+void kii_set_cb_mqtt_sock_close(kii_t* kii, KHC_CB_SOCK_CLOSE cb, void* userdata);
 
 void kii_set_mqtt_to_sock_recv(kii_t* kii, unsigned int to_sock_recv_sec);
 void kii_set_mqtt_to_sock_send(kii_t* kii, unsigned int to_sock_send_sec);
@@ -686,10 +686,10 @@ void kii_set_task_continue_cb(kii_t* kii, KII_CB_TASK_CONTINUE continue_cb, void
  * In exit_cb, you'll need to free memory used for MQTT buffer set by kii_set_mqtt_buff(),
  * Memory used for the userdata passed to following callbacks in case not yet freed.
 
- * - kii_set_mqtt_cb_sock_send()
- * - kii_set_mqtt_cb_sock_connect()
- * - kii_set_mqtt_cb_sock_recv()
- * - kii_set_mqtt_cb_sock_close()
+ * - kii_set_cb_mqtt_sock_send()
+ * - kii_set_cb_mqtt_sock_connect()
+ * - kii_set_cb_mqtt_sock_recv()
+ * - kii_set_cb_mqtt_sock_close()
  * - kii_set_task_continue_cb()
  * - kii_set_task_exit_cb()
 

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -154,8 +154,8 @@ typedef struct kii_t {
     JKII_CB_RESOURCE_ALLOC _json_cb_alloc;
     JKII_CB_RESOURCE_FREE _json_cb_free;
 
-    CB_KHC_SLIST_ALLOC _slist_cb_alloc;
-    KHC_SLIST_FREE_CB _slist_cb_free;
+    KHC_CB_SLIST_ALLOC _slist_cb_alloc;
+    KHC_CB_SLIST_FREE _slist_cb_free;
     void* _slist_cb_alloc_data;
     void* _slist_cb_free_data;
 } kii_t;
@@ -735,8 +735,8 @@ void kii_set_cb_json_parser_resource(kii_t* kii,
  */
 void kii_set_slist_resource_cb(
     kii_t* kii,
-    CB_KHC_SLIST_ALLOC cb_alloc,
-    KHC_SLIST_FREE_CB cb_free,
+    KHC_CB_SLIST_ALLOC cb_alloc,
+    KHC_CB_SLIST_FREE cb_free,
     void* cb_alloc_data,
     void* cb_free_data);
 

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -151,12 +151,12 @@ typedef struct kii_t {
 
     jkii_resource_t* _json_resource;
 
-    JKII_CB_RESOURCE_ALLOC _json_alloc_cb;
+    JKII_CB_RESOURCE_ALLOC _json_cb_alloc;
     JKII_CB_RESOURCE_FREE _json_free_cb;
 
-    KHC_SLIST_ALLOC_CB _slist_alloc_cb;
+    KHC_SLIST_ALLOC_CB _slist_cb_alloc;
     KHC_SLIST_FREE_CB _slist_free_cb;
-    void* _slist_alloc_cb_data;
+    void* _slist_cb_alloc_data;
     void* _slist_free_cb_data;
 } kii_t;
 
@@ -720,11 +720,11 @@ void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
  *  To use Allocator instead of fixed size memory given by kii_set_json_parser_resource(kii_t, jkii_resource_t),
  *  call kii_set_json_parser_resource(kii_t, jkii_resource_t) with NULL resource argument.
  * @param [inout] kii SDK instance.
- * @param [in] alloc_cb allocator callback.
- * @param [in] free_cb free callback should free memories allocated in alloc_cb.
+ * @param [in] cb_alloc allocator callback.
+ * @param [in] free_cb free callback should free memories allocated in cb_alloc.
  */
 void kii_set_cb_json_parser_resource(kii_t* kii,
-    JKII_CB_RESOURCE_ALLOC alloc_cb,
+    JKII_CB_RESOURCE_ALLOC cb_alloc,
     JKII_CB_RESOURCE_FREE free_cb);
 
 /**
@@ -735,9 +735,9 @@ void kii_set_cb_json_parser_resource(kii_t* kii,
  */
 void kii_set_slist_resource_cb(
     kii_t* kii,
-    KHC_SLIST_ALLOC_CB alloc_cb,
+    KHC_SLIST_ALLOC_CB cb_alloc,
     KHC_SLIST_FREE_CB free_cb,
-    void* alloc_cb_data,
+    void* cb_alloc_data,
     void* free_cb_data);
 
 const char* kii_get_etag(kii_t* kii);

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -120,7 +120,7 @@ typedef struct kii_t {
     KII_CB_TASK_CREATE task_create_cb;
     void* _task_create_data;
 
-    KII_TASK_CONTINUE _task_continue_cb;
+    KII_CB_TASK_CONTINUE _task_continue_cb;
     void* _task_continue_data;
 
     KII_CB_TASK_EXIT _task_exit_cb;
@@ -667,7 +667,7 @@ void kii_set_task_create_cb(kii_t* kii, KII_CB_TASK_CREATE create_cb, void* user
  * Implementation must ensure consistency of the flag by using Mutex, etc.
 
  * If un-recoverble error occurs, task exits the infinite loop and immediately calls KII_CB_TASK_EXIT callback if set.
- * In this case KII_TASK_CONTINUE callback is not called.
+ * In this case KII_CB_TASK_CONTINUE callback is not called.
 
  * \param kii [out] kii instance
  * \param continue_cb [in] Callback determines whether to continue or discontinue task.
@@ -676,12 +676,12 @@ void kii_set_task_create_cb(kii_t* kii, KII_CB_TASK_CREATE create_cb, void* user
  * task_info argument type of the continue_cb function (defined as void* in KII_CB_TASK_EXIT) is kii_mqtt_task_info*.
  * \param userdata [in] Context data pointer passed as second argument when continue_cb is called.
  */
-void kii_set_task_continue_cb(kii_t* kii, KII_TASK_CONTINUE continue_cb, void* userdata);
+void kii_set_task_continue_cb(kii_t* kii, KII_CB_TASK_CONTINUE continue_cb, void* userdata);
 
 /**
  * \brief Callback called right before exit of MQTT task.
 
- * Task exits when the task is discontinued by KII_TASK_CONTINUE callback or
+ * Task exits when the task is discontinued by KII_CB_TASK_CONTINUE callback or
  * un-recoverble error occurs.
  * In exit_cb, you'll need to free memory used for MQTT buffer set by kii_set_mqtt_buff(),
  * Memory used for the userdata passed to following callbacks in case not yet freed.

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -712,7 +712,7 @@ void kii_set_cb_delay_ms(kii_t* kii, KII_CB_DELAY_MS delay_cb, void* userdata);
  * @param [inout] kii SDK instance.
  * @param [in] resource to be used parse JSON. 256 tokens_num might be enough for almost all usecases.
  * If you need to parse large object or allocate exact size of memory used,
- * see kii_set_json_parser_resource_cb(kii_t, JKII_CB_RESOURCE_ALLOC, JKII_CB_RESOURCE_FREE)
+ * see kii_set_cb_json_parser_resource(kii_t, JKII_CB_RESOURCE_ALLOC, JKII_CB_RESOURCE_FREE)
  */
 void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
 
@@ -723,7 +723,7 @@ void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
  * @param [in] alloc_cb allocator callback.
  * @param [in] free_cb free callback should free memories allocated in alloc_cb.
  */
-void kii_set_json_parser_resource_cb(kii_t* kii,
+void kii_set_cb_json_parser_resource(kii_t* kii,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_CB_RESOURCE_FREE free_cb);
 

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -691,7 +691,7 @@ void kii_set_cb_task_continue(kii_t* kii, KII_CB_TASK_CONTINUE continue_cb, void
  * - kii_set_cb_mqtt_sock_recv()
  * - kii_set_cb_mqtt_sock_close()
  * - kii_set_cb_task_continue()
- * - kii_set_task_exit_cb()
+ * - kii_set_cb_task_exit()
 
  * In addition, you may need to call task/ thread termination API.
  * It depends on the task/ threading framework you used to create task/ thread.
@@ -705,8 +705,8 @@ void kii_set_cb_task_continue(kii_t* kii, KII_CB_TASK_CONTINUE continue_cb, void
  * task_info argument type of exit_cb (defined as void* in KII_CB_TASK_EXIT) is kii_mqtt_task_info*.
  * \param userdata [in] Context data pointer passed as second argument when exit_cb is called.
  */
-void kii_set_task_exit_cb(kii_t* kii, KII_CB_TASK_EXIT exit_cb, void* userdata);
-void kii_set_delay_ms_cb(kii_t* kii, KII_CB_DELAY_MS delay_cb, void* userdata);
+void kii_set_cb_task_exit(kii_t* kii, KII_CB_TASK_EXIT exit_cb, void* userdata);
+void kii_set_cb_delay_ms(kii_t* kii, KII_CB_DELAY_MS delay_cb, void* userdata);
 
 /** Set JSON paraser resource
  * @param [inout] kii SDK instance.

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -152,7 +152,7 @@ typedef struct kii_t {
     jkii_resource_t* _json_resource;
 
     JKII_CB_RESOURCE_ALLOC _json_alloc_cb;
-    JKII_RESOURCE_FREE_CB _json_free_cb;
+    JKII_CB_RESOURCE_FREE _json_free_cb;
 
     KHC_SLIST_ALLOC_CB _slist_alloc_cb;
     KHC_SLIST_FREE_CB _slist_free_cb;
@@ -712,7 +712,7 @@ void kii_set_cb_delay_ms(kii_t* kii, KII_CB_DELAY_MS delay_cb, void* userdata);
  * @param [inout] kii SDK instance.
  * @param [in] resource to be used parse JSON. 256 tokens_num might be enough for almost all usecases.
  * If you need to parse large object or allocate exact size of memory used,
- * see kii_set_json_parser_resource_cb(kii_t, JKII_CB_RESOURCE_ALLOC, JKII_RESOURCE_FREE_CB)
+ * see kii_set_json_parser_resource_cb(kii_t, JKII_CB_RESOURCE_ALLOC, JKII_CB_RESOURCE_FREE)
  */
 void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
 
@@ -725,7 +725,7 @@ void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
  */
 void kii_set_json_parser_resource_cb(kii_t* kii,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
-    JKII_RESOURCE_FREE_CB free_cb);
+    JKII_CB_RESOURCE_FREE free_cb);
 
 /**
  * \brief Set khc_slist (linked list) resource allocators.

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -154,7 +154,7 @@ typedef struct kii_t {
     JKII_CB_RESOURCE_ALLOC _json_cb_alloc;
     JKII_CB_RESOURCE_FREE _json_cb_free;
 
-    KHC_SLIST_ALLOC_CB _slist_cb_alloc;
+    CB_KHC_SLIST_ALLOC _slist_cb_alloc;
     KHC_SLIST_FREE_CB _slist_cb_free;
     void* _slist_cb_alloc_data;
     void* _slist_cb_free_data;
@@ -735,7 +735,7 @@ void kii_set_cb_json_parser_resource(kii_t* kii,
  */
 void kii_set_slist_resource_cb(
     kii_t* kii,
-    KHC_SLIST_ALLOC_CB cb_alloc,
+    CB_KHC_SLIST_ALLOC cb_alloc,
     KHC_SLIST_FREE_CB cb_free,
     void* cb_alloc_data,
     void* cb_free_data);

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -152,12 +152,12 @@ typedef struct kii_t {
     jkii_resource_t* _json_resource;
 
     JKII_CB_RESOURCE_ALLOC _json_cb_alloc;
-    JKII_CB_RESOURCE_FREE _json_free_cb;
+    JKII_CB_RESOURCE_FREE _json_cb_free;
 
     KHC_SLIST_ALLOC_CB _slist_cb_alloc;
-    KHC_SLIST_FREE_CB _slist_free_cb;
+    KHC_SLIST_FREE_CB _slist_cb_free;
     void* _slist_cb_alloc_data;
-    void* _slist_free_cb_data;
+    void* _slist_cb_free_data;
 } kii_t;
 
 /** Initializes Kii SDK
@@ -721,11 +721,11 @@ void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
  *  call kii_set_json_parser_resource(kii_t, jkii_resource_t) with NULL resource argument.
  * @param [inout] kii SDK instance.
  * @param [in] cb_alloc allocator callback.
- * @param [in] free_cb free callback should free memories allocated in cb_alloc.
+ * @param [in] cb_free free callback should free memories allocated in cb_alloc.
  */
 void kii_set_cb_json_parser_resource(kii_t* kii,
     JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE free_cb);
+    JKII_CB_RESOURCE_FREE cb_free);
 
 /**
  * \brief Set khc_slist (linked list) resource allocators.
@@ -736,9 +736,9 @@ void kii_set_cb_json_parser_resource(kii_t* kii,
 void kii_set_slist_resource_cb(
     kii_t* kii,
     KHC_SLIST_ALLOC_CB cb_alloc,
-    KHC_SLIST_FREE_CB free_cb,
+    KHC_SLIST_FREE_CB cb_free,
     void* cb_alloc_data,
-    void* free_cb_data);
+    void* cb_free_data);
 
 const char* kii_get_etag(kii_t* kii);
 

--- a/kii/kii.h
+++ b/kii/kii.h
@@ -126,7 +126,7 @@ typedef struct kii_t {
     KII_TASK_EXIT _task_exit_cb;
     void* _task_exit_data;
 
-    KII_DELAY_MS delay_ms_cb;
+    KII_CB_DELAY_MS delay_ms_cb;
     void* _delay_ms_data;
 
     KII_PUSH_RECEIVED_CB push_received_cb;
@@ -706,7 +706,7 @@ void kii_set_task_continue_cb(kii_t* kii, KII_TASK_CONTINUE continue_cb, void* u
  * \param userdata [in] Context data pointer passed as second argument when exit_cb is called.
  */
 void kii_set_task_exit_cb(kii_t* kii, KII_TASK_EXIT exit_cb, void* userdata);
-void kii_set_delay_ms_cb(kii_t* kii, KII_DELAY_MS delay_cb, void* userdata);
+void kii_set_delay_ms_cb(kii_t* kii, KII_CB_DELAY_MS delay_cb, void* userdata);
 
 /** Set JSON paraser resource
  * @param [inout] kii SDK instance.

--- a/kii/kii_api_call.c
+++ b/kii/kii_api_call.c
@@ -73,7 +73,7 @@ kii_code_t kii_api_call_append_header(kii_t* kii, const char* key, const char* v
         _req_headers_free_all(kii);
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);
+    khc_slist* list = khc_slist_append_using_cb_alloc(kii->_req_headers, buff, header_len, kii->_slist_cb_alloc, kii->_slist_cb_alloc_data);
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }

--- a/kii/kii_json_wrapper.c
+++ b/kii/kii_json_wrapper.c
@@ -12,7 +12,7 @@ jkii_parse_err_t _jkii_read_object(
     jkii_parse_err_t res = JKII_ERR_INVALID_INPUT;
     jkii_resource_t* resource = kii->_json_resource;
     if (resource == NULL) {
-        res = jkii_parse_with_allocator(json_string, json_string_size, fields, kii->_json_cb_alloc, kii->_json_free_cb);
+        res = jkii_parse_with_allocator(json_string, json_string_size, fields, kii->_json_cb_alloc, kii->_json_cb_free);
     } else {
         res = jkii_parse(json_string, json_string_size, fields, kii->_json_resource);
     }

--- a/kii/kii_json_wrapper.c
+++ b/kii/kii_json_wrapper.c
@@ -12,7 +12,7 @@ jkii_parse_err_t _jkii_read_object(
     jkii_parse_err_t res = JKII_ERR_INVALID_INPUT;
     jkii_resource_t* resource = kii->_json_resource;
     if (resource == NULL) {
-        res = jkii_parse_with_allocator(json_string, json_string_size, fields, kii->_json_alloc_cb, kii->_json_free_cb);
+        res = jkii_parse_with_allocator(json_string, json_string_size, fields, kii->_json_cb_alloc, kii->_json_free_cb);
     } else {
         res = jkii_parse(json_string, json_string_size, fields, kii->_json_resource);
     }

--- a/kii/kii_req_impl.c
+++ b/kii/kii_req_impl.c
@@ -156,7 +156,7 @@ kii_code_t _set_content_type(
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);
+    khc_slist* list = khc_slist_append_using_cb_alloc(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_cb_alloc, kii->_slist_cb_alloc_data);
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }
@@ -177,7 +177,7 @@ kii_code_t _set_object_content_type(
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);;
+    khc_slist* list = khc_slist_append_using_cb_alloc(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_cb_alloc, kii->_slist_cb_alloc_data);;
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }
@@ -198,7 +198,7 @@ kii_code_t _set_object_body_content_type(
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);;
+    khc_slist* list = khc_slist_append_using_cb_alloc(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_cb_alloc, kii->_slist_cb_alloc_data);;
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }
@@ -220,7 +220,7 @@ kii_code_t _set_content_length(
     if (header_len >= cl_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, cl_h, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);
+    khc_slist* list = khc_slist_append_using_cb_alloc(kii->_req_headers, cl_h, header_len, kii->_slist_cb_alloc, kii->_slist_cb_alloc_data);
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }
@@ -238,7 +238,7 @@ kii_code_t _set_app_id_header(kii_t* kii)
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);;
+    khc_slist* list = khc_slist_append_using_cb_alloc(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_cb_alloc, kii->_slist_cb_alloc_data);;
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }
@@ -256,7 +256,7 @@ kii_code_t _set_app_key_header(kii_t* kii)
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);;
+    khc_slist* list = khc_slist_append_using_cb_alloc(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_cb_alloc, kii->_slist_cb_alloc_data);;
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }
@@ -280,7 +280,7 @@ kii_code_t _set_auth_bearer_token(kii_t* kii, const char* token)
         if (header_len >= kii->_rw_buff_size) {
             return KII_ERR_TOO_LARGE_DATA;
         }
-        khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);;
+        khc_slist* list = khc_slist_append_using_cb_alloc(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_cb_alloc, kii->_slist_cb_alloc_data);;
         if (list == NULL) {
             return KII_ERR_ALLOCATION;
         }
@@ -306,7 +306,7 @@ kii_code_t _set_if_match(kii_t* kii, const char* etag)
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
-    khc_slist* list = khc_slist_append_using_alloc_cb(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_alloc_cb, kii->_slist_alloc_cb_data);;
+    khc_slist* list = khc_slist_append_using_cb_alloc(kii->_req_headers, kii->_rw_buff, header_len, kii->_slist_cb_alloc, kii->_slist_cb_alloc_data);;
     if (list == NULL) {
         return KII_ERR_ALLOCATION;
     }

--- a/kii/kii_task_callback.h
+++ b/kii/kii_task_callback.h
@@ -27,7 +27,7 @@ typedef kii_task_code_t
      void* userdata);
 
 typedef void
-(*KII_DELAY_MS)
+(*KII_CB_DELAY_MS)
     (unsigned int msec,
      void* userdata);
 

--- a/kii/kii_task_callback.h
+++ b/kii/kii_task_callback.h
@@ -32,7 +32,7 @@ typedef void
      void* userdata);
 
 typedef void
-(*KII_TASK_EXIT)
+(*KII_CB_TASK_EXIT)
     (void* task_info,
     void* userdata);
 

--- a/kii/kii_task_callback.h
+++ b/kii/kii_task_callback.h
@@ -37,7 +37,7 @@ typedef void
     void* userdata);
 
 typedef kii_bool_t
-(*KII_TASK_CONTINUE)
+(*KII_CB_TASK_CONTINUE)
     (void* task_info,
     void* userdata);
 

--- a/kii/kii_task_callback.h
+++ b/kii/kii_task_callback.h
@@ -20,7 +20,7 @@ typedef enum kii_bool_t
 typedef void* (*KII_TASK_ENTRY)(void* value);
 
 typedef kii_task_code_t
-(*KII_TASK_CREATE)
+(*KII_CB_TASK_CREATE)
     (const char* name,
      KII_TASK_ENTRY entry,
      void* entry_param,

--- a/tests/large_test/kii/large_test.h
+++ b/tests/large_test/kii/large_test.h
@@ -26,15 +26,15 @@ inline void init(
 
     kii_set_buff(kii, buffer, buffer_size);
 
-    kii_set_http_cb_sock_connect(kii, ebisu::ltest::ssl::cb_connect, http_ssl_ctx);
-    kii_set_http_cb_sock_send(kii, ebisu::ltest::ssl::cb_send, http_ssl_ctx);
-    kii_set_http_cb_sock_recv(kii, ebisu::ltest::ssl::cb_recv, http_ssl_ctx);
-    kii_set_http_cb_sock_close(kii, ebisu::ltest::ssl::cb_close, http_ssl_ctx);
+    kii_set_cb_http_sock_connect(kii, ebisu::ltest::ssl::cb_connect, http_ssl_ctx);
+    kii_set_cb_http_sock_send(kii, ebisu::ltest::ssl::cb_send, http_ssl_ctx);
+    kii_set_cb_http_sock_recv(kii, ebisu::ltest::ssl::cb_recv, http_ssl_ctx);
+    kii_set_cb_http_sock_close(kii, ebisu::ltest::ssl::cb_close, http_ssl_ctx);
 
-    kii_set_mqtt_cb_sock_connect(kii, ebisu::ltest::ssl::cb_connect, mqtt_ssl_ctx);
-    kii_set_mqtt_cb_sock_send(kii, ebisu::ltest::ssl::cb_send, mqtt_ssl_ctx);
-    kii_set_mqtt_cb_sock_recv(kii, ebisu::ltest::ssl::cb_recv, mqtt_ssl_ctx);
-    kii_set_mqtt_cb_sock_close(kii, ebisu::ltest::ssl::cb_close, mqtt_ssl_ctx);
+    kii_set_cb_mqtt_sock_connect(kii, ebisu::ltest::ssl::cb_connect, mqtt_ssl_ctx);
+    kii_set_cb_mqtt_sock_send(kii, ebisu::ltest::ssl::cb_send, mqtt_ssl_ctx);
+    kii_set_cb_mqtt_sock_recv(kii, ebisu::ltest::ssl::cb_recv, mqtt_ssl_ctx);
+    kii_set_cb_mqtt_sock_close(kii, ebisu::ltest::ssl::cb_close, mqtt_ssl_ctx);
     kii_set_json_parser_resource(kii, resource);
 
     kii->_author.author_id[0] = '\0';

--- a/tests/small_test/jkii/src/jkii_test.cpp
+++ b/tests/small_test/jkii/src/jkii_test.cpp
@@ -23,7 +23,7 @@ static jkii_resource_t* cb_alloc(size_t required_size)
     return res;
 }
 
-static void free_cb(jkii_resource_t* resource) {
+static void cb_free(jkii_resource_t* resource) {
     free(resource->tokens);
     free(resource);
 }
@@ -1511,7 +1511,7 @@ TEST_CASE("KiiJson, AllocatorTest")
         strlen(json_string),
         fields,
         cb_alloc,
-        free_cb);
+        cb_free);
 
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
@@ -1538,7 +1538,7 @@ TEST_CASE("KiiJson, FailedAllocationTest")
         strlen(json_string),
         fields,
         allocate_cb_fail,
-        free_cb);
+        cb_free);
 
     REQUIRE(JKII_ERR_ALLOCATION == res);
 }

--- a/tests/small_test/jkii/src/jkii_test.cpp
+++ b/tests/small_test/jkii/src/jkii_test.cpp
@@ -5,7 +5,7 @@
 #include <math.h>
 #include <limits.h>
 
-static jkii_resource_t* alloc_cb(size_t required_size)
+static jkii_resource_t* cb_alloc(size_t required_size)
 {
     jkii_resource_t* res =
         (jkii_resource_t*)malloc(sizeof(jkii_resource_t));
@@ -1510,7 +1510,7 @@ TEST_CASE("KiiJson, AllocatorTest")
         json_string,
         strlen(json_string),
         fields,
-        alloc_cb,
+        cb_alloc,
         free_cb);
 
     REQUIRE(JKII_ERR_OK == res);

--- a/tests/small_test/khc/slist_test.cpp
+++ b/tests/small_test/khc/slist_test.cpp
@@ -33,7 +33,7 @@ typedef struct {
   khc_slist* free_requested_node;
 } slist_alloc_ctx;
 
-khc_slist* alloc_cb(const char* str, size_t len, void* data) {
+khc_slist* cb_alloc(const char* str, size_t len, void* data) {
   slist_alloc_ctx* ctx = (slist_alloc_ctx*)data;
   ctx->alloc_requested_str = str;
   ctx->alloc_requested_str_len = len;
@@ -66,7 +66,7 @@ TEST_CASE( "slist append (3)" ) {
   slist_alloc_ctx ctx;
   memset(&ctx, 0, sizeof(slist_alloc_ctx));
   const char str[] = "aaaaa";
-  khc_slist* appended = khc_slist_append_using_alloc_cb(list, str, 5, alloc_cb, &ctx);
+  khc_slist* appended = khc_slist_append_using_cb_alloc(list, str, 5, cb_alloc, &ctx);
   REQUIRE( appended != NULL );
   REQUIRE( strlen(appended->data) == 5 );
   REQUIRE( strncmp(appended->data, str, 5) == 0 );

--- a/tests/small_test/khc/slist_test.cpp
+++ b/tests/small_test/khc/slist_test.cpp
@@ -54,7 +54,7 @@ khc_slist* cb_alloc(const char* str, size_t len, void* data) {
   return node;
 }
 
-void free_cb(khc_slist* node, void* data) {
+void cb_free(khc_slist* node, void* data) {
   slist_alloc_ctx* ctx = (slist_alloc_ctx*)data;
   ctx->free_requested_node = node;
   free(node->data);
@@ -75,6 +75,6 @@ TEST_CASE( "slist append (3)" ) {
   REQUIRE( ctx.alloc_requested_str == str );
   REQUIRE( ctx.alloc_requested_str_len == 5 );
 
-  khc_slist_free_all_using_free_cb(appended, free_cb, &ctx);
+  khc_slist_free_all_using_cb_free(appended, cb_free, &ctx);
   REQUIRE( ctx.free_requested_node == appended );
 }

--- a/tio/README.md
+++ b/tio/README.md
@@ -390,12 +390,12 @@ Alternatively, you can use dynamic allocation for tokens by using following API:
 void tio_handler_set_cb_json_parser_resource(
     tio_handler_t* handler,
     JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE free_cb);
+    JKII_CB_RESOURCE_FREE cb_free);
 ```
 
 `cb_alloc` is called when the token is required and it's number is exactly same as numbers need to parse json string.
 
-`free_cb` is called when the parse has been done.
+`cb_free` is called when the parse has been done.
 
 ## Execute onboarding
 

--- a/tio/README.md
+++ b/tio/README.md
@@ -133,7 +133,7 @@ Delay callback function signature is following.
 
 ```
 typedef void
-(*KII_DELAY_MS)
+(*KII_CB_DELAY_MS)
     (unsigned int msec);
 ```
 

--- a/tio/README.md
+++ b/tio/README.md
@@ -389,11 +389,11 @@ Alternatively, you can use dynamic allocation for tokens by using following API:
 ```c
 void tio_handler_set_cb_json_parser_resource(
     tio_handler_t* handler,
-    JKII_CB_RESOURCE_ALLOC alloc_cb,
+    JKII_CB_RESOURCE_ALLOC cb_alloc,
     JKII_CB_RESOURCE_FREE free_cb);
 ```
 
-`alloc_cb` is called when the token is required and it's number is exactly same as numbers need to parse json string.
+`cb_alloc` is called when the token is required and it's number is exactly same as numbers need to parse json string.
 
 `free_cb` is called when the parse has been done.
 

--- a/tio/README.md
+++ b/tio/README.md
@@ -43,7 +43,7 @@ Task create callback function signature is following.
 
 ```c
 typedef kii_task_code_t
-(*KII_TASK_CREATE)
+(*KII_CB_TASK_CREATE)
     (const char* name,
      KII_TASK_ENTRY entry,
      void* param);

--- a/tio/README.md
+++ b/tio/README.md
@@ -390,7 +390,7 @@ Alternatively, you can use dynamic allocation for tokens by using following API:
 void tio_handler_set_json_parser_resource_cb(
     tio_handler_t* handler,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
-    JKII_RESOURCE_FREE_CB free_cb);
+    JKII_CB_RESOURCE_FREE free_cb);
 ```
 
 `alloc_cb` is called when the token is required and it's number is exactly same as numbers need to parse json string.

--- a/tio/README.md
+++ b/tio/README.md
@@ -78,7 +78,7 @@ Task continue callback signature:
 
 ```c
 typedef kii_bool_t
-(*KII_TASK_CONTINUE)
+(*KII_CB_TASK_CONTINUE)
     (void* task_info,
     void* userdata);
 ```

--- a/tio/README.md
+++ b/tio/README.md
@@ -387,7 +387,7 @@ If you defined complex(i.e, a lot of fields or long arrays in the commands) cont
 Alternatively, you can use dynamic allocation for tokens by using following API:
 
 ```c
-void tio_handler_set_json_parser_resource_cb(
+void tio_handler_set_cb_json_parser_resource(
     tio_handler_t* handler,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_CB_RESOURCE_FREE free_cb);
@@ -607,7 +607,7 @@ The name of tasks executed by `tio_handler_t` and `tio_updater_t` listed bellow.
     - `tio_handler_start()` (`TIO_CB_ACTION` callback)
     - `tio_handler_set_cb_err()`
         (Optional. In case set the error handler for debugging, etc.)
-    - `tio_handler_set_json_parser_resource_cb()`
+    - `tio_handler_set_cb_json_parser_resource()`
         (Optional. In case dynamic memory allocation is chosen for parsing JSON.)
 
     This task uses buffers set by following APIs.
@@ -635,7 +635,7 @@ The name of tasks executed by `tio_handler_t` and `tio_updater_t` listed bellow.
     - `tio_updater_start()` (`TIO_CB_SIZE`, `TIO_CB_READ` callbacks.)
     - `tio_updater_set_cb_err()`
         (Optional. In case set the error handler for debugging, etc.)
-    - `tio_updater_set_json_parser_resource_cb()`
+    - `tio_updater_set_cb_json_parser_resource()`
         (Optional. In case dynamic memory allocation is chosen for parsing JSON.)
 
     This task uses buffers set by following APIs.

--- a/tio/README.md
+++ b/tio/README.md
@@ -389,7 +389,7 @@ Alternatively, you can use dynamic allocation for tokens by using following API:
 ```c
 void tio_handler_set_json_parser_resource_cb(
     tio_handler_t* handler,
-    JKII_RESOURCE_ALLOC_CB alloc_cb,
+    JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb);
 ```
 

--- a/tio/command_parser.c
+++ b/tio/command_parser.c
@@ -7,7 +7,7 @@
 
 _cmd_parser_code_t _get_object_in_array(
     jkii_resource_t* resource,
-    JKII_RESOURCE_ALLOC_CB alloc_cb,
+    JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb,
     const char* json_array,
     size_t json_array_length,
@@ -447,7 +447,7 @@ jkii_parse_err_t _parse_json(
     if (resource != NULL) {
         res = jkii_parse(json_string, json_string_size, fields, resource);
     } else {
-        JKII_RESOURCE_ALLOC_CB alloc_cb = handler->_kii._json_alloc_cb;
+        JKII_CB_RESOURCE_ALLOC alloc_cb = handler->_kii._json_alloc_cb;
         JKII_RESOURCE_FREE_CB free_cb = handler->_kii._json_free_cb;
         res = jkii_parse_with_allocator(json_string, json_string_size, fields, alloc_cb, free_cb);
     }

--- a/tio/command_parser.c
+++ b/tio/command_parser.c
@@ -8,7 +8,7 @@
 _cmd_parser_code_t _get_object_in_array(
     jkii_resource_t* resource,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
-    JKII_RESOURCE_FREE_CB free_cb,
+    JKII_CB_RESOURCE_FREE free_cb,
     const char* json_array,
     size_t json_array_length,
     size_t index,
@@ -448,7 +448,7 @@ jkii_parse_err_t _parse_json(
         res = jkii_parse(json_string, json_string_size, fields, resource);
     } else {
         JKII_CB_RESOURCE_ALLOC alloc_cb = handler->_kii._json_alloc_cb;
-        JKII_RESOURCE_FREE_CB free_cb = handler->_kii._json_free_cb;
+        JKII_CB_RESOURCE_FREE free_cb = handler->_kii._json_free_cb;
         res = jkii_parse_with_allocator(json_string, json_string_size, fields, alloc_cb, free_cb);
     }
     return res;

--- a/tio/command_parser.c
+++ b/tio/command_parser.c
@@ -8,7 +8,7 @@
 _cmd_parser_code_t _get_object_in_array(
     jkii_resource_t* resource,
     JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE free_cb,
+    JKII_CB_RESOURCE_FREE cb_free,
     const char* json_array,
     size_t json_array_length,
     size_t index,
@@ -32,7 +32,7 @@ _cmd_parser_code_t _get_object_in_array(
     if (resource != NULL) {
         res = jkii_parse(json_array, json_array_length, field, resource);
     } else {
-        res = jkii_parse_with_allocator(json_array, json_array_length, field, cb_alloc, free_cb);
+        res = jkii_parse_with_allocator(json_array, json_array_length, field, cb_alloc, cb_free);
     }
 
     if (res == JKII_ERR_OK) {
@@ -96,7 +96,7 @@ _cmd_parser_code_t _parse_alias(
     _cmd_parser_code_t res = _get_object_in_array(
         handler->_kii._json_resource,
         handler->_kii._json_cb_alloc,
-        handler->_kii._json_free_cb,
+        handler->_kii._json_cb_free,
         actions_array,
         actions_array_length,
         alias_index,
@@ -176,7 +176,7 @@ _cmd_parser_code_t _parse_action(
     _cmd_parser_code_t res = _get_object_in_array(
         handler->_kii._json_resource,
         handler->_kii._json_cb_alloc,
-        handler->_kii._json_free_cb,
+        handler->_kii._json_cb_free,
         actions_array_in_alias,
         actions_array_in_alias_length,
         action_index,
@@ -448,8 +448,8 @@ jkii_parse_err_t _parse_json(
         res = jkii_parse(json_string, json_string_size, fields, resource);
     } else {
         JKII_CB_RESOURCE_ALLOC cb_alloc = handler->_kii._json_cb_alloc;
-        JKII_CB_RESOURCE_FREE free_cb = handler->_kii._json_free_cb;
-        res = jkii_parse_with_allocator(json_string, json_string_size, fields, cb_alloc, free_cb);
+        JKII_CB_RESOURCE_FREE cb_free = handler->_kii._json_cb_free;
+        res = jkii_parse_with_allocator(json_string, json_string_size, fields, cb_alloc, cb_free);
     }
     return res;
 }

--- a/tio/command_parser.c
+++ b/tio/command_parser.c
@@ -7,7 +7,7 @@
 
 _cmd_parser_code_t _get_object_in_array(
     jkii_resource_t* resource,
-    JKII_CB_RESOURCE_ALLOC alloc_cb,
+    JKII_CB_RESOURCE_ALLOC cb_alloc,
     JKII_CB_RESOURCE_FREE free_cb,
     const char* json_array,
     size_t json_array_length,
@@ -32,7 +32,7 @@ _cmd_parser_code_t _get_object_in_array(
     if (resource != NULL) {
         res = jkii_parse(json_array, json_array_length, field, resource);
     } else {
-        res = jkii_parse_with_allocator(json_array, json_array_length, field, alloc_cb, free_cb);
+        res = jkii_parse_with_allocator(json_array, json_array_length, field, cb_alloc, free_cb);
     }
 
     if (res == JKII_ERR_OK) {
@@ -95,7 +95,7 @@ _cmd_parser_code_t _parse_alias(
     size_t alias_length;
     _cmd_parser_code_t res = _get_object_in_array(
         handler->_kii._json_resource,
-        handler->_kii._json_alloc_cb,
+        handler->_kii._json_cb_alloc,
         handler->_kii._json_free_cb,
         actions_array,
         actions_array_length,
@@ -175,7 +175,7 @@ _cmd_parser_code_t _parse_action(
     size_t action_object_length = 0;
     _cmd_parser_code_t res = _get_object_in_array(
         handler->_kii._json_resource,
-        handler->_kii._json_alloc_cb,
+        handler->_kii._json_cb_alloc,
         handler->_kii._json_free_cb,
         actions_array_in_alias,
         actions_array_in_alias_length,
@@ -447,9 +447,9 @@ jkii_parse_err_t _parse_json(
     if (resource != NULL) {
         res = jkii_parse(json_string, json_string_size, fields, resource);
     } else {
-        JKII_CB_RESOURCE_ALLOC alloc_cb = handler->_kii._json_alloc_cb;
+        JKII_CB_RESOURCE_ALLOC cb_alloc = handler->_kii._json_cb_alloc;
         JKII_CB_RESOURCE_FREE free_cb = handler->_kii._json_free_cb;
-        res = jkii_parse_with_allocator(json_string, json_string_size, fields, alloc_cb, free_cb);
+        res = jkii_parse_with_allocator(json_string, json_string_size, fields, cb_alloc, free_cb);
     }
     return res;
 }

--- a/tio/command_parser.h
+++ b/tio/command_parser.h
@@ -18,7 +18,7 @@ typedef enum _cmd_parser_code_t {
 _cmd_parser_code_t _get_object_in_array(
     jkii_resource_t* resource,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
-    JKII_RESOURCE_FREE_CB free_cb,
+    JKII_CB_RESOURCE_FREE free_cb,
     const char* json_array,
     size_t json_array_length,
     size_t index,

--- a/tio/command_parser.h
+++ b/tio/command_parser.h
@@ -18,7 +18,7 @@ typedef enum _cmd_parser_code_t {
 _cmd_parser_code_t _get_object_in_array(
     jkii_resource_t* resource,
     JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE free_cb,
+    JKII_CB_RESOURCE_FREE cb_free,
     const char* json_array,
     size_t json_array_length,
     size_t index,

--- a/tio/command_parser.h
+++ b/tio/command_parser.h
@@ -17,7 +17,7 @@ typedef enum _cmd_parser_code_t {
 
 _cmd_parser_code_t _get_object_in_array(
     jkii_resource_t* resource,
-    JKII_CB_RESOURCE_ALLOC alloc_cb,
+    JKII_CB_RESOURCE_ALLOC cb_alloc,
     JKII_CB_RESOURCE_FREE free_cb,
     const char* json_array,
     size_t json_array_length,

--- a/tio/command_parser.h
+++ b/tio/command_parser.h
@@ -17,7 +17,7 @@ typedef enum _cmd_parser_code_t {
 
 _cmd_parser_code_t _get_object_in_array(
     jkii_resource_t* resource,
-    JKII_RESOURCE_ALLOC_CB alloc_cb,
+    JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb,
     const char* json_array,
     size_t json_array_length,

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -81,7 +81,7 @@ typedef struct tio_handler_t {
     size_t _keep_alive_interval;
     KII_TASK_CONTINUE _cb_task_continue;
     void* _task_continue_data;
-    KII_TASK_EXIT _cb_task_exit;
+    KII_CB_TASK_EXIT _cb_task_exit;
     void* _task_exit_data;
 } tio_handler_t;
 
@@ -101,7 +101,7 @@ typedef struct tio_updater_t {
     size_t _update_interval;
     KII_TASK_CONTINUE _cb_task_continue;
     void* _task_continue_data;
-    KII_TASK_EXIT _cb_task_exit;
+    KII_CB_TASK_EXIT _cb_task_exit;
     void* _task_exit_data;
 } tio_updater_t;
 
@@ -198,13 +198,13 @@ void tio_handler_set_cb_task_create(tio_handler_t* handler, KII_CB_TASK_CREATE c
  * In case checking cancellation flag in continue_cb, the flag might be set by other task/ thread.
  * Implementation must ensure consistency of the flag by using Mutex, etc.
 
- * If un-recoverble error occurs, task exits the infinite loop and immediately calls KII_TASK_EXIT callback if set.
+ * If un-recoverble error occurs, task exits the infinite loop and immediately calls KII_CB_TASK_EXIT callback if set.
  * In this case KII_TASK_CONTINUE callback is not called.
 
  * \param tio_handler_t [out] tio_handler_t instance
  * \param continue_cb [in] Callback determines whether to continue or discontinue task.
  * If continue_cb returns KII_TRUE, task continues. Otherwise the task exits the infinite loop
- * and calls KII_TASK_EXIT callback if set.
+ * and calls KII_CB_TASK_EXIT callback if set.
  * task_info argument type of the cb_continue (defined as void* in KII_TASK_CONTINUE) is tio_handler_task_info*.
  * \param userdata [in] Context data pointer passed as second argument when cb_continue is called.
  */
@@ -241,10 +241,10 @@ void tio_handler_set_cb_task_continue(tio_handler_t* handler, KII_TASK_CONTINUE 
 
  * \param handler [out] tio_handler_t instance.
  * \param cb_exit [in] Called right before the exit.
- * task_info argument type of cb_exit (defined as void* in KII_TASK_EXIT) is tio_handler_task_info*
+ * task_info argument type of cb_exit (defined as void* in KII_CB_TASK_EXIT) is tio_handler_task_info*
  * \param userdata [in] Context data pointer passed as second argument when cb_exit is called.
  */
-void tio_handler_set_cb_task_exit(tio_handler_t* handler, KII_TASK_EXIT cb_exit, void* userdata);
+void tio_handler_set_cb_task_exit(tio_handler_t* handler, KII_CB_TASK_EXIT cb_exit, void* userdata);
 void tio_handler_set_cb_delay_ms(tio_handler_t* handler, KII_CB_DELAY_MS cb_delay_ms, void* userdata);
 
 void tio_handler_set_cb_err(tio_handler_t* handler, TIO_CB_ERR cb_err, void* userdata);
@@ -342,7 +342,7 @@ void tio_updater_set_cb_task_create(tio_updater_t* updater, KII_CB_TASK_CREATE c
  * \param updater [out] tio_updater_t instances
  * \param continue_cb [in] Callback determines whether to continue or discontinue task.
  * If continue_cb returns KII_TRUE, task continues. Otherwise the task exits the infinite loop
- * and calls KII_TASK_EXIT callback if set.
+ * and calls KII_CB_TASK_EXIT callback if set.
  * task_info argument of the cb_continue (defined as void* in KII_TASK_CONTINUE) is always NULL.
  * \param userdata [in] Context data pointer passed as second argument when cb_continue is called.
  */
@@ -373,10 +373,10 @@ void tio_updater_set_cb_task_continue(tio_updater_t* updater, KII_TASK_CONTINUE 
 
  * \param updater [out] tio_updater_t instance
  * \param exit_cb [in] Callback called right befor exit.
- * task_info argument of the cb_exit (defind as void* in KII_TASK_EXIT) function is always NULL.
+ * task_info argument of the cb_exit (defind as void* in KII_CB_TASK_EXIT) function is always NULL.
  * \param userdata [in] Context data pointer passed as second argument when cb_exit is called.
  */
-void tio_updater_set_cb_task_exit(tio_updater_t* updater, KII_TASK_EXIT cb_exit, void* userdata);
+void tio_updater_set_cb_task_exit(tio_updater_t* updater, KII_CB_TASK_EXIT cb_exit, void* userdata);
 void tio_updater_set_cb_delay_ms(tio_updater_t* updater, KII_CB_DELAY_MS cb_delay_ms, void* userdata);
 
 void tio_updater_set_cb_error(tio_updater_t* updater, TIO_CB_ERR cb_err, void* userdata);

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -280,7 +280,7 @@ void tio_handler_set_json_parser_resource(tio_handler_t* handler, jkii_resource_
 
 void tio_handler_set_json_parser_resource_cb(
     tio_handler_t* handler,
-    JKII_RESOURCE_ALLOC_CB alloc_cb,
+    JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb);
 
 /**
@@ -454,7 +454,7 @@ void tio_updater_set_json_parser_resource(tio_updater_t* updater, jkii_resource_
 
 void tio_updater_set_json_parser_resource_cb(
     tio_updater_t* updater,
-    JKII_RESOURCE_ALLOC_CB alloc_cb,
+    JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb);
 
 /**

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -79,7 +79,7 @@ typedef struct tio_handler_t {
     void* _cb_push_data;
     kii_t _kii;
     size_t _keep_alive_interval;
-    KII_TASK_CONTINUE _cb_task_continue;
+    KII_CB_TASK_CONTINUE _cb_task_continue;
     void* _task_continue_data;
     KII_CB_TASK_EXIT _cb_task_exit;
     void* _task_exit_data;
@@ -99,7 +99,7 @@ typedef struct tio_updater_t {
     void* _cb_err_data;
     kii_t _kii;
     size_t _update_interval;
-    KII_TASK_CONTINUE _cb_task_continue;
+    KII_CB_TASK_CONTINUE _cb_task_continue;
     void* _task_continue_data;
     KII_CB_TASK_EXIT _cb_task_exit;
     void* _task_exit_data;
@@ -199,21 +199,21 @@ void tio_handler_set_cb_task_create(tio_handler_t* handler, KII_CB_TASK_CREATE c
  * Implementation must ensure consistency of the flag by using Mutex, etc.
 
  * If un-recoverble error occurs, task exits the infinite loop and immediately calls KII_CB_TASK_EXIT callback if set.
- * In this case KII_TASK_CONTINUE callback is not called.
+ * In this case KII_CB_TASK_CONTINUE callback is not called.
 
  * \param tio_handler_t [out] tio_handler_t instance
  * \param continue_cb [in] Callback determines whether to continue or discontinue task.
  * If continue_cb returns KII_TRUE, task continues. Otherwise the task exits the infinite loop
  * and calls KII_CB_TASK_EXIT callback if set.
- * task_info argument type of the cb_continue (defined as void* in KII_TASK_CONTINUE) is tio_handler_task_info*.
+ * task_info argument type of the cb_continue (defined as void* in KII_CB_TASK_CONTINUE) is tio_handler_task_info*.
  * \param userdata [in] Context data pointer passed as second argument when cb_continue is called.
  */
-void tio_handler_set_cb_task_continue(tio_handler_t* handler, KII_TASK_CONTINUE cb_continue, void* userdata);
+void tio_handler_set_cb_task_continue(tio_handler_t* handler, KII_CB_TASK_CONTINUE cb_continue, void* userdata);
 
 /**
  * \brief Callback called right before exit of tio_handler task.
 
- * Task exits when the task is discontinued by KII_TASK_CONTINUE callback or
+ * Task exits when the task is discontinued by KII_CB_TASK_CONTINUE callback or
  * un-recoverble error occurs.
  * In exit_cb, you'll need to free memory used for buffers set by following APIs
  * - tio_handler_set_http_buff(),
@@ -343,15 +343,15 @@ void tio_updater_set_cb_task_create(tio_updater_t* updater, KII_CB_TASK_CREATE c
  * \param continue_cb [in] Callback determines whether to continue or discontinue task.
  * If continue_cb returns KII_TRUE, task continues. Otherwise the task exits the infinite loop
  * and calls KII_CB_TASK_EXIT callback if set.
- * task_info argument of the cb_continue (defined as void* in KII_TASK_CONTINUE) is always NULL.
+ * task_info argument of the cb_continue (defined as void* in KII_CB_TASK_CONTINUE) is always NULL.
  * \param userdata [in] Context data pointer passed as second argument when cb_continue is called.
  */
-void tio_updater_set_cb_task_continue(tio_updater_t* updater, KII_TASK_CONTINUE cb_continue, void* userdata);
+void tio_updater_set_cb_task_continue(tio_updater_t* updater, KII_CB_TASK_CONTINUE cb_continue, void* userdata);
 
 /**
  * \brief Callback called right before exit of tio_updater task.
 
- * Task exits when the task is discontinued by KII_TASK_CONTINUE callback.
+ * Task exits when the task is discontinued by KII_CB_TASK_CONTINUE callback.
  * In exit_cb, you'll need to free memory used for buffers set by following APIs
  * - tio_updater_set_buff(),
  * - tio_updater_set_stream_buff(),

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -185,7 +185,7 @@ void tio_handler_set_cb_sock_close_mqtt(tio_handler_t* handler, KHC_CB_SOCK_CLOS
 void tio_handler_set_mqtt_to_sock_recv(tio_handler_t* handler, unsigned int to_sock_recv_sec);
 void tio_handler_set_mqtt_to_sock_send(tio_handler_t* handler, unsigned int to_sock_send_sec);
 
-void tio_handler_set_cb_task_create(tio_handler_t* handler, KII_TASK_CREATE cb_task_create, void* userdata);
+void tio_handler_set_cb_task_create(tio_handler_t* handler, KII_CB_TASK_CREATE cb_task_create, void* userdata);
 
 /**
  * \brief set callback determines whether to continue or discontinue task.
@@ -326,7 +326,7 @@ void tio_updater_set_cb_sock_send(tio_updater_t* updater, KHC_CB_SOCK_SEND cb_se
 void tio_updater_set_cb_sock_recv(tio_updater_t* updater, KHC_CB_SOCK_RECV cb_recv, void* userdata);
 void tio_updater_set_cb_sock_close(tio_updater_t* updater, KHC_CB_SOCK_CLOSE cb_close, void* userdata);
 
-void tio_updater_set_cb_task_create(tio_updater_t* updater, KII_TASK_CREATE cb_task_create, void* userdata);
+void tio_updater_set_cb_task_create(tio_updater_t* updater, KII_CB_TASK_CREATE cb_task_create, void* userdata);
 
 /**
  * \brief set callback determines whether to continue or discontinue task.

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -245,7 +245,7 @@ void tio_handler_set_cb_task_continue(tio_handler_t* handler, KII_TASK_CONTINUE 
  * \param userdata [in] Context data pointer passed as second argument when cb_exit is called.
  */
 void tio_handler_set_cb_task_exit(tio_handler_t* handler, KII_TASK_EXIT cb_exit, void* userdata);
-void tio_handler_set_cb_delay_ms(tio_handler_t* handler, KII_DELAY_MS cb_delay_ms, void* userdata);
+void tio_handler_set_cb_delay_ms(tio_handler_t* handler, KII_CB_DELAY_MS cb_delay_ms, void* userdata);
 
 void tio_handler_set_cb_err(tio_handler_t* handler, TIO_CB_ERR cb_err, void* userdata);
 
@@ -377,7 +377,7 @@ void tio_updater_set_cb_task_continue(tio_updater_t* updater, KII_TASK_CONTINUE 
  * \param userdata [in] Context data pointer passed as second argument when cb_exit is called.
  */
 void tio_updater_set_cb_task_exit(tio_updater_t* updater, KII_TASK_EXIT cb_exit, void* userdata);
-void tio_updater_set_cb_delay_ms(tio_updater_t* updater, KII_DELAY_MS cb_delay_ms, void* userdata);
+void tio_updater_set_cb_delay_ms(tio_updater_t* updater, KII_CB_DELAY_MS cb_delay_ms, void* userdata);
 
 void tio_updater_set_cb_error(tio_updater_t* updater, TIO_CB_ERR cb_err, void* userdata);
 

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -293,8 +293,8 @@ void tio_handler_set_cb_json_parser_resource(
  */
 void tio_handler_set_slist_resource_cb(
     tio_handler_t* handler,
-    CB_KHC_SLIST_ALLOC cb_alloc,
-    KHC_SLIST_FREE_CB cb_free,
+    KHC_CB_SLIST_ALLOC cb_alloc,
+    KHC_CB_SLIST_FREE cb_free,
     void* cb_alloc_data,
     void* cb_free_data
 );
@@ -467,8 +467,8 @@ void tio_updater_set_cb_json_parser_resource(
  */
 void tio_updater_set_slist_resource_cb(
     tio_updater_t* updater,
-    CB_KHC_SLIST_ALLOC cb_alloc,
-    KHC_SLIST_FREE_CB cb_free,
+    KHC_CB_SLIST_ALLOC cb_alloc,
+    KHC_CB_SLIST_FREE cb_free,
     void* cb_alloc_data,
     void* cb_free_data
 );

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -293,7 +293,7 @@ void tio_handler_set_cb_json_parser_resource(
  */
 void tio_handler_set_slist_resource_cb(
     tio_handler_t* handler,
-    KHC_SLIST_ALLOC_CB cb_alloc,
+    CB_KHC_SLIST_ALLOC cb_alloc,
     KHC_SLIST_FREE_CB cb_free,
     void* cb_alloc_data,
     void* cb_free_data
@@ -467,7 +467,7 @@ void tio_updater_set_cb_json_parser_resource(
  */
 void tio_updater_set_slist_resource_cb(
     tio_updater_t* updater,
-    KHC_SLIST_ALLOC_CB cb_alloc,
+    CB_KHC_SLIST_ALLOC cb_alloc,
     KHC_SLIST_FREE_CB cb_free,
     void* cb_alloc_data,
     void* cb_free_data

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -278,7 +278,7 @@ void tio_handler_set_app(tio_handler_t* handler, const char* app_id, const char*
 
 void tio_handler_set_json_parser_resource(tio_handler_t* handler, jkii_resource_t* resource);
 
-void tio_handler_set_json_parser_resource_cb(
+void tio_handler_set_cb_json_parser_resource(
     tio_handler_t* handler,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_CB_RESOURCE_FREE free_cb);
@@ -452,7 +452,7 @@ void tio_updater_set_interval(tio_updater_t* updater, size_t update_interval);
 
 void tio_updater_set_json_parser_resource(tio_updater_t* updater, jkii_resource_t* resource);
 
-void tio_updater_set_json_parser_resource_cb(
+void tio_updater_set_cb_json_parser_resource(
     tio_updater_t* updater,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_CB_RESOURCE_FREE free_cb);

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -291,7 +291,7 @@ void tio_handler_set_cb_json_parser_resource(
  * tio_handler_set_app(tio_handler_t*, const char*, const char*) since the
  * tio_handler_set_app() method has side effect resetting to default memory allocator.
  */
-void tio_handler_set_slist_resource_cb(
+void tio_handler_set_cb_slist_resource(
     tio_handler_t* handler,
     KHC_CB_SLIST_ALLOC cb_alloc,
     KHC_CB_SLIST_FREE cb_free,
@@ -465,7 +465,7 @@ void tio_updater_set_cb_json_parser_resource(
  * tio_updater_set_app(tio_updater_t*, const char*, const char*) since the
  * tio_updater_set_app() method has side effect resetting to default memory allocator.
  */
-void tio_updater_set_slist_resource_cb(
+void tio_updater_set_cb_slist_resource(
     tio_updater_t* updater,
     KHC_CB_SLIST_ALLOC cb_alloc,
     KHC_CB_SLIST_FREE cb_free,

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -281,7 +281,7 @@ void tio_handler_set_json_parser_resource(tio_handler_t* handler, jkii_resource_
 void tio_handler_set_json_parser_resource_cb(
     tio_handler_t* handler,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
-    JKII_RESOURCE_FREE_CB free_cb);
+    JKII_CB_RESOURCE_FREE free_cb);
 
 /**
  * \brief Set custom memory allocator for the linked list used to constuct request headers of HTTP.
@@ -455,7 +455,7 @@ void tio_updater_set_json_parser_resource(tio_updater_t* updater, jkii_resource_
 void tio_updater_set_json_parser_resource_cb(
     tio_updater_t* updater,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
-    JKII_RESOURCE_FREE_CB free_cb);
+    JKII_CB_RESOURCE_FREE free_cb);
 
 /**
  * \brief Set custom memory allocator for the linked list used to constuct request headers of HTTP.

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -280,7 +280,7 @@ void tio_handler_set_json_parser_resource(tio_handler_t* handler, jkii_resource_
 
 void tio_handler_set_cb_json_parser_resource(
     tio_handler_t* handler,
-    JKII_CB_RESOURCE_ALLOC alloc_cb,
+    JKII_CB_RESOURCE_ALLOC cb_alloc,
     JKII_CB_RESOURCE_FREE free_cb);
 
 /**
@@ -293,9 +293,9 @@ void tio_handler_set_cb_json_parser_resource(
  */
 void tio_handler_set_slist_resource_cb(
     tio_handler_t* handler,
-    KHC_SLIST_ALLOC_CB alloc_cb,
+    KHC_SLIST_ALLOC_CB cb_alloc,
     KHC_SLIST_FREE_CB free_cb,
-    void* alloc_cb_data,
+    void* cb_alloc_data,
     void* free_cb_data
 );
 
@@ -454,7 +454,7 @@ void tio_updater_set_json_parser_resource(tio_updater_t* updater, jkii_resource_
 
 void tio_updater_set_cb_json_parser_resource(
     tio_updater_t* updater,
-    JKII_CB_RESOURCE_ALLOC alloc_cb,
+    JKII_CB_RESOURCE_ALLOC cb_alloc,
     JKII_CB_RESOURCE_FREE free_cb);
 
 /**
@@ -467,9 +467,9 @@ void tio_updater_set_cb_json_parser_resource(
  */
 void tio_updater_set_slist_resource_cb(
     tio_updater_t* updater,
-    KHC_SLIST_ALLOC_CB alloc_cb,
+    KHC_SLIST_ALLOC_CB cb_alloc,
     KHC_SLIST_FREE_CB free_cb,
-    void* alloc_cb_data,
+    void* cb_alloc_data,
     void* free_cb_data
 );
 

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -281,7 +281,7 @@ void tio_handler_set_json_parser_resource(tio_handler_t* handler, jkii_resource_
 void tio_handler_set_cb_json_parser_resource(
     tio_handler_t* handler,
     JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE free_cb);
+    JKII_CB_RESOURCE_FREE cb_free);
 
 /**
  * \brief Set custom memory allocator for the linked list used to constuct request headers of HTTP.
@@ -294,9 +294,9 @@ void tio_handler_set_cb_json_parser_resource(
 void tio_handler_set_slist_resource_cb(
     tio_handler_t* handler,
     KHC_SLIST_ALLOC_CB cb_alloc,
-    KHC_SLIST_FREE_CB free_cb,
+    KHC_SLIST_FREE_CB cb_free,
     void* cb_alloc_data,
-    void* free_cb_data
+    void* cb_free_data
 );
 
 tio_code_t tio_handler_onboard(
@@ -455,7 +455,7 @@ void tio_updater_set_json_parser_resource(tio_updater_t* updater, jkii_resource_
 void tio_updater_set_cb_json_parser_resource(
     tio_updater_t* updater,
     JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE free_cb);
+    JKII_CB_RESOURCE_FREE cb_free);
 
 /**
  * \brief Set custom memory allocator for the linked list used to constuct request headers of HTTP.
@@ -468,9 +468,9 @@ void tio_updater_set_cb_json_parser_resource(
 void tio_updater_set_slist_resource_cb(
     tio_updater_t* updater,
     KHC_SLIST_ALLOC_CB cb_alloc,
-    KHC_SLIST_FREE_CB free_cb,
+    KHC_SLIST_FREE_CB cb_free,
     void* cb_alloc_data,
-    void* free_cb_data
+    void* cb_free_data
 );
 
 tio_code_t tio_updater_onboard(

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -50,7 +50,7 @@ void tio_handler_init(tio_handler_t* handler)
     handler->_cb_task_exit = NULL;
     handler->_task_exit_data = NULL;
     kii_set_cb_task_continue(&handler->_kii, _task_continue, handler);
-    kii_set_task_exit_cb(&handler->_kii, _task_exit, handler);
+    kii_set_cb_task_exit(&handler->_kii, _task_exit, handler);
 }
 
 void tio_handler_set_cb_sock_connect_http(
@@ -168,7 +168,7 @@ void tio_handler_set_cb_delay_ms(
     KII_CB_DELAY_MS cb_delay_ms,
     void* userdata)
 {
-    kii_set_delay_ms_cb(&handler->_kii, cb_delay_ms, userdata);
+    kii_set_cb_delay_ms(&handler->_kii, cb_delay_ms, userdata);
 }
 
 void tio_handler_set_cb_err(
@@ -369,7 +369,7 @@ void tio_updater_set_cb_delay_ms(
     KII_CB_DELAY_MS cb_delay_ms,
     void* userdata)
 {
-    kii_set_delay_ms_cb(&updater->_kii, cb_delay_ms, userdata);
+    kii_set_cb_delay_ms(&updater->_kii, cb_delay_ms, userdata);
 }
 
 void tio_updater_set_cb_error(

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -58,7 +58,7 @@ void tio_handler_set_cb_sock_connect_http(
     KHC_CB_SOCK_CONNECT cb_connect,
     void* userdata)
 {
-    kii_set_http_cb_sock_connect(&handler->_kii, cb_connect, userdata);
+    kii_set_cb_http_sock_connect(&handler->_kii, cb_connect, userdata);
 }
 
 void tio_handler_set_cb_sock_send_http(
@@ -66,7 +66,7 @@ void tio_handler_set_cb_sock_send_http(
     KHC_CB_SOCK_SEND cb_send,
     void* userdata)
 {
-    kii_set_http_cb_sock_send(&handler->_kii, cb_send, userdata);
+    kii_set_cb_http_sock_send(&handler->_kii, cb_send, userdata);
 }
 
 void tio_handler_set_cb_sock_recv_http(
@@ -74,7 +74,7 @@ void tio_handler_set_cb_sock_recv_http(
     KHC_CB_SOCK_RECV cb_recv,
     void* userdata)
 {
-    kii_set_http_cb_sock_recv(&handler->_kii, cb_recv, userdata);
+    kii_set_cb_http_sock_recv(&handler->_kii, cb_recv, userdata);
 }
 
 void tio_handler_set_cb_sock_close_http(
@@ -82,7 +82,7 @@ void tio_handler_set_cb_sock_close_http(
     KHC_CB_SOCK_CLOSE cb_close,
     void* userdata)
 {
-    kii_set_http_cb_sock_close(&handler->_kii, cb_close, userdata);
+    kii_set_cb_http_sock_close(&handler->_kii, cb_close, userdata);
 }
 
 void tio_handler_set_http_buff(
@@ -106,7 +106,7 @@ void tio_handler_set_cb_sock_connect_mqtt(
     KHC_CB_SOCK_CONNECT cb_connect,
     void* userdata)
 {
-    kii_set_mqtt_cb_sock_connect(&handler->_kii, cb_connect, userdata);
+    kii_set_cb_mqtt_sock_connect(&handler->_kii, cb_connect, userdata);
 }
 
 void tio_handler_set_cb_sock_send_mqtt(
@@ -114,7 +114,7 @@ void tio_handler_set_cb_sock_send_mqtt(
     KHC_CB_SOCK_SEND cb_send,
     void* userdata)
 {
-    kii_set_mqtt_cb_sock_send(&handler->_kii, cb_send, userdata);
+    kii_set_cb_mqtt_sock_send(&handler->_kii, cb_send, userdata);
 }
 
 void tio_handler_set_cb_sock_recv_mqtt(
@@ -122,7 +122,7 @@ void tio_handler_set_cb_sock_recv_mqtt(
     KHC_CB_SOCK_RECV cb_recv,
     void* userdata)
 {
-    kii_set_mqtt_cb_sock_recv(&handler->_kii, cb_recv, userdata);
+    kii_set_cb_mqtt_sock_recv(&handler->_kii, cb_recv, userdata);
 }
 
 void tio_handler_set_cb_sock_close_mqtt(
@@ -130,7 +130,7 @@ void tio_handler_set_cb_sock_close_mqtt(
     KHC_CB_SOCK_CLOSE cb_close,
     void* userdata)
 {
-    kii_set_mqtt_cb_sock_close(&handler->_kii, cb_close, userdata);
+    kii_set_cb_mqtt_sock_close(&handler->_kii, cb_close, userdata);
 }
 
 void tio_handler_set_mqtt_to_sock_recv(tio_handler_t* handler, unsigned int to_sock_recv_sec)
@@ -317,7 +317,7 @@ void tio_updater_set_cb_sock_connect(
     KHC_CB_SOCK_CONNECT cb_connect,
     void* userdata)
 {
-    kii_set_http_cb_sock_connect(&updater->_kii, cb_connect, userdata);
+    kii_set_cb_http_sock_connect(&updater->_kii, cb_connect, userdata);
 }
 
 void tio_updater_set_cb_sock_send(
@@ -325,7 +325,7 @@ void tio_updater_set_cb_sock_send(
     KHC_CB_SOCK_SEND cb_send,
     void* userdata)
 {
-    kii_set_http_cb_sock_send(&updater->_kii, cb_send, userdata);
+    kii_set_cb_http_sock_send(&updater->_kii, cb_send, userdata);
 }
 
 void tio_updater_set_cb_sock_recv(
@@ -333,7 +333,7 @@ void tio_updater_set_cb_sock_recv(
     KHC_CB_SOCK_RECV cb_recv,
     void* userdata)
 {
-    kii_set_http_cb_sock_recv(&updater->_kii, cb_recv, userdata);
+    kii_set_cb_http_sock_recv(&updater->_kii, cb_recv, userdata);
 }
 
 void tio_updater_set_cb_sock_close(
@@ -341,7 +341,7 @@ void tio_updater_set_cb_sock_close(
     KHC_CB_SOCK_CLOSE cb_close,
     void* userdata)
 {
-    kii_set_http_cb_sock_close(&updater->_kii, cb_close, userdata);
+    kii_set_cb_http_sock_close(&updater->_kii, cb_close, userdata);
 }
 
 void tio_updater_set_cb_task_create(

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -239,7 +239,7 @@ void tio_handler_set_json_parser_resource_cb(
     JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_CB_RESOURCE_FREE free_cb)
 {
-    kii_set_json_parser_resource_cb(&handler->_kii, alloc_cb, free_cb);
+    kii_set_cb_json_parser_resource(&handler->_kii, alloc_cb, free_cb);
 }
 
 void tio_handler_set_slist_resource_cb(
@@ -468,7 +468,7 @@ void tio_updater_set_json_parser_resource_cb(
     JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_CB_RESOURCE_FREE free_cb)
 {
-    kii_set_json_parser_resource_cb(&updater->_kii, alloc_cb, free_cb);
+    kii_set_cb_json_parser_resource(&updater->_kii, alloc_cb, free_cb);
 }
 
 void tio_updater_set_slist_resource_cb(

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -148,7 +148,7 @@ void tio_handler_set_cb_task_create(
     KII_CB_TASK_CREATE cb_task_create,
     void* userdata)
 {
-    kii_set_task_create_cb(&handler->_kii, cb_task_create, userdata);
+    kii_set_cb_task_create(&handler->_kii, cb_task_create, userdata);
 }
 
 void tio_handler_set_cb_task_continue(tio_handler_t* handler, KII_CB_TASK_CONTINUE cb_continue, void* userdata)
@@ -349,7 +349,7 @@ void tio_updater_set_cb_task_create(
     KII_CB_TASK_CREATE cb_task_create,
     void* userdata)
 {
-    kii_set_task_create_cb(&updater->_kii, cb_task_create, userdata);
+    kii_set_cb_task_create(&updater->_kii, cb_task_create, userdata);
 }
 
 void tio_updater_set_cb_task_continue(tio_updater_t* updater, KII_CB_TASK_CONTINUE cb_continue, void* userdata)

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -236,20 +236,20 @@ void tio_handler_set_json_parser_resource(
 
 void tio_handler_set_cb_json_parser_resource(
     tio_handler_t* handler,
-    JKII_CB_RESOURCE_ALLOC alloc_cb,
+    JKII_CB_RESOURCE_ALLOC cb_alloc,
     JKII_CB_RESOURCE_FREE free_cb)
 {
-    kii_set_cb_json_parser_resource(&handler->_kii, alloc_cb, free_cb);
+    kii_set_cb_json_parser_resource(&handler->_kii, cb_alloc, free_cb);
 }
 
 void tio_handler_set_slist_resource_cb(
     tio_handler_t* handler,
-    KHC_SLIST_ALLOC_CB alloc_cb,
+    KHC_SLIST_ALLOC_CB cb_alloc,
     KHC_SLIST_FREE_CB free_cb,
-    void* alloc_cb_data,
+    void* cb_alloc_data,
     void* free_cb_data)
 {
-    kii_set_slist_resource_cb(&handler->_kii, alloc_cb, free_cb, alloc_cb_data, free_cb_data);
+    kii_set_slist_resource_cb(&handler->_kii, cb_alloc, free_cb, cb_alloc_data, free_cb_data);
 }
 
 tio_code_t tio_handler_onboard(
@@ -465,20 +465,20 @@ void tio_updater_set_json_parser_resource(
 
 void tio_updater_set_cb_json_parser_resource(
     tio_updater_t* updater,
-    JKII_CB_RESOURCE_ALLOC alloc_cb,
+    JKII_CB_RESOURCE_ALLOC cb_alloc,
     JKII_CB_RESOURCE_FREE free_cb)
 {
-    kii_set_cb_json_parser_resource(&updater->_kii, alloc_cb, free_cb);
+    kii_set_cb_json_parser_resource(&updater->_kii, cb_alloc, free_cb);
 }
 
 void tio_updater_set_slist_resource_cb(
     tio_updater_t* updater,
-    KHC_SLIST_ALLOC_CB alloc_cb,
+    KHC_SLIST_ALLOC_CB cb_alloc,
     KHC_SLIST_FREE_CB free_cb,
-    void* alloc_cb_data,
+    void* cb_alloc_data,
     void* free_cb_data)
 {
-    kii_set_slist_resource_cb(&updater->_kii, alloc_cb, free_cb, alloc_cb_data, free_cb_data);
+    kii_set_slist_resource_cb(&updater->_kii, cb_alloc, free_cb, cb_alloc_data, free_cb_data);
 }
 
 tio_code_t tio_updater_onboard(

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -157,7 +157,7 @@ void tio_handler_set_cb_task_continue(tio_handler_t* handler, KII_TASK_CONTINUE 
     handler->_task_continue_data = userdata;
 }
 
-void tio_handler_set_cb_task_exit(tio_handler_t* handler, KII_TASK_EXIT cb_exit, void* userdata)
+void tio_handler_set_cb_task_exit(tio_handler_t* handler, KII_CB_TASK_EXIT cb_exit, void* userdata)
 {
     handler->_cb_task_exit = cb_exit;
     handler->_task_exit_data = userdata;
@@ -358,7 +358,7 @@ void tio_updater_set_cb_task_continue(tio_updater_t* updater, KII_TASK_CONTINUE 
     updater->_task_continue_data = userdata;
 }
 
-void tio_updater_set_cb_task_exit(tio_updater_t* updater, KII_TASK_EXIT cb_exit, void* userdata)
+void tio_updater_set_cb_task_exit(tio_updater_t* updater, KII_CB_TASK_EXIT cb_exit, void* userdata)
 {
     updater->_cb_task_exit = cb_exit;
     updater->_task_exit_data = userdata;

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -249,7 +249,7 @@ void tio_handler_set_slist_resource_cb(
     void* cb_alloc_data,
     void* cb_free_data)
 {
-    kii_set_slist_resource_cb(&handler->_kii, cb_alloc, cb_free, cb_alloc_data, cb_free_data);
+    kii_set_cb_slist_resource(&handler->_kii, cb_alloc, cb_free, cb_alloc_data, cb_free_data);
 }
 
 tio_code_t tio_handler_onboard(
@@ -478,7 +478,7 @@ void tio_updater_set_slist_resource_cb(
     void* cb_alloc_data,
     void* cb_free_data)
 {
-    kii_set_slist_resource_cb(&updater->_kii, cb_alloc, cb_free, cb_alloc_data, cb_free_data);
+    kii_set_cb_slist_resource(&updater->_kii, cb_alloc, cb_free, cb_alloc_data, cb_free_data);
 }
 
 tio_code_t tio_updater_onboard(

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -237,19 +237,19 @@ void tio_handler_set_json_parser_resource(
 void tio_handler_set_cb_json_parser_resource(
     tio_handler_t* handler,
     JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE free_cb)
+    JKII_CB_RESOURCE_FREE cb_free)
 {
-    kii_set_cb_json_parser_resource(&handler->_kii, cb_alloc, free_cb);
+    kii_set_cb_json_parser_resource(&handler->_kii, cb_alloc, cb_free);
 }
 
 void tio_handler_set_slist_resource_cb(
     tio_handler_t* handler,
     KHC_SLIST_ALLOC_CB cb_alloc,
-    KHC_SLIST_FREE_CB free_cb,
+    KHC_SLIST_FREE_CB cb_free,
     void* cb_alloc_data,
-    void* free_cb_data)
+    void* cb_free_data)
 {
-    kii_set_slist_resource_cb(&handler->_kii, cb_alloc, free_cb, cb_alloc_data, free_cb_data);
+    kii_set_slist_resource_cb(&handler->_kii, cb_alloc, cb_free, cb_alloc_data, cb_free_data);
 }
 
 tio_code_t tio_handler_onboard(
@@ -466,19 +466,19 @@ void tio_updater_set_json_parser_resource(
 void tio_updater_set_cb_json_parser_resource(
     tio_updater_t* updater,
     JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE free_cb)
+    JKII_CB_RESOURCE_FREE cb_free)
 {
-    kii_set_cb_json_parser_resource(&updater->_kii, cb_alloc, free_cb);
+    kii_set_cb_json_parser_resource(&updater->_kii, cb_alloc, cb_free);
 }
 
 void tio_updater_set_slist_resource_cb(
     tio_updater_t* updater,
     KHC_SLIST_ALLOC_CB cb_alloc,
-    KHC_SLIST_FREE_CB free_cb,
+    KHC_SLIST_FREE_CB cb_free,
     void* cb_alloc_data,
-    void* free_cb_data)
+    void* cb_free_data)
 {
-    kii_set_slist_resource_cb(&updater->_kii, cb_alloc, free_cb, cb_alloc_data, free_cb_data);
+    kii_set_slist_resource_cb(&updater->_kii, cb_alloc, cb_free, cb_alloc_data, cb_free_data);
 }
 
 tio_code_t tio_updater_onboard(

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -151,7 +151,7 @@ void tio_handler_set_cb_task_create(
     kii_set_task_create_cb(&handler->_kii, cb_task_create, userdata);
 }
 
-void tio_handler_set_cb_task_continue(tio_handler_t* handler, KII_TASK_CONTINUE cb_continue, void* userdata)
+void tio_handler_set_cb_task_continue(tio_handler_t* handler, KII_CB_TASK_CONTINUE cb_continue, void* userdata)
 {
     handler->_cb_task_continue = cb_continue;
     handler->_task_continue_data = userdata;
@@ -352,7 +352,7 @@ void tio_updater_set_cb_task_create(
     kii_set_task_create_cb(&updater->_kii, cb_task_create, userdata);
 }
 
-void tio_updater_set_cb_task_continue(tio_updater_t* updater, KII_TASK_CONTINUE cb_continue, void* userdata)
+void tio_updater_set_cb_task_continue(tio_updater_t* updater, KII_CB_TASK_CONTINUE cb_continue, void* userdata)
 {
     updater->_cb_task_continue = cb_continue;
     updater->_task_continue_data = userdata;

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -49,7 +49,7 @@ void tio_handler_init(tio_handler_t* handler)
     handler->_task_continue_data = NULL;
     handler->_cb_task_exit = NULL;
     handler->_task_exit_data = NULL;
-    kii_set_task_continue_cb(&handler->_kii, _task_continue, handler);
+    kii_set_cb_task_continue(&handler->_kii, _task_continue, handler);
     kii_set_task_exit_cb(&handler->_kii, _task_exit, handler);
 }
 

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -145,7 +145,7 @@ void tio_handler_set_mqtt_to_sock_send(tio_handler_t* handler, unsigned int to_s
 
 void tio_handler_set_cb_task_create(
     tio_handler_t* handler,
-    KII_TASK_CREATE cb_task_create,
+    KII_CB_TASK_CREATE cb_task_create,
     void* userdata)
 {
     kii_set_task_create_cb(&handler->_kii, cb_task_create, userdata);
@@ -346,7 +346,7 @@ void tio_updater_set_cb_sock_close(
 
 void tio_updater_set_cb_task_create(
     tio_updater_t* updater,
-    KII_TASK_CREATE cb_task_create,
+    KII_CB_TASK_CREATE cb_task_create,
     void* userdata)
 {
     kii_set_task_create_cb(&updater->_kii, cb_task_create, userdata);

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -236,7 +236,7 @@ void tio_handler_set_json_parser_resource(
 
 void tio_handler_set_json_parser_resource_cb(
     tio_handler_t* handler,
-    JKII_RESOURCE_ALLOC_CB alloc_cb,
+    JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb)
 {
     kii_set_json_parser_resource_cb(&handler->_kii, alloc_cb, free_cb);
@@ -465,7 +465,7 @@ void tio_updater_set_json_parser_resource(
 
 void tio_updater_set_json_parser_resource_cb(
     tio_updater_t* updater,
-    JKII_RESOURCE_ALLOC_CB alloc_cb,
+    JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_RESOURCE_FREE_CB free_cb)
 {
     kii_set_json_parser_resource_cb(&updater->_kii, alloc_cb, free_cb);

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -237,7 +237,7 @@ void tio_handler_set_json_parser_resource(
 void tio_handler_set_json_parser_resource_cb(
     tio_handler_t* handler,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
-    JKII_RESOURCE_FREE_CB free_cb)
+    JKII_CB_RESOURCE_FREE free_cb)
 {
     kii_set_json_parser_resource_cb(&handler->_kii, alloc_cb, free_cb);
 }
@@ -466,7 +466,7 @@ void tio_updater_set_json_parser_resource(
 void tio_updater_set_json_parser_resource_cb(
     tio_updater_t* updater,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
-    JKII_RESOURCE_FREE_CB free_cb)
+    JKII_CB_RESOURCE_FREE free_cb)
 {
     kii_set_json_parser_resource_cb(&updater->_kii, alloc_cb, free_cb);
 }

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -234,7 +234,7 @@ void tio_handler_set_json_parser_resource(
     kii_set_json_parser_resource(&handler->_kii, resource);
 }
 
-void tio_handler_set_json_parser_resource_cb(
+void tio_handler_set_cb_json_parser_resource(
     tio_handler_t* handler,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_CB_RESOURCE_FREE free_cb)
@@ -463,7 +463,7 @@ void tio_updater_set_json_parser_resource(
     kii_set_json_parser_resource(&updater->_kii, resource);
 }
 
-void tio_updater_set_json_parser_resource_cb(
+void tio_updater_set_cb_json_parser_resource(
     tio_updater_t* updater,
     JKII_CB_RESOURCE_ALLOC alloc_cb,
     JKII_CB_RESOURCE_FREE free_cb)

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -244,7 +244,7 @@ void tio_handler_set_cb_json_parser_resource(
 
 void tio_handler_set_slist_resource_cb(
     tio_handler_t* handler,
-    KHC_SLIST_ALLOC_CB cb_alloc,
+    CB_KHC_SLIST_ALLOC cb_alloc,
     KHC_SLIST_FREE_CB cb_free,
     void* cb_alloc_data,
     void* cb_free_data)
@@ -473,7 +473,7 @@ void tio_updater_set_cb_json_parser_resource(
 
 void tio_updater_set_slist_resource_cb(
     tio_updater_t* updater,
-    KHC_SLIST_ALLOC_CB cb_alloc,
+    CB_KHC_SLIST_ALLOC cb_alloc,
     KHC_SLIST_FREE_CB cb_free,
     void* cb_alloc_data,
     void* cb_free_data)

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -242,7 +242,7 @@ void tio_handler_set_cb_json_parser_resource(
     kii_set_cb_json_parser_resource(&handler->_kii, cb_alloc, cb_free);
 }
 
-void tio_handler_set_slist_resource_cb(
+void tio_handler_set_cb_slist_resource(
     tio_handler_t* handler,
     KHC_CB_SLIST_ALLOC cb_alloc,
     KHC_CB_SLIST_FREE cb_free,
@@ -471,7 +471,7 @@ void tio_updater_set_cb_json_parser_resource(
     kii_set_cb_json_parser_resource(&updater->_kii, cb_alloc, cb_free);
 }
 
-void tio_updater_set_slist_resource_cb(
+void tio_updater_set_cb_slist_resource(
     tio_updater_t* updater,
     KHC_CB_SLIST_ALLOC cb_alloc,
     KHC_CB_SLIST_FREE cb_free,

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -165,7 +165,7 @@ void tio_handler_set_cb_task_exit(tio_handler_t* handler, KII_TASK_EXIT cb_exit,
 
 void tio_handler_set_cb_delay_ms(
     tio_handler_t* handler,
-    KII_DELAY_MS cb_delay_ms,
+    KII_CB_DELAY_MS cb_delay_ms,
     void* userdata)
 {
     kii_set_delay_ms_cb(&handler->_kii, cb_delay_ms, userdata);
@@ -366,7 +366,7 @@ void tio_updater_set_cb_task_exit(tio_updater_t* updater, KII_TASK_EXIT cb_exit,
 
 void tio_updater_set_cb_delay_ms(
     tio_updater_t* updater,
-    KII_DELAY_MS cb_delay_ms,
+    KII_CB_DELAY_MS cb_delay_ms,
     void* userdata)
 {
     kii_set_delay_ms_cb(&updater->_kii, cb_delay_ms, userdata);

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -244,8 +244,8 @@ void tio_handler_set_cb_json_parser_resource(
 
 void tio_handler_set_slist_resource_cb(
     tio_handler_t* handler,
-    CB_KHC_SLIST_ALLOC cb_alloc,
-    KHC_SLIST_FREE_CB cb_free,
+    KHC_CB_SLIST_ALLOC cb_alloc,
+    KHC_CB_SLIST_FREE cb_free,
     void* cb_alloc_data,
     void* cb_free_data)
 {
@@ -473,8 +473,8 @@ void tio_updater_set_cb_json_parser_resource(
 
 void tio_updater_set_slist_resource_cb(
     tio_updater_t* updater,
-    CB_KHC_SLIST_ALLOC cb_alloc,
-    KHC_SLIST_FREE_CB cb_free,
+    KHC_CB_SLIST_ALLOC cb_alloc,
+    KHC_CB_SLIST_FREE cb_free,
     void* cb_alloc_data,
     void* cb_free_data)
 {


### PR DESCRIPTION
`cb_{}` , `{}_cb` のパターンが混在していたので、 `cb_{}` に統一しました。