### PR TITLE
Add content-encoding for thing state APIs thru data normalizer

### DIFF
--- a/kii/include/kii.h
+++ b/kii/include/kii.h
@@ -618,6 +618,8 @@ kii_code_t kii_ti_put_thing_type(
  * \param [in] state_read_cb_data Context object passed to state_read_cb.
  * \param [in] opt_content_type Content-Type can be specified when you use data normalizer.
  * If you don't use data normalizer, set NULL.
+ * \param [in] opt_content_encoding Content-Encoding can be specified when you use data normalizer.
+ * If you don't use data normalizer, set NULL.
  * \param [in] opt_normalizer_host Specify data normalizer host.
  * If you don't use data normalizer, set NULL.
  * \return kii_code_t
@@ -627,6 +629,7 @@ kii_code_t kii_ti_put_state(
     KII_CB_READ state_read_cb,
     void* state_read_cb_data,
     const char* opt_content_type,
+    const char* opt_content_encoding,
     const char* opt_normalizer_host);
 
 /**
@@ -686,7 +689,7 @@ kii_code_t kii_ti_patch_bulk_states(
     const char* opt_content_type,
     const char* opt_normalizer_host);
 
-/** 
+/**
  * \brief Start making REST API call.
  *
  * Between this function and kii_api_call_run(kii_t*), you can call
@@ -1042,7 +1045,7 @@ void kii_set_cb_delay_ms(kii_t* kii, KII_CB_DELAY_MS cb_delay_ms, void* userdata
  */
 void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
 
-/** 
+/**
  * \brief Set JSON parser resource allocators.
  * To use Allocator instead of fixed size memory given by kii_set_json_parser_resource(kii_t, jkii_resource_t),
  * call kii_set_json_parser_resource(kii_t, jkii_resource_t) with NULL resource argument.

--- a/kii/include/kii.h
+++ b/kii/include/kii.h
@@ -619,7 +619,8 @@ kii_code_t kii_ti_put_thing_type(
  * \param [in] opt_content_type Content-Type can be specified when you use data normalizer.
  * If you don't use data normalizer, set NULL.
  * \param [in] opt_content_encoding Content-Encoding can be specified when you use data normalizer.
- * If you don't use data normalizer, set NULL.
+ * If you don't use data normalizer, set NULL. Please note that sdk doesn't encode the state.
+ * We expect app encodes state beforehand and encoded state is read from KII_CB_READ callback.
  * \param [in] opt_normalizer_host Specify data normalizer host.
  * If you don't use data normalizer, set NULL.
  * \return kii_code_t
@@ -641,7 +642,8 @@ kii_code_t kii_ti_put_state(
  * \param [in] opt_content_type Content-Type can be specified when you use data normalizer.
  * If you don't use data normalizer, set NULL.
  * \param [in] opt_content_encoding Content-Encoding can be specified when you use data normalizer.
- * If you don't use data normalizer, set NULL.
+ * If you don't use data normalizer, set NULL. Please note that sdk doesn't encode the state.
+ * We expect app encodes state beforehand and encoded state is read from KII_CB_READ callback.
  * \param [in] opt_normalizer_host Specify data normalizer host.
  * If you don't use data normalizer, set NULL.
  * \return kii_code_t
@@ -663,7 +665,8 @@ kii_code_t kii_ti_put_bulk_states(
  * \param [in] opt_content_type Content-Type can be specified when you use data normalizer.
  * If you don't use data normalizer, set NULL.
  * \param [in] opt_content_encoding Content-Encoding can be specified when you use data normalizer.
- * If you don't use data normalizer, set NULL.
+ * If you don't use data normalizer, set NULL. Please note that sdk doesn't encode the state.
+ * We expect app encodes state beforehand and encoded state is read from KII_CB_READ callback.
  * \param [in] opt_normalizer_host Specify data normalizer host.
  * If you don't use data normalizer, set NULL.
  * \return kii_code_t
@@ -685,7 +688,8 @@ kii_code_t kii_ti_patch_state(
  * \param [in] opt_content_type Content-Type can be specified when you use data normalizer.
  * If you don't use data normalizer, set NULL.
  * \param [in] opt_content_encoding Content-Encoding can be specified when you use data normalizer.
- * If you don't use data normalizer, set NULL.
+ * If you don't use data normalizer, set NULL. Please note that sdk doesn't encode the state.
+ * We expect app encodes state beforehand and encoded state is read from KII_CB_READ callback.
  * \param [in] opt_normalizer_host Specify data normalizer host.
  * If you don't use data normalizer, set NULL.
  * \return kii_code_t

--- a/kii/include/kii.h
+++ b/kii/include/kii.h
@@ -640,6 +640,8 @@ kii_code_t kii_ti_put_state(
  * \param [in] state_read_cb_data Context object passed to state_read_cb.
  * \param [in] opt_content_type Content-Type can be specified when you use data normalizer.
  * If you don't use data normalizer, set NULL.
+ * \param [in] opt_content_encoding Content-Encoding can be specified when you use data normalizer.
+ * If you don't use data normalizer, set NULL.
  * \param [in] opt_normalizer_host Specify data normalizer host.
  * If you don't use data normalizer, set NULL.
  * \return kii_code_t
@@ -649,6 +651,7 @@ kii_code_t kii_ti_put_bulk_states(
     KII_CB_READ state_read_cb,
     void* state_read_cb_data,
     const char* opt_content_type,
+    const char* opt_content_encoding,
     const char* opt_normalizer_host);
 
 /**
@@ -659,6 +662,8 @@ kii_code_t kii_ti_put_bulk_states(
  * \param [in] state_read_cb_data Context object passed to state_read_cb.
  * \param [in] opt_content_type Content-Type can be specified when you use data normalizer.
  * If you don't use data normalizer, set NULL.
+ * \param [in] opt_content_encoding Content-Encoding can be specified when you use data normalizer.
+ * If you don't use data normalizer, set NULL.
  * \param [in] opt_normalizer_host Specify data normalizer host.
  * If you don't use data normalizer, set NULL.
  * \return kii_code_t
@@ -668,6 +673,7 @@ kii_code_t kii_ti_patch_state(
     KII_CB_READ state_read_cb,
     void* state_read_cb_data,
     const char* opt_content_type,
+    const char* opt_content_encoding,
     const char* opt_normalizer_host);
 
 /**
@@ -678,6 +684,8 @@ kii_code_t kii_ti_patch_state(
  * \param [in] state_read_cb_data Context object passed to state_read_cb.
  * \param [in] opt_content_type Content-Type can be specified when you use data normalizer.
  * If you don't use data normalizer, set NULL.
+ * \param [in] opt_content_encoding Content-Encoding can be specified when you use data normalizer.
+ * If you don't use data normalizer, set NULL.
  * \param [in] opt_normalizer_host Specify data normalizer host.
  * If you don't use data normalizer, set NULL.
  * \return kii_code_t
@@ -687,6 +695,7 @@ kii_code_t kii_ti_patch_bulk_states(
     KII_CB_READ state_read_cb,
     void* state_read_cb_data,
     const char* opt_content_type,
+    const char* opt_content_encoding,
     const char* opt_normalizer_host);
 
 /**

--- a/kii/kii_req_impl.c
+++ b/kii/kii_req_impl.c
@@ -164,6 +164,22 @@ kii_code_t _set_content_type(
     return KII_ERR_OK;
 }
 
+kii_code_t _set_content_encoding(
+    kii_t* kii,
+    const char* content_encoding)
+{
+    int header_len = snprintf(kii->_rw_buff, kii->_rw_buff_size, "Content-Encoding: %s", content_encoding);
+    if (header_len >= kii->_rw_buff_size) {
+        return KII_ERR_TOO_LARGE_DATA;
+    }
+    khc_slist* list = khc_slist_append_using_cb_alloc(kii->_req_headers, kii->_rw_buff, header_len, kii->_cb_slist_alloc, kii->_slist_alloc_data);
+    if (list == NULL) {
+        return KII_ERR_ALLOCATION;
+    }
+    kii->_req_headers = list;
+    return KII_ERR_OK;
+}
+
 kii_code_t _set_object_content_type(
     kii_t* kii,
     const char* object_content_type)
@@ -321,6 +337,6 @@ kii_code_t _set_req_body(kii_t* kii, const char* body_contents)
         return KII_ERR_TOO_LARGE_DATA;
     }
     strncpy(kii->_rw_buff, body_contents, kii->_rw_buff_size);
-    
+
     return _set_content_length(kii, content_len);
 }

--- a/kii/kii_req_impl.h
+++ b/kii/kii_req_impl.h
@@ -38,6 +38,10 @@ kii_code_t _set_content_length(
     kii_t* kii,
     size_t content_length);
 
+kii_code_t _set_content_encoding(
+    kii_t* kii,
+    const char* content_encoding);
+
 kii_code_t _set_app_id_header(kii_t* kii);
 
 kii_code_t _set_app_key_header(kii_t* kii);

--- a/kii/kii_ti.c
+++ b/kii/kii_ti.c
@@ -54,3 +54,48 @@ kii_code_t kii_ti_put_state(
     }
     return _upload_state(kii, state_read_cb, state_read_cb_data, "states", "PUT", content_type, opt_content_encoding, opt_normalizer_host);
 }
+
+kii_code_t kii_ti_put_bulk_states(
+    kii_t* kii,
+    KII_CB_READ state_read_cb,
+    void* state_read_cb_data,
+    const char* opt_content_type,
+    const char* opt_content_encoding,
+    const char* opt_normalizer_host)
+{
+    const char* content_type = opt_content_type;
+    if (opt_content_type == NULL) {
+        content_type = "application/vnd.kii.StateBulkUploadRequest+json";
+    }
+    return _upload_state(kii, state_read_cb, state_read_cb_data, "states-bulk", "POST", content_type, opt_content_encoding, opt_normalizer_host);
+}
+
+kii_code_t kii_ti_patch_state(
+    kii_t* kii,
+    KII_CB_READ state_read_cb,
+    void* state_read_cb_data,
+    const char* opt_content_type,
+    const char* opt_content_encoding,
+    const char* opt_normalizer_host)
+{
+    const char* content_type = opt_content_type;
+    if (opt_content_type == NULL) {
+        content_type = "application/vnd.kii.MultipleTraitStatePatch+json";
+    }
+    return _upload_state(kii, state_read_cb, state_read_cb_data, "states", "PATCH", content_type, opt_content_encoding, opt_normalizer_host);
+}
+
+kii_code_t kii_ti_patch_bulk_states(
+    kii_t* kii,
+    KII_CB_READ state_read_cb,
+    void* state_read_cb_data,
+    const char* opt_content_type,
+    const char* opt_content_encoding,
+    const char* opt_normalizer_host)
+{
+    const char* content_type = opt_content_type;
+    if (opt_content_type == NULL) {
+        content_type = "application/vnd.kii.StatePatchBulkUploadRequest+json";
+    }
+    return _upload_state(kii, state_read_cb, state_read_cb_data, "states-bulk", "POST", content_type, opt_content_encoding, opt_normalizer_host);
+}

--- a/kii/kii_ti.c
+++ b/kii/kii_ti.c
@@ -45,11 +45,12 @@ kii_code_t kii_ti_put_state(
     KII_CB_READ state_read_cb,
     void* state_read_cb_data,
     const char* opt_content_type,
+    const char* opt_content_encoding,
     const char* opt_normalizer_host)
 {
     const char* content_type = opt_content_type;
     if (opt_content_type == NULL) {
         content_type = "application/vnd.kii.MultipleTraitState+json";
     }
-    return _upload_state(kii, state_read_cb, state_read_cb_data, "states", "PUT", content_type, opt_normalizer_host);
+    return _upload_state(kii, state_read_cb, state_read_cb_data, "states", "PUT", content_type, opt_content_encoding, opt_normalizer_host);
 }

--- a/kii/kii_ti_impl.c
+++ b/kii/kii_ti_impl.c
@@ -381,6 +381,7 @@ kii_code_t _upload_state(
         const char* last_path_segment,
         const char* method,
         const char* content_type,
+        const char* opt_content_encoding,
         const char* opt_normalizer_host)
 {
     kii_code_t ret = KII_ERR_FAIL;
@@ -410,6 +411,9 @@ kii_code_t _upload_state(
     if (ret != KII_ERR_OK) {
         _req_headers_free_all(kii);
         return ret;
+    }
+    if (opt_content_encoding != NULL) {
+        _set_content_encoding(kii, opt_content_encoding);
     }
 
     khc_set_req_headers(&kii->_khc, kii->_req_headers);

--- a/kii/kii_ti_impl.h
+++ b/kii/kii_ti_impl.h
@@ -36,6 +36,7 @@ kii_code_t _upload_state(
         const char* last_path_segment,
         const char* method,
         const char* content_type,
+        const char* opt_content_encoding,
         const char* opt_normalizer_host);
 
 #endif

--- a/tests/large_test/kii/ti_test.cpp
+++ b/tests/large_test/kii/ti_test.cpp
@@ -117,7 +117,7 @@ TEST_CASE("TI Tests")
             };
         kiiltest::RWFunc ctx;
         ctx.on_read = on_read;
-        res = kii_ti_put_state(&kii, kiiltest::read_cb, &ctx, "application/json", NULL);
+        res = kii_ti_put_state(&kii, kiiltest::read_cb, &ctx, "application/json", NULL, NULL);
 
         REQUIRE( res == KII_ERR_OK );
         REQUIRE( khc_get_status_code(&kii._khc) == 204 );

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -438,6 +438,7 @@ static void* _update_state(void* data) {
                     updater->_state_reader,
                     updater->_state_reader_data,
                     NULL,
+                    NULL,
                     NULL);
                 if (res != KII_ERR_OK) {
                     tio_code_t code = _tio_convert_code(res);


### PR DESCRIPTION
`Content-Encoding` header is required when upload compressed data to data normalizer, like `Content-Encoding: gzip`. 
In this PR, the following changes are performed:
- add `opt_content_encoding` parameter to `kii_put_state`
- add content_encoding handle logic
- add `opt_content_encoding` parameter to `kii_put_bulk_states`, `kii_patch_state` and `kii_patcth_bulk_states`
- implement `kii_put_bulk_states`, `kii_patch_state` and `kii_patcth_bulk_states`.