### PR TITLE
check errno when ssl_error is SSL_ERROR_SYSCALL

### DIFF
--- a/tio/linux-sample/sock_cb_linux.c
+++ b/tio/linux-sample/sock_cb_linux.c
@@ -11,6 +11,8 @@
 
 #include <openssl/crypto.h>
 #include <openssl/err.h>
+#include <errno.h>
+
 
 /* Suppress warnings, because OpenSSL was deprecated in Mac. */
 #ifdef __APPLE__
@@ -142,6 +144,13 @@ khc_sock_code_t
             return KHC_SOCK_OK;
         } else if (ssl_error == SSL_ERROR_WANT_READ || ssl_error == SSL_ERROR_WANT_WRITE) {
             return KHC_SOCK_AGAIN;
+        } else if (ssl_error == SSL_ERROR_SYSCALL){
+            if (errno == 0){
+                return KHC_SOCK_OK;
+            } else {
+                printf("errno=%d: %s\n", errno, strerror(errno));
+                return KHC_SOCK_FAIL;
+            }
         } else {
             return KHC_SOCK_FAIL;
         }


### PR DESCRIPTION
Fixed #87 
### Changes
- check errno when error is SSL_ERROR_SYSCALL 

### References
[SSL_ERROR_SYSCALL](https://www.openssl.org/docs/man1.0.2/ssl/SSL_get_error.html)