### PR TITLE
fix indent.

### DIFF
--- a/khc/include/khc.h
+++ b/khc/include/khc.h
@@ -56,8 +56,8 @@ typedef size_t (*KHC_CB_HEADER)(char *buffer, size_t size, void *userdata);
  * Linked list manages c string data.
  */
 typedef struct khc_slist {
-  char* data; /**< \brief Null terminated string */
-  struct khc_slist* next; /**< \brief Pointer to the next node. */
+    char* data; /**< \brief Null terminated string */
+    struct khc_slist* next; /**< \brief Pointer to the next node. */
 } khc_slist;
 
 /**
@@ -128,11 +128,11 @@ khc_slist* khc_slist_append(khc_slist* slist, const char* string, size_t length)
  * \returns pointer to the linked list (first node).
  */
 khc_slist* khc_slist_append_using_cb_alloc(
-  khc_slist* slist,
-  const char* string,
-  size_t length,
-  KHC_CB_SLIST_ALLOC cb_alloc,
-  void* cb_alloc_data);
+        khc_slist* slist,
+        const char* string,
+        size_t length,
+        KHC_CB_SLIST_ALLOC cb_alloc,
+        void* cb_alloc_data);
 
 /**
  * \brief Free memory used for the entire linked list.
@@ -153,9 +153,9 @@ void khc_slist_free_all(khc_slist* slist);
  * \param [in] cb_free_data context object pointer passed to cb_free.
  */
 void khc_slist_free_all_using_cb_free(
-  khc_slist* slist,
-  KHC_CB_SLIST_FREE cb_free,
-  void* cb_free_data);
+        khc_slist* slist,
+        KHC_CB_SLIST_FREE cb_free,
+        void* cb_free_data);
 
 /**
  * \brief Indicate state of khc.
@@ -163,67 +163,67 @@ void khc_slist_free_all_using_cb_free(
  * No need to reference state of khc to run HTTP session.
  */
 typedef enum khc_state {
-  KHC_STATE_IDLE,
-  KHC_STATE_CONNECT,
-  KHC_STATE_REQ_LINE,
-  KHC_STATE_REQ_HOST_HEADER,
-  KHC_STATE_REQ_HEADER,
-  KHC_STATE_REQ_HEADER_SEND,
-  KHC_STATE_REQ_HEADER_SEND_CRLF,
-  KHC_STATE_REQ_HEADER_END,
-  KHC_STATE_REQ_BODY_READ,
-  KHC_STATE_REQ_BODY_SEND_SIZE,
-  KHC_STATE_REQ_BODY_SEND,
-  KHC_STATE_REQ_BODY_SEND_CRLF,
+    KHC_STATE_IDLE,
+    KHC_STATE_CONNECT,
+    KHC_STATE_REQ_LINE,
+    KHC_STATE_REQ_HOST_HEADER,
+    KHC_STATE_REQ_HEADER,
+    KHC_STATE_REQ_HEADER_SEND,
+    KHC_STATE_REQ_HEADER_SEND_CRLF,
+    KHC_STATE_REQ_HEADER_END,
+    KHC_STATE_REQ_BODY_READ,
+    KHC_STATE_REQ_BODY_SEND_SIZE,
+    KHC_STATE_REQ_BODY_SEND,
+    KHC_STATE_REQ_BODY_SEND_CRLF,
 
-  KHC_STATE_RESP_STATUS_READ,
-  KHC_STATE_RESP_STATUS_PARSE,
-  KHC_STATE_RESP_HEADER_CALLBACK,
-  KHC_STATE_RESP_HEADER_READ,
-  KHC_STATE_RESP_HEADER_SKIP,
-  KHC_STATE_RESP_BODY_FRAGMENT,
-  KHC_STATE_READ_CHUNK_SIZE_FROM_HEADER_BUFF,
-  KHC_STATE_READ_CHUNK_BODY_FROM_HEADER_BUFF,
+    KHC_STATE_RESP_STATUS_READ,
+    KHC_STATE_RESP_STATUS_PARSE,
+    KHC_STATE_RESP_HEADER_CALLBACK,
+    KHC_STATE_RESP_HEADER_READ,
+    KHC_STATE_RESP_HEADER_SKIP,
+    KHC_STATE_RESP_BODY_FRAGMENT,
+    KHC_STATE_READ_CHUNK_SIZE_FROM_HEADER_BUFF,
+    KHC_STATE_READ_CHUNK_BODY_FROM_HEADER_BUFF,
 
-  /* Process fragment of body obtained when trying to find body boundary. */
-  KHC_STATE_RESP_BODY_READ,
-  KHC_STATE_RESP_BODY_CALLBACK,
+    /* Process fragment of body obtained when trying to find body boundary. */
+    KHC_STATE_RESP_BODY_READ,
+    KHC_STATE_RESP_BODY_CALLBACK,
 
-  KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE,
-  KHC_STATE_RESP_BODY_READ_CHUNK_SIZE,
-  KHC_STATE_RESP_BODY_PARSE_CHUNK_BODY,
-  KHC_STATE_RESP_BODY_READ_CHUNK_BODY,
-  KHC_STATE_RESP_BODY_SKIP_CHUNK_BODY_CRLF,
-  KHC_STATE_RESP_BODY_SKIP_TRAILERS,
+    KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE,
+    KHC_STATE_RESP_BODY_READ_CHUNK_SIZE,
+    KHC_STATE_RESP_BODY_PARSE_CHUNK_BODY,
+    KHC_STATE_RESP_BODY_READ_CHUNK_BODY,
+    KHC_STATE_RESP_BODY_SKIP_CHUNK_BODY_CRLF,
+    KHC_STATE_RESP_BODY_SKIP_TRAILERS,
 
-  KHC_STATE_CLOSE,
-  KHC_STATE_FINISHED,
+    KHC_STATE_CLOSE,
+    KHC_STATE_FINISHED,
 } khc_state;
 
 /**
  * \brief Error codes.
  */
 typedef enum khc_code {
-  /**< \brief Operation succeeded. */
-  KHC_ERR_OK,
-  /**< \brief Failure in connecting to server. */
-  KHC_ERR_SOCK_CONNECT,
-  /**< \brief Failure in closing connection. */
-  KHC_ERR_SOCK_CLOSE,
-  /**< \brief Failure in sending data. */
-  KHC_ERR_SOCK_SEND,
-  /**< \brief Failure in receiving data. */
-  KHC_ERR_SOCK_RECV,
-  /**< \brief Failure in handling response headers. */
-  KHC_ERR_HEADER_CALLBACK,
-  /**< \brief Failure in handling response body. */
-  KHC_ERR_WRITE_CALLBACK,
-  /**< \brief Memory allocation error. */
-  KHC_ERR_ALLOCATION,
-  /**< \brief Data is too large and doesn't fit to buffers statically allocated. */
-  KHC_ERR_TOO_LARGE_DATA,
-  /**< \brief Other errors. */
-  KHC_ERR_FAIL,
+    /**< \brief Operation succeeded. */
+    KHC_ERR_OK,
+    /**< \brief Failure in connecting to server. */
+    KHC_ERR_SOCK_CONNECT,
+    /**< \brief Failure in closing connection. */
+    KHC_ERR_SOCK_CLOSE,
+    /**< \brief Failure in sending data. */
+    KHC_ERR_SOCK_SEND,
+    /**< \brief Failure in receiving data. */
+    KHC_ERR_SOCK_RECV,
+    /**< \brief Failure in handling response headers. */
+    KHC_ERR_HEADER_CALLBACK,
+    /**< \brief Failure in handling response body. */
+    KHC_ERR_WRITE_CALLBACK,
+    /**< \brief Memory allocation error. */
+    KHC_ERR_ALLOCATION,
+    /**< \brief Data is too large and doesn't fit to buffers statically allocated. */
+    KHC_ERR_TOO_LARGE_DATA,
+    /**< \brief Other errors. */
+    KHC_ERR_FAIL,
 } khc_code;
 
 /**
@@ -234,72 +234,72 @@ typedef enum khc_code {
  * Do not reference/ change members directly.
  */
 typedef struct khc {
-  KHC_CB_WRITE _cb_write; /**< \private **/
-  void* _write_data; /**< \private **/
-  KHC_CB_READ _cb_read; /**< \private **/
-  void* _read_data; /**< \private **/
-  KHC_CB_HEADER _cb_header; /**< \private **/
-  void* _header_data; /**< \private **/
+    KHC_CB_WRITE _cb_write; /**< \private **/
+    void* _write_data; /**< \private **/
+    KHC_CB_READ _cb_read; /**< \private **/
+    void* _read_data; /**< \private **/
+    KHC_CB_HEADER _cb_header; /**< \private **/
+    void* _header_data; /**< \private **/
 
-  /** \private Request header list */
-  khc_slist* _req_headers;
+    /** \private Request header list */
+    khc_slist* _req_headers;
 
-  char _host[128]; /**< \private **/
-  char _path[256]; /**< \private **/
-  char _method[16]; /**< \private **/
+    char _host[128]; /**< \private **/
+    char _path[256]; /**< \private **/
+    char _method[16]; /**< \private **/
 
-  /* State machine */
-  khc_state _state; /**< \private **/
+    /* State machine */
+    khc_state _state; /**< \private **/
 
-  /* Socket functions. */
-  KHC_CB_SOCK_CONNECT _cb_sock_connect; /**< \private **/
-  KHC_CB_SOCK_SEND _cb_sock_send; /**< \private **/
-  KHC_CB_SOCK_RECV _cb_sock_recv; /**< \private **/
-  KHC_CB_SOCK_CLOSE _cb_sock_close; /**< \private **/
-  /* Socket context. */
-  void* _sock_ctx_connect; /**< \private **/
-  void* _sock_ctx_send; /**< \private **/
-  void* _sock_ctx_recv; /**< \private **/
-  void* _sock_ctx_close; /**< \private **/
+    /* Socket functions. */
+    KHC_CB_SOCK_CONNECT _cb_sock_connect; /**< \private **/
+    KHC_CB_SOCK_SEND _cb_sock_send; /**< \private **/
+    KHC_CB_SOCK_RECV _cb_sock_recv; /**< \private **/
+    KHC_CB_SOCK_CLOSE _cb_sock_close; /**< \private **/
+    /* Socket context. */
+    void* _sock_ctx_connect; /**< \private **/
+    void* _sock_ctx_send; /**< \private **/
+    void* _sock_ctx_recv; /**< \private **/
+    void* _sock_ctx_close; /**< \private **/
 
-  khc_slist* _current_req_header; /**< \private **/
+    khc_slist* _current_req_header; /**< \private **/
 
-  char* _stream_buff; /**< \private **/
-  size_t _stream_buff_size; /**< \private **/
-  int _stream_buff_allocated; /**< \private **/
+    char* _stream_buff; /**< \private **/
+    size_t _stream_buff_size; /**< \private **/
+    int _stream_buff_allocated; /**< \private **/
 
-  size_t _read_size; /**< \private **/
-  int _read_req_end; /**< \private **/
+    size_t _read_size; /**< \private **/
+    int _read_req_end; /**< \private **/
 
-  /* Response header buffer */
-  char* _resp_header_buff; /**< \private **/
-  size_t _resp_header_buff_size; /**< \private **/
-  int _resp_header_buff_allocated; /**< \private **/
+    /* Response header buffer */
+    char* _resp_header_buff; /**< \private **/
+    size_t _resp_header_buff_size; /**< \private **/
+    int _resp_header_buff_allocated; /**< \private **/
 
-  size_t _resp_header_read_size; /**< \private **/
+    size_t _resp_header_read_size; /**< \private **/
 
-  int _status_code; /**< \private **/
-  /* Pointer to the double CRLF boundary in the resp_header_buffer */
-  char* _body_boundary; /**< \private **/
+    int _status_code; /**< \private **/
+    /* Pointer to the double CRLF boundary in the resp_header_buffer */
+    char* _body_boundary; /**< \private **/
 
-  /* Header callback */
-  char* _cb_header_pos; /**< \private **/
-  /* Used to seek for CRFL effectively. */
-  size_t _cb_header_remaining_size; /**< \private **/
+    /* Header callback */
+    char* _cb_header_pos; /**< \private **/
+    /* Used to seek for CRFL effectively. */
+    size_t _cb_header_remaining_size; /**< \private **/
 
-  char* _body_fragment; /**< \private **/
-  size_t _body_fragment_size; /**< \private **/
-  int _chunked_resp; /**< \private **/
-  long _chunk_size; /**< \private **/
-  long _chunk_size_written; /**< \private **/
-  size_t _resp_content_length; /**< \private **/
-  int _read_end; /**< \private **/
+    char* _body_fragment; /**< \private **/
+    size_t _body_fragment_size; /**< \private **/
+    int _chunked_resp; /**< \private **/
+    long _chunk_size; /**< \private **/
+    long _chunk_size_written; /**< \private **/
+    size_t _resp_content_length; /**< \private **/
+    int _read_end; /**< \private **/
 
-  size_t _body_read_size; /**< \private **/
+    size_t _body_read_size; /**< \private **/
 
-  size_t _sent_length; /**< \private **/
+    size_t _sent_length; /**< \private **/
 
-  khc_code _result; /**< \private **/
+    khc_code _result; /**< \private **/
 } khc;
 
 /**
@@ -432,9 +432,9 @@ void khc_set_stream_buff(khc* khc, char* buffer, size_t buff_size);
  * \param [in] userdata context data of the callback.
  */
 khc_code khc_set_cb_sock_connect(
-  khc* khc,
-  KHC_CB_SOCK_CONNECT cb,
-  void* userdata);
+        khc* khc,
+        KHC_CB_SOCK_CONNECT cb,
+        void* userdata);
 
 /**
  * \brief Set socket send callback.
@@ -445,9 +445,9 @@ khc_code khc_set_cb_sock_connect(
  * \param [in] userdata context data of the callback.
  */
 khc_code khc_set_cb_sock_send(
-  khc* khc,
-  KHC_CB_SOCK_SEND cb,
-  void* userdata);
+        khc* khc,
+        KHC_CB_SOCK_SEND cb,
+        void* userdata);
 
 /**
  * \brief Set socket recv callback.
@@ -459,9 +459,9 @@ khc_code khc_set_cb_sock_send(
  * \param [in] userdata context data of the callback.
  */
 khc_code khc_set_cb_sock_recv(
-  khc* khc,
-  KHC_CB_SOCK_RECV cb,
-  void* userdata);
+        khc* khc,
+        KHC_CB_SOCK_RECV cb,
+        void* userdata);
 
 /**
  * \brief Set socket close callback.
@@ -472,9 +472,9 @@ khc_code khc_set_cb_sock_recv(
  * \param [in] userdata context data of the callback.
  */
 khc_code khc_set_cb_sock_close(
-  khc* khc,
-  KHC_CB_SOCK_CLOSE cb,
-  void* userdata);
+        khc* khc,
+        KHC_CB_SOCK_CLOSE cb,
+        void* userdata);
 
 /**
  * \brief Set read callback.
@@ -487,9 +487,9 @@ khc_code khc_set_cb_sock_close(
  * \param [in] userdata context data of the callback.
  */
 khc_code khc_set_cb_read(
-  khc* khc,
-  KHC_CB_READ cb,
-  void* userdata);
+        khc* khc,
+        KHC_CB_READ cb,
+        void* userdata);
 
 /**
  * \brief Set write callback.
@@ -501,9 +501,9 @@ khc_code khc_set_cb_read(
  * \param [in] userdata context data of the callback.
  */
 khc_code khc_set_cb_write(
-  khc* khc,
-  KHC_CB_WRITE cb,
-  void* userdata);
+        khc* khc,
+        KHC_CB_WRITE cb,
+        void* userdata);
 
 /**
  * \brief Set header callback.
@@ -515,9 +515,9 @@ khc_code khc_set_cb_write(
  * \param [in] userdata context data of the callback.
  */
 khc_code khc_set_cb_header(
-  khc* khc,
-  KHC_CB_HEADER cb,
-  void* userdata);
+        khc* khc,
+        KHC_CB_HEADER cb,
+        void* userdata);
 
 /**
  * \brief Get HTTP status code.
@@ -526,7 +526,7 @@ khc_code khc_set_cb_header(
  * \returns HTTP status code.
  */
 int khc_get_status_code(
-  khc* khc
+        khc* khc
 );
 
 #ifdef __cplusplus

--- a/khc/src/khc.c
+++ b/khc/src/khc.c
@@ -6,92 +6,92 @@
 #include "khc_socket_callback.h"
 
 void khc_set_resp_header_buff(khc* khc, char* buffer, size_t buff_size) {
-  khc->_resp_header_buff = buffer;
-  khc->_resp_header_buff_size = buff_size;
+    khc->_resp_header_buff = buffer;
+    khc->_resp_header_buff_size = buff_size;
 }
 
 void khc_set_stream_buff(khc* khc, char* buffer, size_t buff_size) {
-  khc->_stream_buff = buffer;
-  khc->_stream_buff_size = buff_size;
+    khc->_stream_buff = buffer;
+    khc->_stream_buff_size = buff_size;
 }
 
 khc_code khc_perform(khc* khc) {
-  khc->_state = KHC_STATE_IDLE;
-  while(khc->_state != KHC_STATE_FINISHED) {
-    state_handlers[khc->_state](khc);
-  }
-  khc_code res = khc->_result;
-  khc->_state = KHC_STATE_IDLE;
-  khc->_result = KHC_ERR_OK;
-  
-  return res;
+    khc->_state = KHC_STATE_IDLE;
+    while(khc->_state != KHC_STATE_FINISHED) {
+        state_handlers[khc->_state](khc);
+    }
+    khc_code res = khc->_result;
+    khc->_state = KHC_STATE_IDLE;
+    khc->_result = KHC_ERR_OK;
+
+    return res;
 }
 
 void khc_init(khc* khc) {
-  // Callbacks.
-  khc->_cb_write = NULL;
-  khc->_write_data = NULL;
+    // Callbacks.
+    khc->_cb_write = NULL;
+    khc->_write_data = NULL;
 
-  khc->_cb_header = NULL;
-  khc->_header_data = NULL;
+    khc->_cb_header = NULL;
+    khc->_header_data = NULL;
 
-  khc->_cb_read = NULL;
-  khc->_read_data = NULL;
+    khc->_cb_read = NULL;
+    khc->_read_data = NULL;
 
-  khc->_cb_sock_connect = NULL;
-  khc->_sock_ctx_connect = NULL;
+    khc->_cb_sock_connect = NULL;
+    khc->_sock_ctx_connect = NULL;
 
-  khc->_cb_sock_send = NULL;
-  khc->_sock_ctx_send = NULL;
+    khc->_cb_sock_send = NULL;
+    khc->_sock_ctx_send = NULL;
 
-  khc->_cb_sock_recv = NULL;
-  khc->_sock_ctx_recv = NULL;
+    khc->_cb_sock_recv = NULL;
+    khc->_sock_ctx_recv = NULL;
 
-  khc->_cb_sock_close = NULL;
-  khc->_sock_ctx_close = NULL;
+    khc->_cb_sock_close = NULL;
+    khc->_sock_ctx_close = NULL;
 
-  khc_reset_except_cb(khc);
+    khc_reset_except_cb(khc);
 }
 
 void khc_reset_except_cb(khc* khc) {
-  khc->_req_headers = NULL;
-  khc->_host[0] = '\0';
-  khc->_path[0] = '\0';
-  khc->_method[0] = '\0';
+    khc->_req_headers = NULL;
+    khc->_host[0] = '\0';
+    khc->_path[0] = '\0';
+    khc->_method[0] = '\0';
 
-  // Internal states.
-  khc->_state = KHC_STATE_IDLE;
-  khc->_current_req_header = NULL;
-  khc->_read_size = 0;
-  khc->_read_req_end = 0;
-  khc->_resp_header_read_size = 0;
-  khc->_status_code =0;
-  khc->_body_boundary = NULL;
-  khc->_cb_header_pos = NULL;
-  khc->_cb_header_remaining_size = 0;
-  khc->_body_fragment = NULL;
-  khc->_body_fragment_size = 0;
-  khc->_chunked_resp = 0;
-  khc->_chunk_size = 0;
-  khc->_chunk_size_written = 0;
-  khc->_resp_content_length = 0;
-  khc->_read_end = 0;
-  khc->_body_read_size = 0;
-  khc->_result = KHC_ERR_OK;
-  khc->_sent_length = 0;
+    // Internal states.
+    khc->_state = KHC_STATE_IDLE;
+    khc->_current_req_header = NULL;
+    khc->_read_size = 0;
+    khc->_read_req_end = 0;
+    khc->_resp_header_read_size = 0;
+    khc->_status_code =0;
+    khc->_body_boundary = NULL;
+    khc->_cb_header_pos = NULL;
+    khc->_cb_header_remaining_size = 0;
+    khc->_body_fragment = NULL;
+    khc->_body_fragment_size = 0;
+    khc->_chunked_resp = 0;
+    khc->_chunk_size = 0;
+    khc->_chunk_size_written = 0;
+    khc->_resp_content_length = 0;
+    khc->_read_end = 0;
+    khc->_body_read_size = 0;
+    khc->_result = KHC_ERR_OK;
+    khc->_sent_length = 0;
 
-  // Response header Buffer
-  khc->_resp_header_buff = NULL;
-  khc->_resp_header_buff_size = 0;
-  khc->_resp_header_buff_allocated = 0;
-  // Stream Buffer
-  khc->_stream_buff = NULL;
-  khc->_stream_buff_size = 0;
-  khc->_stream_buff_allocated = 0;
+    // Response header Buffer
+    khc->_resp_header_buff = NULL;
+    khc->_resp_header_buff_size = 0;
+    khc->_resp_header_buff_allocated = 0;
+    // Stream Buffer
+    khc->_stream_buff = NULL;
+    khc->_stream_buff_size = 0;
+    khc->_stream_buff_allocated = 0;
 }
 
 int khc_get_status_code(
-  khc* khc
+        khc* khc
 ) {
-  return khc->_status_code;
+    return khc->_status_code;
 }

--- a/khc/src/khc_slist.c
+++ b/khc/src/khc_slist.c
@@ -3,68 +3,68 @@
 #include "khc.h"
 
 khc_slist* khc_cb_slist_alloc(const char* str, size_t str_len, void* data) {
-  char* copy = malloc(str_len+1);
-  if (copy == NULL) {
-    return NULL;
-  }
-  khc_slist* node = malloc(sizeof(khc_slist));
-  if (node == NULL) {
-    free(copy);
-    return NULL;
-  }
-  strncpy(copy, str, str_len);
-  copy[str_len] = '\0';
-  node->data = copy;
-  node->next = NULL;
-  return node;
+    char* copy = malloc(str_len+1);
+    if (copy == NULL) {
+        return NULL;
+    }
+    khc_slist* node = malloc(sizeof(khc_slist));
+    if (node == NULL) {
+        free(copy);
+        return NULL;
+    }
+    strncpy(copy, str, str_len);
+    copy[str_len] = '\0';
+    node->data = copy;
+    node->next = NULL;
+    return node;
 }
 
 void khc_cb_slist_free(khc_slist* slist, void* data) {
-  free(slist->data);
-  free(slist);
+    free(slist->data);
+    free(slist);
 }
 
 khc_slist* khc_slist_append(khc_slist* slist, const char* string, size_t length) {
-  return khc_slist_append_using_cb_alloc(slist, string, length, khc_cb_slist_alloc, NULL);
+    return khc_slist_append_using_cb_alloc(slist, string, length, khc_cb_slist_alloc, NULL);
 }
 
 khc_slist* khc_slist_append_using_cb_alloc(
-  khc_slist* slist,
-  const char* string,
-  size_t length,
-  KHC_CB_SLIST_ALLOC cb_alloc,
-  void* cb_alloc_data) {
-  khc_slist* next;
-  next = cb_alloc(string, length, cb_alloc_data);
-  if (next == NULL) {
-    return NULL;
-  }
-  next->next = NULL;
+        khc_slist* slist,
+        const char* string,
+        size_t length,
+        KHC_CB_SLIST_ALLOC cb_alloc,
+        void* cb_alloc_data) {
+    khc_slist* next;
+    next = cb_alloc(string, length, cb_alloc_data);
+    if (next == NULL) {
+        return NULL;
+    }
+    next->next = NULL;
 
-  if (slist == NULL) {
-    return next;
-  }
-  khc_slist* end = slist;
-  while (end->next != NULL) {
-    end = end->next;
-  }
-  end->next = next;
-  return slist;
+    if (slist == NULL) {
+        return next;
+    }
+    khc_slist* end = slist;
+    while (end->next != NULL) {
+        end = end->next;
+    }
+    end->next = next;
+    return slist;
 }
 
 void khc_slist_free_all(khc_slist* slist) {
-  khc_slist_free_all_using_cb_free(slist, khc_cb_slist_free, NULL);
+    khc_slist_free_all_using_cb_free(slist, khc_cb_slist_free, NULL);
 }
 
 void khc_slist_free_all_using_cb_free(
-  khc_slist* slist,
-  KHC_CB_SLIST_FREE cb_free,
-  void* cb_free_data) {
-  khc_slist *curr;
-  curr = slist;
-  while (curr != NULL) {
-    khc_slist *next = curr->next;
-    cb_free(curr, cb_free_data);
-    curr = next;
-  }
+        khc_slist* slist,
+        KHC_CB_SLIST_FREE cb_free,
+        void* cb_free_data) {
+    khc_slist *curr;
+    curr = slist;
+    while (curr != NULL) {
+        khc_slist *next = curr->next;
+        cb_free(curr, cb_free_data);
+        curr = next;
+    }
 }

--- a/khc/src/khc_state_impl.c
+++ b/khc/src/khc_state_impl.c
@@ -7,970 +7,970 @@
 #include "khc_state_impl.h"
 
 khc_code khc_set_cb_sock_connect(
-  khc* khc,
-  KHC_CB_SOCK_CONNECT cb,
-  void* userdata)
+        khc* khc,
+        KHC_CB_SOCK_CONNECT cb,
+        void* userdata)
 {
-  khc->_cb_sock_connect = cb;
-  khc->_sock_ctx_connect = userdata;
-  return KHC_ERR_OK;
+    khc->_cb_sock_connect = cb;
+    khc->_sock_ctx_connect = userdata;
+    return KHC_ERR_OK;
 }
 
 khc_code khc_set_cb_sock_send(
-  khc* khc,
-  KHC_CB_SOCK_SEND cb,
-  void* userdata)
+        khc* khc,
+        KHC_CB_SOCK_SEND cb,
+        void* userdata)
 {
-  khc->_cb_sock_send = cb;
-  khc->_sock_ctx_send = userdata;
-  return KHC_ERR_OK;
+    khc->_cb_sock_send = cb;
+    khc->_sock_ctx_send = userdata;
+    return KHC_ERR_OK;
 }
 
 khc_code khc_set_cb_sock_recv(
-  khc* khc,
-  KHC_CB_SOCK_RECV cb,
-  void* userdata)
+        khc* khc,
+        KHC_CB_SOCK_RECV cb,
+        void* userdata)
 {
-  khc->_cb_sock_recv = cb;
-  khc->_sock_ctx_recv = userdata;
-  return KHC_ERR_OK;
+    khc->_cb_sock_recv = cb;
+    khc->_sock_ctx_recv = userdata;
+    return KHC_ERR_OK;
 }
 
 khc_code khc_set_cb_sock_close(
-  khc* khc,
-  KHC_CB_SOCK_CLOSE cb,
-  void* userdata)
+        khc* khc,
+        KHC_CB_SOCK_CLOSE cb,
+        void* userdata)
 {
-  khc->_cb_sock_close = cb;
-  khc->_sock_ctx_close = userdata;
-  return KHC_ERR_OK;
+    khc->_cb_sock_close = cb;
+    khc->_sock_ctx_close = userdata;
+    return KHC_ERR_OK;
 }
 
 khc_code khc_set_cb_read(
-  khc* khc,
-  KHC_CB_READ cb,
-  void* userdata)
+        khc* khc,
+        KHC_CB_READ cb,
+        void* userdata)
 {
-  khc->_cb_read = cb;
-  khc->_read_data = userdata;
-  return KHC_ERR_OK;
+    khc->_cb_read = cb;
+    khc->_read_data = userdata;
+    return KHC_ERR_OK;
 }
 
 khc_code khc_set_cb_write(
-  khc* khc,
-  KHC_CB_WRITE cb,
-  void* userdata)
+        khc* khc,
+        KHC_CB_WRITE cb,
+        void* userdata)
 {
-  khc->_cb_write = cb;
-  khc->_write_data = userdata;
-  return KHC_ERR_OK;
+    khc->_cb_write = cb;
+    khc->_write_data = userdata;
+    return KHC_ERR_OK;
 }
 
 khc_code khc_set_cb_header(
-  khc* khc,
-  KHC_CB_HEADER cb,
-  void* userdata)
+        khc* khc,
+        KHC_CB_HEADER cb,
+        void* userdata)
 {
-  khc->_cb_header = cb;
-  khc->_header_data = userdata;
-  return KHC_ERR_OK;
+    khc->_cb_header = cb;
+    khc->_header_data = userdata;
+    return KHC_ERR_OK;
 }
 
 khc_code khc_set_host(khc* khc, const char* host) {
-  size_t len = strlen(host);
-  size_t buff_len = sizeof(khc->_host);
-  if (buff_len < len + 1) {
-    return KHC_ERR_TOO_LARGE_DATA;
-  }
-  memcpy(khc->_host, host, len + 1);
-  return KHC_ERR_OK;
+    size_t len = strlen(host);
+    size_t buff_len = sizeof(khc->_host);
+    if (buff_len < len + 1) {
+        return KHC_ERR_TOO_LARGE_DATA;
+    }
+    memcpy(khc->_host, host, len + 1);
+    return KHC_ERR_OK;
 }
 
 khc_code khc_set_path(khc* khc, const char* path) {
-  size_t len = strlen(path);
-  size_t buff_len = sizeof(khc->_path);
-  if (buff_len < len + 1) {
-    return KHC_ERR_TOO_LARGE_DATA;
-  }
-  memcpy(khc->_path, path, len + 1);
-  return KHC_ERR_OK;
+    size_t len = strlen(path);
+    size_t buff_len = sizeof(khc->_path);
+    if (buff_len < len + 1) {
+        return KHC_ERR_TOO_LARGE_DATA;
+    }
+    memcpy(khc->_path, path, len + 1);
+    return KHC_ERR_OK;
 }
 
 khc_code khc_set_method(khc* khc, const char* method) {
-  size_t len = strlen(method);
-  size_t buff_len = sizeof(khc->_method);
-  if (buff_len < len + 1) {
-    return KHC_ERR_TOO_LARGE_DATA;
-  }
-  memcpy(khc->_method, method, len + 1);
-  return KHC_ERR_OK;
+    size_t len = strlen(method);
+    size_t buff_len = sizeof(khc->_method);
+    if (buff_len < len + 1) {
+        return KHC_ERR_TOO_LARGE_DATA;
+    }
+    memcpy(khc->_method, method, len + 1);
+    return KHC_ERR_OK;
 }
 
 khc_code khc_set_req_headers(khc* khc, khc_slist* headers) {
-  khc->_req_headers = headers;
-  return KHC_ERR_OK;
+    khc->_req_headers = headers;
+    return KHC_ERR_OK;
 }
 
 void khc_state_idle(khc* khc) {
-  if (strlen(khc->_host) == 0) {
-    // Fallback to localhost
-    strncpy(khc->_host, "localhost", sizeof(khc->_host));
-  }
-  if (strlen(khc->_method) == 0) {
-    // Fallback to GET.
-    strncpy(khc->_method, "GET", sizeof(khc->_method));
-  }
-  if (khc->_resp_header_buff == NULL) {
-    char* buff = malloc(DEFAULT_RESP_HEADER_BUFF_SIZE);
-    if (buff == NULL) {
-      khc->_state = KHC_STATE_FINISHED;
-      khc->_result = KHC_ERR_ALLOCATION;
-      return;
+    if (strlen(khc->_host) == 0) {
+        // Fallback to localhost
+        strncpy(khc->_host, "localhost", sizeof(khc->_host));
     }
-    khc->_resp_header_buff = buff;
-    khc->_resp_header_buff_allocated = 1;
-    khc->_resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
-  }
-  if (khc->_stream_buff == NULL) {
-    char* buff = malloc(DEFAULT_STREAM_BUFF_SIZE);
-    if (buff == NULL) {
-      khc->_state = KHC_STATE_FINISHED;
-      khc->_result = KHC_ERR_ALLOCATION;
-      return;
+    if (strlen(khc->_method) == 0) {
+        // Fallback to GET.
+        strncpy(khc->_method, "GET", sizeof(khc->_method));
     }
-    khc->_stream_buff = buff;
-    khc->_stream_buff_allocated = 1;
-    khc->_stream_buff_size = DEFAULT_STREAM_BUFF_SIZE;
-  }
-  khc->_state = KHC_STATE_CONNECT;
-  return;
+    if (khc->_resp_header_buff == NULL) {
+        char* buff = malloc(DEFAULT_RESP_HEADER_BUFF_SIZE);
+        if (buff == NULL) {
+            khc->_state = KHC_STATE_FINISHED;
+            khc->_result = KHC_ERR_ALLOCATION;
+            return;
+        }
+        khc->_resp_header_buff = buff;
+        khc->_resp_header_buff_allocated = 1;
+        khc->_resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
+    }
+    if (khc->_stream_buff == NULL) {
+        char* buff = malloc(DEFAULT_STREAM_BUFF_SIZE);
+        if (buff == NULL) {
+            khc->_state = KHC_STATE_FINISHED;
+            khc->_result = KHC_ERR_ALLOCATION;
+            return;
+        }
+        khc->_stream_buff = buff;
+        khc->_stream_buff_allocated = 1;
+        khc->_stream_buff_size = DEFAULT_STREAM_BUFF_SIZE;
+    }
+    khc->_state = KHC_STATE_CONNECT;
+    return;
 }
 
 void khc_state_connect(khc* khc) {
-  khc_sock_code_t con_res = khc->_cb_sock_connect(khc->_sock_ctx_connect, khc->_host, 443);
-  if (con_res == KHC_SOCK_OK) {
-    khc->_sent_length = 0;
-    khc->_state = KHC_STATE_REQ_LINE;
-    return;
-  }
-  if (con_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (con_res == KHC_SOCK_FAIL) {
-    khc->_result = KHC_ERR_SOCK_CONNECT;
-    khc->_state = KHC_STATE_FINISHED;
-    return;
-  }
+    khc_sock_code_t con_res = khc->_cb_sock_connect(khc->_sock_ctx_connect, khc->_host, 443);
+    if (con_res == KHC_SOCK_OK) {
+        khc->_sent_length = 0;
+        khc->_state = KHC_STATE_REQ_LINE;
+        return;
+    }
+    if (con_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (con_res == KHC_SOCK_FAIL) {
+        khc->_result = KHC_ERR_SOCK_CONNECT;
+        khc->_state = KHC_STATE_FINISHED;
+        return;
+    }
 }
 
 static const char schema[] = "https://";
 static const char http_version[] = "HTTP/1.1\r\n";
 
 static size_t request_line_len(khc* khc) {
-  char* method = khc->_method;
-  char* host = khc->_host;
-  // Path must be started with '/'
-  char* path = khc->_path;
+    char* method = khc->_method;
+    char* host = khc->_host;
+    // Path must be started with '/'
+    char* path = khc->_path;
 
-  return ( // example)GET https://api.khc.com/v1/users HTTP1.1\r\n
-    strlen(method) + 1
-    + strlen(schema) + strlen(host) + strlen(path) + 1
-    + strlen(http_version)
-  );
+    return ( // example)GET https://api.khc.com/v1/users HTTP1.1\r\n
+        strlen(method) + 1
+        + strlen(schema) + strlen(host) + strlen(path) + 1
+        + strlen(http_version)
+        );
 }
 
 void khc_state_req_line(khc* khc) {
-  size_t len = request_line_len(khc);
-  char request_line[len+1];
-  char* host = khc->_host;
-  char* path = khc->_path;
+    size_t len = request_line_len(khc);
+    char request_line[len+1];
+    char* host = khc->_host;
+    char* path = khc->_path;
 
-  request_line[0] = '\0';
-  strcat(request_line, khc->_method);
-  strcat(request_line, " ");
-  strcat(request_line, schema);
-  strcat(request_line, host);
-  strcat(request_line, path);
-  strcat(request_line, " ");
-  strcat(request_line, http_version);
-  char* send_pos = &request_line[khc->_sent_length];
-  size_t send_len = strlen(send_pos);
-  size_t sent_len = 0;
-  khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
-  if (send_res == KHC_SOCK_OK) {
-    if (sent_len < send_len) {
-      khc->_sent_length += sent_len;
-      // retry.
-      return;
-    } else {
-      khc->_sent_length = 0;
+    request_line[0] = '\0';
+    strcat(request_line, khc->_method);
+    strcat(request_line, " ");
+    strcat(request_line, schema);
+    strcat(request_line, host);
+    strcat(request_line, path);
+    strcat(request_line, " ");
+    strcat(request_line, http_version);
+    char* send_pos = &request_line[khc->_sent_length];
+    size_t send_len = strlen(send_pos);
+    size_t sent_len = 0;
+    khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
+    if (send_res == KHC_SOCK_OK) {
+        if (sent_len < send_len) {
+            khc->_sent_length += sent_len;
+            // retry.
+            return;
+        } else {
+            khc->_sent_length = 0;
+        }
+        khc->_state = KHC_STATE_REQ_HOST_HEADER;
+        return;
     }
-    khc->_state = KHC_STATE_REQ_HOST_HEADER;
-    return;
-  }
-  if (send_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (send_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_SEND;
-    return;
-  }
+    if (send_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (send_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_SEND;
+        return;
+    }
 }
 
 void khc_state_req_host_header(khc* khc) {
-  const char hdr_key[] = "HOST: ";
-  size_t hdr_len = strlen(hdr_key) + strlen(khc->_host) + 2;
-  char buff[hdr_len + 1];
-  snprintf(buff, hdr_len + 1, "%s%s\r\n", hdr_key, khc->_host);
-  char* send_pos = &buff[khc->_sent_length];
-  size_t send_len = strlen(send_pos);
-  size_t sent_len = 0;
-  khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
-  if (send_res == KHC_SOCK_OK) {
-    if (sent_len < send_len) {
-      khc->_sent_length += sent_len;
-      // retry.
-      return;
-    } else {
-      khc->_sent_length = 0;
+    const char hdr_key[] = "HOST: ";
+    size_t hdr_len = strlen(hdr_key) + strlen(khc->_host) + 2;
+    char buff[hdr_len + 1];
+    snprintf(buff, hdr_len + 1, "%s%s\r\n", hdr_key, khc->_host);
+    char* send_pos = &buff[khc->_sent_length];
+    size_t send_len = strlen(send_pos);
+    size_t sent_len = 0;
+    khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
+    if (send_res == KHC_SOCK_OK) {
+        if (sent_len < send_len) {
+            khc->_sent_length += sent_len;
+            // retry.
+            return;
+        } else {
+            khc->_sent_length = 0;
+        }
+        khc->_state = KHC_STATE_REQ_HEADER;
+        khc->_current_req_header = khc->_req_headers;
+        return;
     }
-    khc->_state = KHC_STATE_REQ_HEADER;
-    khc->_current_req_header = khc->_req_headers;
-    return;
-  }
-  if (send_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (send_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_SEND;
-    return;
-  }
+    if (send_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (send_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_SEND;
+        return;
+    }
 }
 
 void khc_state_req_header(khc* khc) {
-  if (khc->_current_req_header == NULL) {
-    khc->_state = KHC_STATE_REQ_HEADER_END;
-    return;
-  }
-  char* data = khc->_current_req_header->data;
-  if (data == NULL) {
-    // Skip if data is NULL.
-    khc->_current_req_header = khc->_current_req_header->next;
-    return;
-  }
-  size_t len = strlen(data);
-  if (len == 0) {
-    // Skip if nothing to send.
-    khc->_current_req_header = khc->_current_req_header->next;
-    return;
-  }
-  khc->_state = KHC_STATE_REQ_HEADER_SEND;
+    if (khc->_current_req_header == NULL) {
+        khc->_state = KHC_STATE_REQ_HEADER_END;
+        return;
+    }
+    char* data = khc->_current_req_header->data;
+    if (data == NULL) {
+        // Skip if data is NULL.
+        khc->_current_req_header = khc->_current_req_header->next;
+        return;
+    }
+    size_t len = strlen(data);
+    if (len == 0) {
+        // Skip if nothing to send.
+        khc->_current_req_header = khc->_current_req_header->next;
+        return;
+    }
+    khc->_state = KHC_STATE_REQ_HEADER_SEND;
 }
 
 void khc_state_req_header_send(khc* khc) {
-  char* line = khc->_current_req_header->data;
-  char* send_pos = &line[khc->_sent_length];
-  size_t send_len = strlen(send_pos);
-  size_t sent_len = 0;
-  khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
-  if (send_res == KHC_SOCK_OK) {
-    if (sent_len < send_len) {
-      khc->_sent_length += sent_len;
-      // retry.
-      return;
-    } else {
-      khc->_sent_length = 0;
+    char* line = khc->_current_req_header->data;
+    char* send_pos = &line[khc->_sent_length];
+    size_t send_len = strlen(send_pos);
+    size_t sent_len = 0;
+    khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
+    if (send_res == KHC_SOCK_OK) {
+        if (sent_len < send_len) {
+            khc->_sent_length += sent_len;
+            // retry.
+            return;
+        } else {
+            khc->_sent_length = 0;
+        }
+        khc->_state = KHC_STATE_REQ_HEADER_SEND_CRLF;
+        return;
     }
-    khc->_state = KHC_STATE_REQ_HEADER_SEND_CRLF;
-    return;
-  }
-  if (send_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (send_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_SEND;
-    return;
-  } 
+    if (send_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (send_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_SEND;
+        return;
+    }
 }
 
 void khc_state_req_header_send_crlf(khc* khc) {
-  char crlf[] = "\r\n";
-  char* send_pos = &crlf[khc->_sent_length];
-  size_t send_len = strlen(send_pos);
-  size_t sent_len = 0;
-  khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
-  if (send_res == KHC_SOCK_OK) {
-    if (sent_len < send_len) {
-      khc->_sent_length += sent_len;
-      // retry.
-      return;
-    } else {
-      khc->_sent_length = 0;
+    char crlf[] = "\r\n";
+    char* send_pos = &crlf[khc->_sent_length];
+    size_t send_len = strlen(send_pos);
+    size_t sent_len = 0;
+    khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
+    if (send_res == KHC_SOCK_OK) {
+        if (sent_len < send_len) {
+            khc->_sent_length += sent_len;
+            // retry.
+            return;
+        } else {
+            khc->_sent_length = 0;
+        }
+        khc->_current_req_header = khc->_current_req_header->next;
+        khc->_state = KHC_STATE_REQ_HEADER;
+        return;
     }
-    khc->_current_req_header = khc->_current_req_header->next;
-    khc->_state = KHC_STATE_REQ_HEADER;
-    return;
-  }
-  if (send_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (send_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_SEND;
-    return;
-  } 
+    if (send_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (send_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_SEND;
+        return;
+    }
 }
 
 void khc_state_req_header_end(khc* khc) {
-  char* text = NULL;
-  if (khc->_cb_read == NULL) {
-    text = "Content-Length: 0\r\nConnection: Close\r\n\r\n";
-  } else {
-    text = "Transfer-Encoding: chunked\r\nConnection: Close\r\n\r\n";
-  }
-  char* send_pos = &text[khc->_sent_length];
-  size_t send_len = strlen(send_pos);
-  size_t sent_len = 0;
-  khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
-  if (send_res == KHC_SOCK_OK) {
-    if (sent_len < send_len) {
-      khc->_sent_length += sent_len;
-      // retry.
-      return;
+    char* text = NULL;
+    if (khc->_cb_read == NULL) {
+        text = "Content-Length: 0\r\nConnection: Close\r\n\r\n";
     } else {
-      khc->_sent_length = 0;
+        text = "Transfer-Encoding: chunked\r\nConnection: Close\r\n\r\n";
     }
-    if (khc->_cb_read != NULL) {
-      khc->_state = KHC_STATE_REQ_BODY_READ;
-    } else {
-      khc->_resp_header_read_size = 0;
-      khc->_state = KHC_STATE_RESP_STATUS_READ;
+    char* send_pos = &text[khc->_sent_length];
+    size_t send_len = strlen(send_pos);
+    size_t sent_len = 0;
+    khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
+    if (send_res == KHC_SOCK_OK) {
+        if (sent_len < send_len) {
+            khc->_sent_length += sent_len;
+            // retry.
+            return;
+        } else {
+            khc->_sent_length = 0;
+        }
+        if (khc->_cb_read != NULL) {
+            khc->_state = KHC_STATE_REQ_BODY_READ;
+        } else {
+            khc->_resp_header_read_size = 0;
+            khc->_state = KHC_STATE_RESP_STATUS_READ;
+        }
+        khc->_read_req_end = 0;
+        return;
     }
-    khc->_read_req_end = 0;
-    return;
-  }
-  if (send_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (send_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_SEND;
-    return;
-  }
+    if (send_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (send_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_SEND;
+        return;
+    }
 }
 
 void khc_state_req_body_read(khc* khc) {
-  khc->_read_size = khc->_cb_read(khc->_stream_buff, khc->_stream_buff_size, khc->_read_data);
-  if (khc->_read_size == 0) {
-    khc->_read_req_end = 1;
-  }
-  khc->_state = KHC_STATE_REQ_BODY_SEND_SIZE;
-  return;
+    khc->_read_size = khc->_cb_read(khc->_stream_buff, khc->_stream_buff_size, khc->_read_data);
+    if (khc->_read_size == 0) {
+        khc->_read_req_end = 1;
+    }
+    khc->_state = KHC_STATE_REQ_BODY_SEND_SIZE;
+    return;
 }
 
 void khc_state_req_body_send_size(khc* khc) {
-  char size_buff[16];
-  int size_len = snprintf(size_buff, 15, "%lx\r\n", khc->_read_size);
-  if (size_len > 15) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_TOO_LARGE_DATA;
-    return;
-  }
-  char* send_pos = &size_buff[khc->_sent_length];
-  size_t send_len = strlen(send_pos);
-  size_t sent_len = 0;
-  khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
-  if (send_res == KHC_SOCK_OK) {
-    if (sent_len < send_len) {
-      khc->_sent_length += sent_len;
-      // retry.
-      return;
-    } else {
-      khc->_sent_length = 0;
+    char size_buff[16];
+    int size_len = snprintf(size_buff, 15, "%lx\r\n", khc->_read_size);
+    if (size_len > 15) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_TOO_LARGE_DATA;
+        return;
     }
-    if (khc->_read_req_end == 1) {
-      khc->_state = KHC_STATE_REQ_BODY_SEND_CRLF;
-    } else {
-      khc->_state = KHC_STATE_REQ_BODY_SEND;
+    char* send_pos = &size_buff[khc->_sent_length];
+    size_t send_len = strlen(send_pos);
+    size_t sent_len = 0;
+    khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
+    if (send_res == KHC_SOCK_OK) {
+        if (sent_len < send_len) {
+            khc->_sent_length += sent_len;
+            // retry.
+            return;
+        } else {
+            khc->_sent_length = 0;
+        }
+        if (khc->_read_req_end == 1) {
+            khc->_state = KHC_STATE_REQ_BODY_SEND_CRLF;
+        } else {
+            khc->_state = KHC_STATE_REQ_BODY_SEND;
+        }
+        return;
     }
-    return;
-  }
-  if (send_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (send_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_SEND;
-    return;
-  }
+    if (send_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (send_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_SEND;
+        return;
+    }
 }
 
 void khc_state_req_body_send(khc* khc) {
-  char* send_pos = &khc->_stream_buff[khc->_sent_length];
-  size_t send_len = khc->_read_size - khc->_sent_length;
-  size_t sent_len = 0;
-  khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
-  if (send_res == KHC_SOCK_OK) {
-    if (sent_len < send_len) {
-      khc->_sent_length += sent_len;
-      // retry.
-      return;
-    } else {
-      khc->_sent_length = 0;
+    char* send_pos = &khc->_stream_buff[khc->_sent_length];
+    size_t send_len = khc->_read_size - khc->_sent_length;
+    size_t sent_len = 0;
+    khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
+    if (send_res == KHC_SOCK_OK) {
+        if (sent_len < send_len) {
+            khc->_sent_length += sent_len;
+            // retry.
+            return;
+        } else {
+            khc->_sent_length = 0;
+        }
+        khc->_state = KHC_STATE_REQ_BODY_SEND_CRLF;
+        return;
     }
-    khc->_state = KHC_STATE_REQ_BODY_SEND_CRLF;
-    return;
-  }
-  if (send_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (send_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_SEND;
-    return;
-  }
+    if (send_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (send_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_SEND;
+        return;
+    }
 }
 
 void khc_state_req_body_send_crlf(khc* khc) {
-  char crlf[] = "\r\n";
-  char* send_pos = &crlf[khc->_sent_length];
-  size_t send_len = strlen(send_pos);
-  size_t sent_len = 0;
-  khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
-  if (send_res == KHC_SOCK_OK) {
-    if (sent_len < send_len) {
-      khc->_sent_length += sent_len;
-      // retry.
-      return;
-    } else {
-      khc->_sent_length = 0;
+    char crlf[] = "\r\n";
+    char* send_pos = &crlf[khc->_sent_length];
+    size_t send_len = strlen(send_pos);
+    size_t sent_len = 0;
+    khc_sock_code_t send_res = khc->_cb_sock_send(khc->_sock_ctx_send, send_pos, send_len, &sent_len);
+    if (send_res == KHC_SOCK_OK) {
+        if (sent_len < send_len) {
+            khc->_sent_length += sent_len;
+            // retry.
+            return;
+        } else {
+            khc->_sent_length = 0;
+        }
+        if (khc->_read_req_end == 1) {
+            khc->_resp_header_read_size = 0;
+            khc->_state = KHC_STATE_RESP_STATUS_READ;
+        } else {
+            khc->_state = KHC_STATE_REQ_BODY_READ;
+        }
+        return;
     }
-    if (khc->_read_req_end == 1) {
-      khc->_resp_header_read_size = 0;
-      khc->_state = KHC_STATE_RESP_STATUS_READ;
-    } else {
-      khc->_state = KHC_STATE_REQ_BODY_READ;
+    if (send_res == KHC_SOCK_AGAIN) {
+        return;
     }
-    return;
-  }
-  if (send_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (send_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_SEND;
-    return;
-  }
+    if (send_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_SEND;
+        return;
+    }
 }
 
 void khc_state_resp_status_read(khc* khc) {
-  size_t read_size = 0;
-  size_t read_req_size = khc->_resp_header_buff_size - khc->_resp_header_read_size - 1;
-  khc_sock_code_t read_res = 
-    khc->_cb_sock_recv(khc->_sock_ctx_recv, &khc->_resp_header_buff[khc->_resp_header_read_size], read_req_size, &read_size);
-  if (read_res == KHC_SOCK_OK) {
-    khc->_resp_header_read_size += read_size;
-    khc->_resp_header_buff[khc->_resp_header_read_size] = '\0';
-    if (read_size == 0) {
-      khc->_read_end = 1;
+    size_t read_size = 0;
+    size_t read_req_size = khc->_resp_header_buff_size - khc->_resp_header_read_size - 1;
+    khc_sock_code_t read_res =
+        khc->_cb_sock_recv(khc->_sock_ctx_recv, &khc->_resp_header_buff[khc->_resp_header_read_size], read_req_size, &read_size);
+    if (read_res == KHC_SOCK_OK) {
+        khc->_resp_header_read_size += read_size;
+        khc->_resp_header_buff[khc->_resp_header_read_size] = '\0';
+        if (read_size == 0) {
+            khc->_read_end = 1;
+        }
+        // check CRLF. no exist -> ERROR.
+        if (strstr(khc->_resp_header_buff, "\r\n") == NULL) {
+            khc->_state = KHC_STATE_CLOSE;
+            khc->_result = KHC_ERR_TOO_LARGE_DATA;
+            return;
+        }
+        khc->_state = KHC_STATE_RESP_STATUS_PARSE;
+        return;
     }
-    // check CRLF. no exist -> ERROR.
-    if (strstr(khc->_resp_header_buff, "\r\n") == NULL) {
-      khc->_state = KHC_STATE_CLOSE;
-      khc->_result = KHC_ERR_TOO_LARGE_DATA;
-      return;
+    if (read_res == KHC_SOCK_AGAIN) {
+        return;
     }
-    khc->_state = KHC_STATE_RESP_STATUS_PARSE;
-    return;
-  }
-  if (read_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (read_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_RECV;
-    return;
-  }
+    if (read_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_RECV;
+        return;
+    }
 }
 
 void khc_state_resp_status_parse(khc* khc) {
-  const char http_version[] = "HTTP/d.d ";
-  char* ptr = khc->_resp_header_buff + strlen(http_version);
+    const char http_version[] = "HTTP/d.d ";
+    char* ptr = khc->_resp_header_buff + strlen(http_version);
 
-  int status_code = 0;
-  for (int i = 0; i < 3; ++i) {
-    char d = ptr[i];
-    if (isdigit((int)d) == 0){
-      khc->_state = KHC_STATE_CLOSE;
-      khc->_result = KHC_ERR_FAIL;  
-      return;
+    int status_code = 0;
+    for (int i = 0; i < 3; ++i) {
+        char d = ptr[i];
+        if (isdigit((int)d) == 0){
+            khc->_state = KHC_STATE_CLOSE;
+            khc->_result = KHC_ERR_FAIL;
+            return;
+        }
+        status_code = status_code * 10 + (d - '0');
     }
-    status_code = status_code * 10 + (d - '0');
-  }
-  khc->_status_code = status_code;
-  khc->_state = KHC_STATE_RESP_HEADER_CALLBACK;
-  return;
+    khc->_status_code = status_code;
+    khc->_state = KHC_STATE_RESP_HEADER_CALLBACK;
+    return;
 }
 
 void khc_state_resp_header_callback(khc* khc) {
-  char* header_boundary = strstr(khc->_resp_header_buff, "\r\n");
-  if (header_boundary == NULL) {
-    if (khc->_resp_header_buff_size == khc->_resp_header_read_size + 1) {
-      // no space in _resp_header_buff.
-      khc->_state = KHC_STATE_RESP_HEADER_SKIP;
-      return;
+    char* header_boundary = strstr(khc->_resp_header_buff, "\r\n");
+    if (header_boundary == NULL) {
+        if (khc->_resp_header_buff_size == khc->_resp_header_read_size + 1) {
+            // no space in _resp_header_buff.
+            khc->_state = KHC_STATE_RESP_HEADER_SKIP;
+            return;
+        }
+        khc->_state = KHC_STATE_RESP_HEADER_READ;
+        return;
     }
-    khc->_state = KHC_STATE_RESP_HEADER_READ;
-    return;
-  }
-  size_t header_size = header_boundary - khc->_resp_header_buff;
-  if (header_size > 0) {
-    size_t content_length = 0;
-    size_t header_written = khc->_cb_header(khc->_resp_header_buff,
-        header_size, khc->_header_data);
-    if (header_written != header_size) { // Error in callback function.
-      khc->_state = KHC_STATE_CLOSE;
-      khc->_result = KHC_ERR_HEADER_CALLBACK;
-      return;
+    size_t header_size = header_boundary - khc->_resp_header_buff;
+    if (header_size > 0) {
+        size_t content_length = 0;
+        size_t header_written = khc->_cb_header(khc->_resp_header_buff,
+                header_size, khc->_header_data);
+        if (header_written != header_size) { // Error in callback function.
+            khc->_state = KHC_STATE_CLOSE;
+            khc->_result = KHC_ERR_HEADER_CALLBACK;
+            return;
+        }
+
+        if (_is_chunked_encoding(khc->_resp_header_buff, header_size) == 1) {
+            khc->_chunked_resp = 1;
+        } else if (_extract_content_length(khc->_resp_header_buff, header_size, &content_length) == 1) {
+            khc->_resp_content_length = content_length;
+        }
     }
 
-    if (_is_chunked_encoding(khc->_resp_header_buff, header_size) == 1) {
-      khc->_chunked_resp = 1;
-    } else if (_extract_content_length(khc->_resp_header_buff, header_size, &content_length) == 1) {
-      khc->_resp_content_length = content_length;
-    }
-  }
+    memmove(khc->_resp_header_buff, header_boundary + 2,
+            khc->_resp_header_read_size - (header_size + 2) + 1); // +1 is '\0' include.
+    khc->_resp_header_read_size -= (header_size + 2);
 
-  memmove(khc->_resp_header_buff, header_boundary + 2,
-      khc->_resp_header_read_size - (header_size + 2) + 1); // +1 is '\0' include.
-  khc->_resp_header_read_size -= (header_size + 2);
-
-  if (header_size == 0) {
-    if (100 <= khc->_status_code && khc->_status_code < 200) {
-      khc->_state = KHC_STATE_RESP_STATUS_READ;
-    } else {
-      if (khc->_chunked_resp) {
-        khc->_body_read_size = 0;
-        khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE;
-      } else {
-        khc->_state = KHC_STATE_RESP_BODY_FRAGMENT;
-      }
-      return;
+    if (header_size == 0) {
+        if (100 <= khc->_status_code && khc->_status_code < 200) {
+            khc->_state = KHC_STATE_RESP_STATUS_READ;
+        } else {
+            if (khc->_chunked_resp) {
+                khc->_body_read_size = 0;
+                khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE;
+            } else {
+                khc->_state = KHC_STATE_RESP_BODY_FRAGMENT;
+            }
+            return;
+        }
     }
-  }
 }
 
 void khc_state_resp_header_read(khc* khc) {
-  size_t read_size = 0;
-  size_t read_req_size = khc->_resp_header_buff_size - khc->_resp_header_read_size - 1;
-  khc_sock_code_t read_res = 
-    khc->_cb_sock_recv(khc->_sock_ctx_recv, &khc->_resp_header_buff[khc->_resp_header_read_size], read_req_size, &read_size);
-  if (read_res == KHC_SOCK_OK) {
-    khc->_resp_header_read_size += read_size;
-    khc->_resp_header_buff[khc->_resp_header_read_size] = '\0';
-    if (read_size == 0) {
-      khc->_read_end = 1;
+    size_t read_size = 0;
+    size_t read_req_size = khc->_resp_header_buff_size - khc->_resp_header_read_size - 1;
+    khc_sock_code_t read_res =
+        khc->_cb_sock_recv(khc->_sock_ctx_recv, &khc->_resp_header_buff[khc->_resp_header_read_size], read_req_size, &read_size);
+    if (read_res == KHC_SOCK_OK) {
+        khc->_resp_header_read_size += read_size;
+        khc->_resp_header_buff[khc->_resp_header_read_size] = '\0';
+        if (read_size == 0) {
+            khc->_read_end = 1;
+        }
+        khc->_state = KHC_STATE_RESP_HEADER_CALLBACK;
+        return;
     }
-    khc->_state = KHC_STATE_RESP_HEADER_CALLBACK;
-    return;
-  }
-  if (read_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (read_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_RECV;
-    return;
-  }
+    if (read_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (read_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_RECV;
+        return;
+    }
 }
 
 void khc_state_resp_header_skip(khc* khc) {
-  // check required http headers.
-  if (_is_header_present("Content-Length", khc->_resp_header_buff, khc->_resp_header_read_size) == 1 ||
-      _is_header_present("Transfer-Encoding", khc->_resp_header_buff, khc->_resp_header_read_size) == 1) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_HEADER_CALLBACK;
-    return;
-  }
-
-  // check and leave CR at last.
-  if (khc->_resp_header_buff[khc->_resp_header_read_size - 1] == '\r') {
-    khc->_resp_header_buff[0] = '\r';
-    khc->_resp_header_read_size = 1;
-  } else {
-    khc->_resp_header_read_size = 0;
-  }
-
-  size_t read_size = 0;
-  size_t read_req_size = khc->_resp_header_buff_size - khc->_resp_header_read_size - 1;
-  khc_sock_code_t read_res = khc->_cb_sock_recv(
-      khc->_sock_ctx_recv,
-      &khc->_resp_header_buff[khc->_resp_header_read_size],
-      read_req_size,
-      &read_size);
-  if (read_res == KHC_SOCK_OK) {
-    khc->_resp_header_read_size += read_size;
-    khc->_resp_header_buff[khc->_resp_header_read_size] = '\0';
-    if (read_size == 0) {
-      khc->_read_end = 1;
+    // check required http headers.
+    if (_is_header_present("Content-Length", khc->_resp_header_buff, khc->_resp_header_read_size) == 1 ||
+            _is_header_present("Transfer-Encoding", khc->_resp_header_buff, khc->_resp_header_read_size) == 1) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_HEADER_CALLBACK;
+        return;
     }
-    // check header boundary.
-    char* header_boundary = strstr(khc->_resp_header_buff, "\r\n");
-    if (header_boundary == NULL) {
-      // re-skip.
-      return;
-    }
-    // discard skip target.
-    size_t header_size = header_boundary - khc->_resp_header_buff;
-    memmove(khc->_resp_header_buff, header_boundary + 2,
-        khc->_resp_header_read_size - (header_size + 2) + 1); // +1 is '\0' include.
-    khc->_resp_header_read_size -= (header_size + 2);
 
-    khc->_state = KHC_STATE_RESP_HEADER_CALLBACK;
-    return;
-  }
-  if (read_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (read_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_RECV;
-    return;
-  }
+    // check and leave CR at last.
+    if (khc->_resp_header_buff[khc->_resp_header_read_size - 1] == '\r') {
+        khc->_resp_header_buff[0] = '\r';
+        khc->_resp_header_read_size = 1;
+    } else {
+        khc->_resp_header_read_size = 0;
+    }
+
+    size_t read_size = 0;
+    size_t read_req_size = khc->_resp_header_buff_size - khc->_resp_header_read_size - 1;
+    khc_sock_code_t read_res = khc->_cb_sock_recv(
+            khc->_sock_ctx_recv,
+            &khc->_resp_header_buff[khc->_resp_header_read_size],
+            read_req_size,
+            &read_size);
+    if (read_res == KHC_SOCK_OK) {
+        khc->_resp_header_read_size += read_size;
+        khc->_resp_header_buff[khc->_resp_header_read_size] = '\0';
+        if (read_size == 0) {
+            khc->_read_end = 1;
+        }
+        // check header boundary.
+        char* header_boundary = strstr(khc->_resp_header_buff, "\r\n");
+        if (header_boundary == NULL) {
+            // re-skip.
+            return;
+        }
+        // discard skip target.
+        size_t header_size = header_boundary - khc->_resp_header_buff;
+        memmove(khc->_resp_header_buff, header_boundary + 2,
+                khc->_resp_header_read_size - (header_size + 2) + 1); // +1 is '\0' include.
+        khc->_resp_header_read_size -= (header_size + 2);
+
+        khc->_state = KHC_STATE_RESP_HEADER_CALLBACK;
+        return;
+    }
+    if (read_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (read_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_RECV;
+        return;
+    }
 }
 
 void khc_state_resp_body_fragment(khc* khc) {
-  if (khc->_resp_header_read_size > 0) {
-    size_t written =
-      khc->_cb_write(khc->_resp_header_buff, khc->_resp_header_read_size, khc->_write_data);
-    if (written != khc->_resp_header_read_size) { // Error in write callback.
-      khc->_state = KHC_STATE_CLOSE;
-      khc->_result = KHC_ERR_WRITE_CALLBACK;
-      return;
+    if (khc->_resp_header_read_size > 0) {
+        size_t written =
+            khc->_cb_write(khc->_resp_header_buff, khc->_resp_header_read_size, khc->_write_data);
+        if (written != khc->_resp_header_read_size) { // Error in write callback.
+            khc->_state = KHC_STATE_CLOSE;
+            khc->_result = KHC_ERR_WRITE_CALLBACK;
+            return;
+        }
     }
-  }
 
-  if (khc->_read_end == 1) {
-    khc->_state = KHC_STATE_CLOSE;
-    return;
-  } else {
-    khc->_state = KHC_STATE_RESP_BODY_READ;
-    return;
-  }
+    if (khc->_read_end == 1) {
+        khc->_state = KHC_STATE_CLOSE;
+        return;
+    } else {
+        khc->_state = KHC_STATE_RESP_BODY_READ;
+        return;
+    }
 }
 
 int _move_resp_header_to_stream(khc* khc) {
-  long remain = khc->_stream_buff_size - khc->_body_read_size;
-  if (remain <= 0) {
-    return 1;
-  }
-  size_t move_size = remain > khc->_resp_header_read_size ? khc->_resp_header_read_size : remain;
-  memmove(
-      &khc->_stream_buff[khc->_body_read_size],
-      khc->_resp_header_buff,
-      move_size);
-  khc->_body_read_size += move_size;
-  khc->_resp_header_read_size -= move_size;
-  memmove(
-      khc->_resp_header_buff,
-      &khc->_resp_header_buff[move_size],
-      khc->_resp_header_read_size + 1);// move with '\0'
-  return 0;
+    long remain = khc->_stream_buff_size - khc->_body_read_size;
+    if (remain <= 0) {
+        return 1;
+    }
+    size_t move_size = remain > khc->_resp_header_read_size ? khc->_resp_header_read_size : remain;
+    memmove(
+            &khc->_stream_buff[khc->_body_read_size],
+            khc->_resp_header_buff,
+            move_size);
+    khc->_body_read_size += move_size;
+    khc->_resp_header_read_size -= move_size;
+    memmove(
+            khc->_resp_header_buff,
+            &khc->_resp_header_buff[move_size],
+            khc->_resp_header_read_size + 1);// move with '\0'
+    return 0;
 }
 
 void khc_state_read_chunk_size_from_header_buff(khc* khc) {
-  if (_move_resp_header_to_stream(khc) == 0) {
-    khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE;
-  } else {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_TOO_LARGE_DATA;
-  }
+    if (_move_resp_header_to_stream(khc) == 0) {
+        khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE;
+    } else {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_TOO_LARGE_DATA;
+    }
 }
 
 void khc_state_read_chunk_body_from_header_buff(khc* khc) {
-  if (_move_resp_header_to_stream(khc) == 0) {
-    khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_BODY;
-  } else {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_TOO_LARGE_DATA;
-  }
+    if (_move_resp_header_to_stream(khc) == 0) {
+        khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_BODY;
+    } else {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_TOO_LARGE_DATA;
+    }
 }
 
 void khc_state_resp_body_read(khc* khc) {
-  size_t read_size = 0;
-  khc_sock_code_t read_res = 
-    khc->_cb_sock_recv(khc->_sock_ctx_recv, khc->_stream_buff, khc->_stream_buff_size, &read_size);
-  if (read_res == KHC_SOCK_OK) {
-    khc->_body_read_size = read_size;
-    if (read_size == 0) {
-      khc->_read_end = 1;
-      khc->_state = KHC_STATE_CLOSE;
-      return;
+    size_t read_size = 0;
+    khc_sock_code_t read_res =
+        khc->_cb_sock_recv(khc->_sock_ctx_recv, khc->_stream_buff, khc->_stream_buff_size, &read_size);
+    if (read_res == KHC_SOCK_OK) {
+        khc->_body_read_size = read_size;
+        if (read_size == 0) {
+            khc->_read_end = 1;
+            khc->_state = KHC_STATE_CLOSE;
+            return;
+        }
+        khc->_state = KHC_STATE_RESP_BODY_CALLBACK;
+        return;
     }
-    khc->_state = KHC_STATE_RESP_BODY_CALLBACK;
-    return;
-  }
-  if (read_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (read_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_RECV;
-    return;
-  }
+    if (read_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (read_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_RECV;
+        return;
+    }
 }
 
 void khc_state_resp_body_callback(khc* khc) {
-  size_t written = khc->_cb_write(khc->_stream_buff, khc->_body_read_size, khc->_write_data);
-  if (written < khc->_body_read_size) { // Error in write callback.
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_WRITE_CALLBACK;
+    size_t written = khc->_cb_write(khc->_stream_buff, khc->_body_read_size, khc->_write_data);
+    if (written < khc->_body_read_size) { // Error in write callback.
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_WRITE_CALLBACK;
+        return;
+    }
+    if (khc->_read_end == 1) {
+        khc->_state = KHC_STATE_CLOSE;
+    } else {
+        khc->_state = KHC_STATE_RESP_BODY_READ;
+    }
     return;
-  }
-  if (khc->_read_end == 1) {
-    khc->_state = KHC_STATE_CLOSE;
-  } else {
-    khc->_state = KHC_STATE_RESP_BODY_READ;
-  }
-  return;
 }
 
 void khc_state_resp_body_parse_chunk_size(khc* khc) {
-  size_t chunk_size = 0;
-  int has_chunk_size = _read_chunk_size(khc->_stream_buff, khc->_body_read_size, &chunk_size);
-  if (has_chunk_size == 1) {
-    khc->_chunk_size = chunk_size;
-    khc->_chunk_size_written = 0;
-    const char* chunk_end = strstr(khc->_stream_buff, "\r\n");
-    size_t remain = khc->_body_read_size - (chunk_end + 2 - khc->_stream_buff);
-    memmove(khc->_stream_buff, chunk_end + 2, remain);
-    khc->_body_read_size = remain;
-    if (chunk_size > 0) {
-      khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_BODY;
+    size_t chunk_size = 0;
+    int has_chunk_size = _read_chunk_size(khc->_stream_buff, khc->_body_read_size, &chunk_size);
+    if (has_chunk_size == 1) {
+        khc->_chunk_size = chunk_size;
+        khc->_chunk_size_written = 0;
+        const char* chunk_end = strstr(khc->_stream_buff, "\r\n");
+        size_t remain = khc->_body_read_size - (chunk_end + 2 - khc->_stream_buff);
+        memmove(khc->_stream_buff, chunk_end + 2, remain);
+        khc->_body_read_size = remain;
+        if (chunk_size > 0) {
+            khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_BODY;
+        } else {
+            khc->_state = KHC_STATE_RESP_BODY_SKIP_TRAILERS;
+        }
     } else {
-      khc->_state = KHC_STATE_RESP_BODY_SKIP_TRAILERS;
+        if (khc->_resp_header_read_size > 0) {
+            khc->_state = KHC_STATE_READ_CHUNK_SIZE_FROM_HEADER_BUFF;
+        } else {
+            khc->_state = KHC_STATE_RESP_BODY_READ_CHUNK_SIZE;
+        }
     }
-  } else {
-    if (khc->_resp_header_read_size > 0) {
-      khc->_state = KHC_STATE_READ_CHUNK_SIZE_FROM_HEADER_BUFF;
-    } else {
-      khc->_state = KHC_STATE_RESP_BODY_READ_CHUNK_SIZE;
-    }
-  }
 }
 
 void khc_state_resp_body_read_chunk_size(khc* khc) {
-  size_t read_size = 0;
-  long remain = khc->_stream_buff_size - khc->_body_read_size;
-  if (remain <= 0) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_TOO_LARGE_DATA;
-    return;
-  }
-  khc_sock_code_t read_res = khc->_cb_sock_recv(
-      khc->_sock_ctx_recv,
-      &khc->_stream_buff[khc->_body_read_size],
-      remain,
-      &read_size);
-  if (read_res == KHC_SOCK_OK) {
-    khc->_body_read_size += read_size;
-    if (read_size == 0) {
-      khc->_state = KHC_STATE_CLOSE;
-      khc->_result = KHC_ERR_FAIL;
-      return;
+    size_t read_size = 0;
+    long remain = khc->_stream_buff_size - khc->_body_read_size;
+    if (remain <= 0) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_TOO_LARGE_DATA;
+        return;
     }
-    khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE;
-    return;
-  }
-  if (read_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (read_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_RECV;
-    return;
-  }
+    khc_sock_code_t read_res = khc->_cb_sock_recv(
+            khc->_sock_ctx_recv,
+            &khc->_stream_buff[khc->_body_read_size],
+            remain,
+            &read_size);
+    if (read_res == KHC_SOCK_OK) {
+        khc->_body_read_size += read_size;
+        if (read_size == 0) {
+            khc->_state = KHC_STATE_CLOSE;
+            khc->_result = KHC_ERR_FAIL;
+            return;
+        }
+        khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE;
+        return;
+    }
+    if (read_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (read_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_RECV;
+        return;
+    }
 }
 
 void khc_state_resp_body_parse_chunk_body(khc* khc) {
-  size_t target_size =
-      khc->_chunk_size > khc->_body_read_size + khc->_chunk_size_written ?
-      khc->_body_read_size :
-      khc->_chunk_size - khc->_chunk_size_written;
-  size_t written = khc->_cb_write(khc->_stream_buff, target_size, khc->_write_data);
-  if (written < target_size) { // Error in write callback.
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_WRITE_CALLBACK;
-    return;
-  }
-  khc->_chunk_size_written += target_size;
-  if (khc->_chunk_size > khc->_chunk_size_written) {
-    if (khc->_resp_header_read_size > 0) {
-      khc->_body_read_size = 0;
-      khc->_state = KHC_STATE_READ_CHUNK_BODY_FROM_HEADER_BUFF;
-    } else {
-      khc->_state = KHC_STATE_RESP_BODY_READ_CHUNK_BODY;
+    size_t target_size =
+        khc->_chunk_size > khc->_body_read_size + khc->_chunk_size_written ?
+        khc->_body_read_size :
+        khc->_chunk_size - khc->_chunk_size_written;
+    size_t written = khc->_cb_write(khc->_stream_buff, target_size, khc->_write_data);
+    if (written < target_size) { // Error in write callback.
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_WRITE_CALLBACK;
+        return;
     }
-  } else {
-    size_t remain = khc->_body_read_size - target_size;
-    memmove(khc->_stream_buff, &khc->_stream_buff[target_size], remain);
-    khc->_body_read_size = remain;
-    khc->_state = KHC_STATE_RESP_BODY_SKIP_CHUNK_BODY_CRLF;
+    khc->_chunk_size_written += target_size;
+    if (khc->_chunk_size > khc->_chunk_size_written) {
+        if (khc->_resp_header_read_size > 0) {
+            khc->_body_read_size = 0;
+            khc->_state = KHC_STATE_READ_CHUNK_BODY_FROM_HEADER_BUFF;
+        } else {
+            khc->_state = KHC_STATE_RESP_BODY_READ_CHUNK_BODY;
+        }
+    } else {
+        size_t remain = khc->_body_read_size - target_size;
+        memmove(khc->_stream_buff, &khc->_stream_buff[target_size], remain);
+        khc->_body_read_size = remain;
+        khc->_state = KHC_STATE_RESP_BODY_SKIP_CHUNK_BODY_CRLF;
+        return;
+    }
     return;
-  }
-  return;
 }
 
 void khc_state_resp_body_read_chunk_body(khc* khc) {
-  size_t read_size = 0;
-  khc_sock_code_t read_res = khc->_cb_sock_recv(
-      khc->_sock_ctx_recv,
-      khc->_stream_buff,
-      khc->_stream_buff_size,
-      &read_size);
-  if (read_res == KHC_SOCK_OK) {
-    if (read_size == 0) {
-      khc->_state = KHC_STATE_CLOSE;
-      khc->_result = KHC_ERR_FAIL;
-      return;
+    size_t read_size = 0;
+    khc_sock_code_t read_res = khc->_cb_sock_recv(
+            khc->_sock_ctx_recv,
+            khc->_stream_buff,
+            khc->_stream_buff_size,
+            &read_size);
+    if (read_res == KHC_SOCK_OK) {
+        if (read_size == 0) {
+            khc->_state = KHC_STATE_CLOSE;
+            khc->_result = KHC_ERR_FAIL;
+            return;
+        }
+        khc->_body_read_size = read_size;
+        khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_BODY;
+        return;
     }
-    khc->_body_read_size = read_size;
-    khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_BODY;
-    return;
-  }
-  if (read_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (read_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_RECV;
-    return;
-  }
+    if (read_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (read_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_RECV;
+        return;
+    }
 }
 
 void khc_state_resp_body_skip_chunk_body_crlf(khc* khc) {
-  if (khc->_body_read_size < 2) {
-    size_t tmp_size = 2 - khc->_body_read_size;
-    char tmp[tmp_size];
-    size_t read_size = 0;
-    khc_sock_code_t read_res = khc->_cb_sock_recv(
-        khc->_sock_ctx_recv,
-        tmp,
-        tmp_size,
-        &read_size);
-    if (read_res == KHC_SOCK_OK) {
-      if (read_size == 0) {
-        khc->_state = KHC_STATE_CLOSE;
-        khc->_result = KHC_ERR_FAIL;
-        return;
-      }
-      khc->_body_read_size = 0;
-      khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE;
-      return;
+    if (khc->_body_read_size < 2) {
+        size_t tmp_size = 2 - khc->_body_read_size;
+        char tmp[tmp_size];
+        size_t read_size = 0;
+        khc_sock_code_t read_res = khc->_cb_sock_recv(
+                khc->_sock_ctx_recv,
+                tmp,
+                tmp_size,
+                &read_size);
+        if (read_res == KHC_SOCK_OK) {
+            if (read_size == 0) {
+                khc->_state = KHC_STATE_CLOSE;
+                khc->_result = KHC_ERR_FAIL;
+                return;
+            }
+            khc->_body_read_size = 0;
+            khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE;
+            return;
+        }
+        if (read_res == KHC_SOCK_AGAIN) {
+            return;
+        }
+        if (read_res == KHC_SOCK_FAIL) {
+            khc->_state = KHC_STATE_CLOSE;
+            khc->_result = KHC_ERR_SOCK_RECV;
+            return;
+        }
+    } else {
+        size_t remain = khc->_body_read_size - 2;
+        memmove(khc->_stream_buff, &khc->_stream_buff[2], remain);
+        khc->_body_read_size = remain;
+        khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE;
     }
-    if (read_res == KHC_SOCK_AGAIN) {
-      return;
-    }
-    if (read_res == KHC_SOCK_FAIL) {
-      khc->_state = KHC_STATE_CLOSE;
-      khc->_result = KHC_ERR_SOCK_RECV;
-      return;
-    }
-  } else {
-    size_t remain = khc->_body_read_size - 2;
-    memmove(khc->_stream_buff, &khc->_stream_buff[2], remain);
-    khc->_body_read_size = remain;
-    khc->_state = KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE;
-  }
 }
 
 void khc_state_resp_body_skip_trailers(khc* khc) {
-  size_t read_size = 0;
-  khc_sock_code_t read_res = khc->_cb_sock_recv(
-      khc->_sock_ctx_recv,
-      khc->_stream_buff,
-      khc->_stream_buff_size,
-      &read_size);
-  if (read_res == KHC_SOCK_OK) {
-    if (read_size == 0) {
-      khc->_state = KHC_STATE_CLOSE;
-      return;
+    size_t read_size = 0;
+    khc_sock_code_t read_res = khc->_cb_sock_recv(
+            khc->_sock_ctx_recv,
+            khc->_stream_buff,
+            khc->_stream_buff_size,
+            &read_size);
+    if (read_res == KHC_SOCK_OK) {
+        if (read_size == 0) {
+            khc->_state = KHC_STATE_CLOSE;
+            return;
+        }
+        return;
     }
-    return;
-  }
-  if (read_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (read_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_CLOSE;
-    khc->_result = KHC_ERR_SOCK_RECV;
-    return;
-  }
+    if (read_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (read_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_CLOSE;
+        khc->_result = KHC_ERR_SOCK_RECV;
+        return;
+    }
 }
 
 void khc_state_close(khc* khc) {
-  if (khc->_stream_buff_allocated == 1) {
-    free(khc->_stream_buff);
-    khc->_stream_buff = NULL;
-    khc->_stream_buff_size = 0;
-    khc->_stream_buff_allocated = 0;
-  }
-  if (khc->_resp_header_buff_allocated == 1) {
-    free(khc->_resp_header_buff);
-    khc->_resp_header_buff = NULL;
-    khc->_resp_header_buff_size = 0;
-    khc->_resp_header_buff_allocated = 0;
-  }
-  khc_sock_code_t close_res = khc->_cb_sock_close(khc->_sock_ctx_close);
-  if (close_res == KHC_SOCK_OK) {
-    khc->_state = KHC_STATE_FINISHED;
-    return;
-  }
-  if (close_res == KHC_SOCK_AGAIN) {
-    return;
-  }
-  if (close_res == KHC_SOCK_FAIL) {
-    khc->_state = KHC_STATE_FINISHED;
-    khc->_result = KHC_ERR_SOCK_CLOSE;
-    return;
-  }
+    if (khc->_stream_buff_allocated == 1) {
+        free(khc->_stream_buff);
+        khc->_stream_buff = NULL;
+        khc->_stream_buff_size = 0;
+        khc->_stream_buff_allocated = 0;
+    }
+    if (khc->_resp_header_buff_allocated == 1) {
+        free(khc->_resp_header_buff);
+        khc->_resp_header_buff = NULL;
+        khc->_resp_header_buff_size = 0;
+        khc->_resp_header_buff_allocated = 0;
+    }
+    khc_sock_code_t close_res = khc->_cb_sock_close(khc->_sock_ctx_close);
+    if (close_res == KHC_SOCK_OK) {
+        khc->_state = KHC_STATE_FINISHED;
+        return;
+    }
+    if (close_res == KHC_SOCK_AGAIN) {
+        return;
+    }
+    if (close_res == KHC_SOCK_FAIL) {
+        khc->_state = KHC_STATE_FINISHED;
+        khc->_result = KHC_ERR_SOCK_CLOSE;
+        return;
+    }
 }
 
 const KHC_STATE_HANDLER state_handlers[] = {
-  khc_state_idle,
-  khc_state_connect,
-  khc_state_req_line,
-  khc_state_req_host_header,
-  khc_state_req_header,
-  khc_state_req_header_send,
-  khc_state_req_header_send_crlf,
-  khc_state_req_header_end,
-  khc_state_req_body_read,
-  khc_state_req_body_send_size,
-  khc_state_req_body_send,
-  khc_state_req_body_send_crlf,
+    khc_state_idle,
+    khc_state_connect,
+    khc_state_req_line,
+    khc_state_req_host_header,
+    khc_state_req_header,
+    khc_state_req_header_send,
+    khc_state_req_header_send_crlf,
+    khc_state_req_header_end,
+    khc_state_req_body_read,
+    khc_state_req_body_send_size,
+    khc_state_req_body_send,
+    khc_state_req_body_send_crlf,
 
-  khc_state_resp_status_read,
-  khc_state_resp_status_parse,
-  khc_state_resp_header_callback,
-  khc_state_resp_header_read,
-  khc_state_resp_header_skip,
-  khc_state_resp_body_fragment,
-  khc_state_read_chunk_size_from_header_buff,
-  khc_state_read_chunk_body_from_header_buff,
+    khc_state_resp_status_read,
+    khc_state_resp_status_parse,
+    khc_state_resp_header_callback,
+    khc_state_resp_header_read,
+    khc_state_resp_header_skip,
+    khc_state_resp_body_fragment,
+    khc_state_read_chunk_size_from_header_buff,
+    khc_state_read_chunk_body_from_header_buff,
 
-  khc_state_resp_body_read,
-  khc_state_resp_body_callback,
+    khc_state_resp_body_read,
+    khc_state_resp_body_callback,
 
-  khc_state_resp_body_parse_chunk_size,
-  khc_state_resp_body_read_chunk_size,
-  khc_state_resp_body_parse_chunk_body,
-  khc_state_resp_body_read_chunk_body,
-  khc_state_resp_body_skip_chunk_body_crlf,
-  khc_state_resp_body_skip_trailers,
+    khc_state_resp_body_parse_chunk_size,
+    khc_state_resp_body_read_chunk_size,
+    khc_state_resp_body_parse_chunk_body,
+    khc_state_resp_body_read_chunk_body,
+    khc_state_resp_body_skip_chunk_body_crlf,
+    khc_state_resp_body_skip_trailers,
 
-  khc_state_close
+    khc_state_close
 };

--- a/kii/include/kii.h
+++ b/kii/include/kii.h
@@ -162,9 +162,9 @@ struct kii_t;
  * \param [in] userdata Context object pointer given to kii_start_push_task().
  */
 typedef void (*KII_PUSH_RECEIVED_CB)(
-                const char* message,
-                size_t message_length,
-                void* userdata);
+        const char* message,
+        size_t message_length,
+        void* userdata);
 
 /**
  * \brief Stores data/ callbacks used by kii module.
@@ -235,7 +235,7 @@ typedef struct kii_t {
  * \param [out] kii kii_t instance.
  */
 void kii_init(
-		kii_t* kii);
+        kii_t* kii);
 
 /**
  * \brief Set site.
@@ -244,8 +244,8 @@ void kii_init(
  * "CN", "CN3", "JP", "US", "SG" or "EU".
  */
 void kii_set_site(
-		kii_t* kii,
-		const char* site);
+        kii_t* kii,
+        const char* site);
 
 /**
  * \brief Set Application ID.
@@ -509,9 +509,9 @@ kii_code_t kii_install_push(
  * \return kii_code_t
  */
 kii_code_t kii_get_mqtt_endpoint(
-    kii_t* kii,
-    const char* installation_id,
-    kii_mqtt_endpoint_t* endpoint);
+        kii_t* kii,
+        const char* installation_id,
+        kii_mqtt_endpoint_t* endpoint);
 
 /**
  * \brief Start MQTT task and watch message arrival.
@@ -562,13 +562,13 @@ kii_code_t kii_execute_server_code(
  * \return kii_code_t
  */
 kii_code_t kii_ti_onboard(
-    kii_t* kii,
-    const char* vendor_thing_id,
-    const char* password,
-    const char* thing_type,
-    const char* firmware_version,
-    const char* layout_position,
-    const char* thing_properties);
+        kii_t* kii,
+        const char* vendor_thing_id,
+        const char* password,
+        const char* thing_type,
+        const char* firmware_version,
+        const char* layout_position,
+        const char* thing_properties);
 
 /**
  * \brief Put firmware version.
@@ -578,8 +578,8 @@ kii_code_t kii_ti_onboard(
  * \return kii_code_t
  */
 kii_code_t kii_ti_put_firmware_version(
-    kii_t* kii,
-    const char* firmware_version);
+        kii_t* kii,
+        const char* firmware_version);
 
 /**
  * \brief Stores firmware version.
@@ -596,8 +596,8 @@ typedef struct kii_ti_firmware_version_t {
  * \return kii_code_t
  */
 kii_code_t kii_ti_get_firmware_version(
-    kii_t* kii,
-    kii_ti_firmware_version_t* version);
+        kii_t* kii,
+        kii_ti_firmware_version_t* version);
 
 /**
  * \brief Put thing type.
@@ -607,8 +607,8 @@ kii_code_t kii_ti_get_firmware_version(
  * \return kii_code_t
  */
 kii_code_t kii_ti_put_thing_type(
-    kii_t* kii,
-    const char* thing_type);
+        kii_t* kii,
+        const char* thing_type);
 
 /**
  * \brief Put thing state.
@@ -626,12 +626,12 @@ kii_code_t kii_ti_put_thing_type(
  * \return kii_code_t
  */
 kii_code_t kii_ti_put_state(
-    kii_t* kii,
-    KII_CB_READ state_read_cb,
-    void* state_read_cb_data,
-    const char* opt_content_type,
-    const char* opt_content_encoding,
-    const char* opt_normalizer_host);
+        kii_t* kii,
+        KII_CB_READ state_read_cb,
+        void* state_read_cb_data,
+        const char* opt_content_type,
+        const char* opt_content_encoding,
+        const char* opt_normalizer_host);
 
 /**
  * \brief Put thing state in bulk.
@@ -649,12 +649,12 @@ kii_code_t kii_ti_put_state(
  * \return kii_code_t
  */
 kii_code_t kii_ti_put_bulk_states(
-    kii_t* kii,
-    KII_CB_READ state_read_cb,
-    void* state_read_cb_data,
-    const char* opt_content_type,
-    const char* opt_content_encoding,
-    const char* opt_normalizer_host);
+        kii_t* kii,
+        KII_CB_READ state_read_cb,
+        void* state_read_cb_data,
+        const char* opt_content_type,
+        const char* opt_content_encoding,
+        const char* opt_normalizer_host);
 
 /**
  * \brief Patch thing state.
@@ -672,12 +672,12 @@ kii_code_t kii_ti_put_bulk_states(
  * \return kii_code_t
  */
 kii_code_t kii_ti_patch_state(
-    kii_t* kii,
-    KII_CB_READ state_read_cb,
-    void* state_read_cb_data,
-    const char* opt_content_type,
-    const char* opt_content_encoding,
-    const char* opt_normalizer_host);
+        kii_t* kii,
+        KII_CB_READ state_read_cb,
+        void* state_read_cb_data,
+        const char* opt_content_type,
+        const char* opt_content_encoding,
+        const char* opt_normalizer_host);
 
 /**
  * \brief Patch thing state in bulk.
@@ -695,12 +695,12 @@ kii_code_t kii_ti_patch_state(
  * \return kii_code_t
  */
 kii_code_t kii_ti_patch_bulk_states(
-    kii_t* kii,
-    KII_CB_READ state_read_cb,
-    void* state_read_cb_data,
-    const char* opt_content_type,
-    const char* opt_content_encoding,
-    const char* opt_normalizer_host);
+        kii_t* kii,
+        KII_CB_READ state_read_cb,
+        void* state_read_cb_data,
+        const char* opt_content_type,
+        const char* opt_content_encoding,
+        const char* opt_normalizer_host);
 
 /**
  * \brief Start making REST API call.
@@ -1067,8 +1067,8 @@ void kii_set_json_parser_resource(kii_t* kii, jkii_resource_t* resource);
  * \param [in] cb_free free callback should free memories allocated in cb_alloc.
  */
 void kii_set_cb_json_parser_resource(kii_t* kii,
-    JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE cb_free);
+        JKII_CB_RESOURCE_ALLOC cb_alloc,
+        JKII_CB_RESOURCE_FREE cb_free);
 
 /**
  * \brief Set khc_slist (linked list) resource allocators.
@@ -1083,11 +1083,11 @@ void kii_set_cb_json_parser_resource(kii_t* kii,
  * \param [in] cb_free_data Context object pointer passed to cb_free.
  */
 void kii_set_cb_slist_resource(
-    kii_t* kii,
-    KHC_CB_SLIST_ALLOC cb_alloc,
-    KHC_CB_SLIST_FREE cb_free,
-    void* cb_alloc_data,
-    void* cb_free_data);
+        kii_t* kii,
+        KHC_CB_SLIST_ALLOC cb_alloc,
+        KHC_CB_SLIST_FREE cb_free,
+        void* cb_alloc_data,
+        void* cb_free_data);
 
 /**
  * \brief Get Etag value.

--- a/kii/kii.c
+++ b/kii/kii.c
@@ -211,11 +211,11 @@ void kii_set_cb_json_parser_resource(
 }
 
 void kii_set_cb_slist_resource(
-    kii_t* kii,
-    KHC_CB_SLIST_ALLOC cb_alloc,
-    KHC_CB_SLIST_FREE cb_free,
-    void* cb_alloc_data,
-    void* cb_free_data) {
+        kii_t* kii,
+        KHC_CB_SLIST_ALLOC cb_alloc,
+        KHC_CB_SLIST_FREE cb_free,
+        void* cb_alloc_data,
+        void* cb_free_data) {
     kii->_cb_slist_alloc = cb_alloc;
     kii->_cb_slist_free = cb_free;
     kii->_slist_alloc_data = cb_alloc_data;

--- a/kii/kii_mqtt_task.c
+++ b/kii/kii_mqtt_task.c
@@ -224,10 +224,10 @@ khc_sock_code_t _mqtt_recv_remaining_trash(kii_t* kii, unsigned long remaining_l
     khc_sock_code_t res = KHC_SOCK_FAIL;
     while (total_received < remaining_length) {
         res = kii->_cb_mqtt_sock_recv(
-            kii->_mqtt_sock_recv_ctx,
-            buff,
-            buff_size,
-            &received);
+                kii->_mqtt_sock_recv_ctx,
+                buff,
+                buff_size,
+                &received);
         if (res == KHC_SOCK_FAIL) {
             return KHC_SOCK_FAIL;
         }
@@ -249,10 +249,10 @@ khc_sock_code_t _mqtt_recv_remaining(kii_t* kii, unsigned long remaining_length,
     khc_sock_code_t res = KHC_SOCK_FAIL;
     while (total_received < remaining_length) {
         res = kii->_cb_mqtt_sock_recv(
-            kii->_mqtt_sock_recv_ctx,
-            buff + received,
-            remaining_length - received,
-            &received);
+                kii->_mqtt_sock_recv_ctx,
+                buff + received,
+                remaining_length - received,
+                &received);
         if (res == KHC_SOCK_FAIL) {
             return KHC_SOCK_FAIL;
         }

--- a/kii/kii_object_impl.c
+++ b/kii/kii_object_impl.c
@@ -4,10 +4,10 @@
 #include "kii_req_impl.h"
 
 kii_code_t _post_object(
-            kii_t* kii,
-            const kii_bucket_t* bucket,
-            const char* object_data,
-            const char* object_content_type)
+        kii_t* kii,
+        const kii_bucket_t* bucket,
+        const char* object_data,
+        const char* object_content_type)
 {
     khc_set_host(&kii->_khc, kii->_app_host);
     khc_set_method(&kii->_khc, "POST");
@@ -275,7 +275,7 @@ kii_code_t _upload_body(
     }
     ret = _set_object_body_content_type(kii, body_content_type);
     if (ret != KII_ERR_OK) {
-        
+
         return ret;
     }
 

--- a/kii/kii_object_impl.h
+++ b/kii/kii_object_impl.h
@@ -8,53 +8,53 @@ extern "C" {
 #include "kii.h"
 
 kii_code_t _make_bucket_path(
-    kii_t *kii,
-    const kii_bucket_t *bucket,
-    const char *objects,
-    const char *object_id,
-    const char *body,
-    int *path_len);
+        kii_t *kii,
+        const kii_bucket_t *bucket,
+        const char *objects,
+        const char *object_id,
+        const char *body,
+        int *path_len);
 
 kii_code_t _make_object_content_type(
-    kii_t *kii,
-    const char *object_content_type,
-    int *header_len);
+        kii_t *kii,
+        const char *object_content_type,
+        int *header_len);
 
 kii_code_t _make_object_body_content_type(
-    kii_t *kii,
-    const char *object_body_content_type,
-    int *header_len);
+        kii_t *kii,
+        const char *object_body_content_type,
+        int *header_len);
 
 kii_code_t _post_object(
-    kii_t *kii,
-    const kii_bucket_t *bucket,
-    const char *object_data,
-    const char *object_content_type);
+        kii_t *kii,
+        const kii_bucket_t *bucket,
+        const char *object_data,
+        const char *object_content_type);
 
 kii_code_t _put_object(
-    kii_t *kii,
-    const kii_bucket_t *bucket,
-    const char *object_id,
-    const char *object_data,
-    const char *opt_object_content_type,
-    const char *opt_etag);
+        kii_t *kii,
+        const kii_bucket_t *bucket,
+        const char *object_id,
+        const char *object_data,
+        const char *opt_object_content_type,
+        const char *opt_etag);
 
 kii_code_t _patch_object(
-    kii_t *kii,
-    const kii_bucket_t *bucket,
-    const char *object_id,
-    const char *patch_data,
-    const char *opt_etag);
+        kii_t *kii,
+        const kii_bucket_t *bucket,
+        const char *object_id,
+        const char *patch_data,
+        const char *opt_etag);
 
 kii_code_t _get_object(
-    kii_t *kii,
-    const kii_bucket_t *bucket,
-    const char *object_id);
+        kii_t *kii,
+        const kii_bucket_t *bucket,
+        const char *object_id);
 
 kii_code_t _delete_object(
-    kii_t *kii,
-    const kii_bucket_t *bucket,
-    const char *object_id);
+        kii_t *kii,
+        const kii_bucket_t *bucket,
+        const char *object_id);
 
 kii_code_t _upload_body(
         kii_t* kii,

--- a/kii/kii_push.c
+++ b/kii/kii_push.c
@@ -53,7 +53,7 @@ exit:
 
 kii_code_t kii_subscribe_topic(kii_t* kii, const kii_topic_t* topic)
 {
-   khc_reset_except_cb(&kii->_khc);
+    khc_reset_except_cb(&kii->_khc);
     _reset_buff(kii);
 
     kii_code_t res = _subscribe_topic(kii, topic);
@@ -73,7 +73,7 @@ exit:
 
 kii_code_t kii_unsubscribe_topic(kii_t* kii, const kii_topic_t* topic)
 {
-   khc_reset_except_cb(&kii->_khc);
+    khc_reset_except_cb(&kii->_khc);
     _reset_buff(kii);
 
     kii_code_t res = _unsubscribe_topic(kii, topic);
@@ -175,9 +175,9 @@ exit:
 }
 
 kii_code_t kii_get_mqtt_endpoint(
-    kii_t* kii,
-    const char* installation_id,
-    kii_mqtt_endpoint_t* endpoint)
+        kii_t* kii,
+        const char* installation_id,
+        kii_mqtt_endpoint_t* endpoint)
 {
     khc_reset_except_cb(&kii->_khc);
     _reset_buff(kii);
@@ -252,9 +252,9 @@ kii_code_t kii_start_push_task(kii_t* kii, unsigned int keep_alive_interval, KII
     kii->_cb_push_received = callback;
     kii->_push_data = userdata;
     kii->_cb_task_create(KII_TASK_NAME_MQTT,
-        mqtt_start_task,
-        (void*)kii,
-        kii->_task_create_data);
+            mqtt_start_task,
+            (void*)kii,
+            kii->_task_create_data);
     return KII_ERR_OK;
 }
 /* vim:set ts=4 sts=4 sw=4 et fenc=UTF-8 ff=unix: */

--- a/kii/kii_push_impl.c
+++ b/kii/kii_push_impl.c
@@ -12,7 +12,7 @@ kii_code_t _install_push(
     khc_set_method(&kii->_khc, "POST");
 
     int path_len = snprintf(kii->_rw_buff, kii->_rw_buff_size,
-        "/api/apps/%s/installations", kii->_app_id);
+            "/api/apps/%s/installations", kii->_app_id);
     if (path_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
@@ -46,8 +46,8 @@ kii_code_t _install_push(
         flag = "true";
     }
     int body_len = snprintf(kii->_rw_buff, kii->_rw_buff_size,
-        "{\"deviceType\":\"MQTT\", \"development\": \"%s\"}",
-        flag);
+            "{\"deviceType\":\"MQTT\", \"development\": \"%s\"}",
+            flag);
     if (body_len >= kii->_rw_buff_size) {
         _req_headers_free_all(kii);
         return KII_ERR_TOO_LARGE_DATA;
@@ -73,8 +73,8 @@ kii_code_t _get_mqtt_endpoint(
     khc_set_method(&kii->_khc, "GET");
 
     int path_len = snprintf(kii->_rw_buff, kii->_rw_buff_size,
-        "/api/apps/%s/installations/%s/mqtt-endpoint",
-        kii->_app_id, installation_id);
+            "/api/apps/%s/installations/%s/mqtt-endpoint",
+            kii->_app_id, installation_id);
     if (path_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }

--- a/kii/kii_req_impl.c
+++ b/kii/kii_req_impl.c
@@ -2,40 +2,40 @@
 #include <string.h>
 
 kii_code_t _set_bucket_path(
-    kii_t* kii,
-    const kii_bucket_t* bucket,
-    const char* objects,
-    const char* object_id,
-    const char* body)
+        kii_t* kii,
+        const kii_bucket_t* bucket,
+        const char* objects,
+        const char* object_id,
+        const char* body)
 {
     char *scope_strs[] = { "", "users", "groups", "things" };
     int path_len = 0;
     switch(bucket->scope) {
         case KII_SCOPE_APP:
             path_len = snprintf(
-                kii->_rw_buff,
-                kii->_rw_buff_size,
-                "/api/apps/%s/buckets/%s%s%s%s",
-                kii->_app_id,
-                bucket->bucket_name,
-                objects,
-                object_id,
-                body);
+                    kii->_rw_buff,
+                    kii->_rw_buff_size,
+                    "/api/apps/%s/buckets/%s%s%s%s",
+                    kii->_app_id,
+                    bucket->bucket_name,
+                    objects,
+                    object_id,
+                    body);
             break;
         case KII_SCOPE_USER:
         case KII_SCOPE_GROUP:
         case KII_SCOPE_THING:
             path_len = snprintf(
-                kii->_rw_buff,
-                kii->_rw_buff_size,
-                "/api/apps/%s/%s/%s/buckets/%s%s%s%s",
-                kii->_app_id,
-                scope_strs[bucket->scope],
-                bucket->scope_id,
-                bucket->bucket_name,
-                objects,
-                object_id,
-                body);
+                    kii->_rw_buff,
+                    kii->_rw_buff_size,
+                    "/api/apps/%s/%s/%s/buckets/%s%s%s%s",
+                    kii->_app_id,
+                    scope_strs[bucket->scope],
+                    bucket->scope_id,
+                    bucket->bucket_name,
+                    objects,
+                    object_id,
+                    body);
             break;
         default:
             return KII_ERR_FAIL;
@@ -84,8 +84,8 @@ kii_code_t _set_bucket_subscription_path(kii_t* kii, const kii_bucket_t* bucket)
 }
 
 kii_code_t _set_topic_path(
-    kii_t* kii,
-    const kii_topic_t* topic)
+        kii_t* kii,
+        const kii_topic_t* topic)
 {
     int len = 0;
     const char* scope_strs[] = { "", "users", "groups", "things" };
@@ -149,8 +149,8 @@ kii_code_t _set_topic_subscription_path(kii_t* kii, const kii_topic_t* topic) {
 }
 
 kii_code_t _set_content_type(
-    kii_t* kii,
-    const char* content_type)
+        kii_t* kii,
+        const char* content_type)
 {
     int header_len = snprintf(kii->_rw_buff, kii->_rw_buff_size, "Content-Type: %s", content_type);
     if (header_len >= kii->_rw_buff_size) {
@@ -165,8 +165,8 @@ kii_code_t _set_content_type(
 }
 
 kii_code_t _set_content_encoding(
-    kii_t* kii,
-    const char* content_encoding)
+        kii_t* kii,
+        const char* content_encoding)
 {
     int header_len = snprintf(kii->_rw_buff, kii->_rw_buff_size, "Content-Encoding: %s", content_encoding);
     if (header_len >= kii->_rw_buff_size) {
@@ -181,8 +181,8 @@ kii_code_t _set_content_encoding(
 }
 
 kii_code_t _set_object_content_type(
-    kii_t* kii,
-    const char* object_content_type)
+        kii_t* kii,
+        const char* object_content_type)
 {
     char ct_key[] = "Content-Type: ";
     char *ct_value = "application/json";
@@ -202,8 +202,8 @@ kii_code_t _set_object_content_type(
 }
 
 kii_code_t _set_object_body_content_type(
-    kii_t* kii,
-    const char* object_body_content_type)
+        kii_t* kii,
+        const char* object_body_content_type)
 {
     char ct_key[] = "Content-Type: ";
     char *ct_value = "application/octet-stream";
@@ -223,16 +223,16 @@ kii_code_t _set_object_body_content_type(
 }
 
 kii_code_t _set_content_length(
-    kii_t* kii,
-    size_t content_length)
+        kii_t* kii,
+        size_t content_length)
 {
     size_t cl_size = 128;
     char cl_h[cl_size];
     int header_len = snprintf(
-        cl_h,
-        cl_size,
-        "Content-Length: %lld",
-        (long long)content_length);
+            cl_h,
+            cl_size,
+            "Content-Length: %lld",
+            (long long)content_length);
     if (header_len >= cl_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
@@ -247,10 +247,10 @@ kii_code_t _set_content_length(
 kii_code_t _set_app_id_header(kii_t* kii)
 {
     int header_len = snprintf(
-        kii->_rw_buff,
-        kii->_rw_buff_size,
-        "X-Kii-Appid: %s",
-        kii->_app_id);
+            kii->_rw_buff,
+            kii->_rw_buff_size,
+            "X-Kii-Appid: %s",
+            kii->_app_id);
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
@@ -265,10 +265,10 @@ kii_code_t _set_app_id_header(kii_t* kii)
 kii_code_t _set_app_key_header(kii_t* kii)
 {
     int header_len = snprintf(
-        kii->_rw_buff,
-        kii->_rw_buff_size,
-        "X-Kii-Appkey: %s",
-        "k");
+            kii->_rw_buff,
+            kii->_rw_buff_size,
+            "X-Kii-Appkey: %s",
+            "k");
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }
@@ -289,10 +289,10 @@ kii_code_t _set_auth_bearer_token(kii_t* kii, const char* token)
 {
     if (strlen(token) > 0) {
         int header_len = snprintf(
-            kii->_rw_buff,
-            kii->_rw_buff_size,
-            "Authorization: Bearer %s",
-            token);
+                kii->_rw_buff,
+                kii->_rw_buff_size,
+                "Authorization: Bearer %s",
+                token);
         if (header_len >= kii->_rw_buff_size) {
             return KII_ERR_TOO_LARGE_DATA;
         }
@@ -315,10 +315,10 @@ kii_code_t _set_if_match(kii_t* kii, const char* etag)
         return KII_ERR_OK;
     }
     int header_len = snprintf(
-        kii->_rw_buff,
-        kii->_rw_buff_size,
-        "If-Match: %s",
-        etag);
+            kii->_rw_buff,
+            kii->_rw_buff_size,
+            "If-Match: %s",
+            etag);
     if (header_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
     }

--- a/kii/kii_req_impl.h
+++ b/kii/kii_req_impl.h
@@ -4,43 +4,43 @@
 #include "kii.h"
 
 kii_code_t _set_bucket_path(
-    kii_t* kii,
-    const kii_bucket_t* bucket,
-    const char* objects,
-    const char* object_id,
-    const char* body);
+        kii_t* kii,
+        const kii_bucket_t* bucket,
+        const char* objects,
+        const char* object_id,
+        const char* body);
 
 kii_code_t _set_bucket_subscription_path(
-    kii_t* kii,
-    const kii_bucket_t* bucket);
+        kii_t* kii,
+        const kii_bucket_t* bucket);
 
 kii_code_t _set_topic_path(
-    kii_t* kii,
-    const kii_topic_t* topic);
+        kii_t* kii,
+        const kii_topic_t* topic);
 
 kii_code_t _set_topic_subscription_path(
-    kii_t* kii,
-    const kii_topic_t* topic);
+        kii_t* kii,
+        const kii_topic_t* topic);
 
 kii_code_t _set_object_content_type(
-    kii_t* kii,
-    const char* object_content_type);
+        kii_t* kii,
+        const char* object_content_type);
 
 kii_code_t _set_object_body_content_type(
-    kii_t* kii,
-    const char* object_body_content_type);
+        kii_t* kii,
+        const char* object_body_content_type);
 
 kii_code_t _set_content_type(
-    kii_t* kii,
-    const char* content_type);
+        kii_t* kii,
+        const char* content_type);
 
 kii_code_t _set_content_length(
-    kii_t* kii,
-    size_t content_length);
+        kii_t* kii,
+        size_t content_length);
 
 kii_code_t _set_content_encoding(
-    kii_t* kii,
-    const char* content_encoding);
+        kii_t* kii,
+        const char* content_encoding);
 
 kii_code_t _set_app_id_header(kii_t* kii);
 

--- a/kii/kii_server_code.c
+++ b/kii/kii_server_code.c
@@ -7,16 +7,16 @@
 #include "kii_req_impl.h"
 
 static kii_code_t _execute_server_code(
-    kii_t* kii,
-    const char* endpoint_name,
-    const char* params)
+        kii_t* kii,
+        const char* endpoint_name,
+        const char* params)
 {
     khc_set_host(&kii->_khc, kii->_app_host);
     khc_set_method(&kii->_khc, "POST");
 
     int path_len = snprintf(kii->_rw_buff, kii->_rw_buff_size,
-        "/api/apps/%s/server-code/versions/current/%s",
-        kii->_app_id, endpoint_name);
+            "/api/apps/%s/server-code/versions/current/%s",
+            kii->_app_id, endpoint_name);
 
     if (path_len >= kii->_rw_buff_size) {
         return KII_ERR_TOO_LARGE_DATA;
@@ -59,9 +59,9 @@ static kii_code_t _execute_server_code(
 }
 
 kii_code_t kii_execute_server_code(
-    kii_t* kii,
-    const char* endpoint_name,
-    const char* params)
+        kii_t* kii,
+        const char* endpoint_name,
+        const char* params)
 {
     khc_reset_except_cb(&kii->_khc);
     _reset_buff(kii);

--- a/kii/kii_thing.c
+++ b/kii/kii_thing.c
@@ -40,12 +40,12 @@ kii_code_t kii_auth_thing(
     fields[0].type = JKII_FIELD_TYPE_STRING;
     fields[0].field_copy.string = kii->_author.author_id;
     fields[0].field_copy_buff_size = sizeof(kii->_author.author_id) /
-            sizeof(kii->_author.author_id[0]);
+        sizeof(kii->_author.author_id[0]);
     fields[1].name = "access_token";
     fields[1].type = JKII_FIELD_TYPE_STRING;
     fields[1].field_copy.string = kii->_author.access_token;
     fields[1].field_copy_buff_size = sizeof(kii->_author.access_token) /
-            sizeof(kii->_author.access_token[0]);
+        sizeof(kii->_author.access_token[0]);
     fields[2].name = NULL;
 
     result = _jkii_read_object(kii, buff, buff_size, fields);
@@ -97,12 +97,12 @@ kii_code_t kii_register_thing(
     fields[0].type = JKII_FIELD_TYPE_STRING;
     fields[0].field_copy.string = kii->_author.access_token;
     fields[0].field_copy_buff_size = sizeof(kii->_author.access_token) /
-            sizeof(kii->_author.access_token[0]);
+        sizeof(kii->_author.access_token[0]);
     fields[1].name = "_thingID";
     fields[1].type = JKII_FIELD_TYPE_STRING;
     fields[1].field_copy.string = kii->_author.author_id;
     fields[1].field_copy_buff_size = sizeof(kii->_author.author_id) /
-            sizeof(kii->_author.author_id[0]);
+        sizeof(kii->_author.author_id[0]);
     fields[2].name = NULL;
 
     result = _jkii_read_object(kii, buff, buff_size, fields);

--- a/kii/kii_thing_impl.c
+++ b/kii/kii_thing_impl.c
@@ -41,10 +41,10 @@ kii_code_t _thing_auth(
     jkii_escape_str(password, esc_pass, sizeof(esc_vid));
 
     int content_len = snprintf(
-        kii->_rw_buff,
-        kii->_rw_buff_size,
-        "{\"username\":\"VENDOR_THING_ID:%s\", \"password\":\"%s\", \"grant_type\":\"password\"}",
-        esc_vid, esc_pass);
+            kii->_rw_buff,
+            kii->_rw_buff_size,
+            "{\"username\":\"VENDOR_THING_ID:%s\", \"password\":\"%s\", \"grant_type\":\"password\"}",
+            esc_vid, esc_pass);
     if (content_len >= kii->_rw_buff_size) {
         _req_headers_free_all(kii);
         return KII_ERR_TOO_LARGE_DATA;
@@ -104,10 +104,10 @@ kii_code_t _thing_register(
     jkii_escape_str(thing_type, esc_type, sizeof(esc_type));
 
     int content_len = snprintf(
-        kii->_rw_buff,
-        kii->_rw_buff_size,
-        "{\"_vendorThingID\":\"%s\", \"_thingType\":\"%s\", \"_password\":\"%s\"}",
-        esc_vid, esc_type, esc_pass);
+            kii->_rw_buff,
+            kii->_rw_buff_size,
+            "{\"_vendorThingID\":\"%s\", \"_thingType\":\"%s\", \"_password\":\"%s\"}",
+            esc_vid, esc_type, esc_pass);
     if (content_len >= kii->_rw_buff_size) {
         _req_headers_free_all(kii);
         return KII_ERR_TOO_LARGE_DATA;

--- a/kii/kii_ti.c
+++ b/kii/kii_ti.c
@@ -2,13 +2,13 @@
 #include "kii_ti_impl.h"
 
 kii_code_t kii_ti_onboard(
-    kii_t* kii,
-    const char* vendor_thing_id,
-    const char* password,
-    const char* thing_type,
-    const char* firmware_version,
-    const char* layout_position,
-    const char* thing_properties)
+        kii_t* kii,
+        const char* vendor_thing_id,
+        const char* password,
+        const char* thing_type,
+        const char* firmware_version,
+        const char* layout_position,
+        const char* thing_properties)
 {
     _kii_token_t out_token;
     kii_code_t ret = KII_ERR_FAIL;
@@ -27,26 +27,26 @@ kii_code_t kii_ti_onboard(
 }
 
 kii_code_t kii_ti_put_firmware_version(
-    kii_t* kii,
-    const char* firmware_version)
+        kii_t* kii,
+        const char* firmware_version)
 {
     return _put_firmware_version(kii, firmware_version);
 }
 
 kii_code_t kii_ti_get_firmware_version(
-    kii_t* kii,
-    kii_ti_firmware_version_t* version)
+        kii_t* kii,
+        kii_ti_firmware_version_t* version)
 {
     return _get_firmware_version(kii, version);
 }
 
 kii_code_t kii_ti_put_state(
-    kii_t* kii,
-    KII_CB_READ state_read_cb,
-    void* state_read_cb_data,
-    const char* opt_content_type,
-    const char* opt_content_encoding,
-    const char* opt_normalizer_host)
+        kii_t* kii,
+        KII_CB_READ state_read_cb,
+        void* state_read_cb_data,
+        const char* opt_content_type,
+        const char* opt_content_encoding,
+        const char* opt_normalizer_host)
 {
     const char* content_type = opt_content_type;
     if (opt_content_type == NULL) {
@@ -56,12 +56,12 @@ kii_code_t kii_ti_put_state(
 }
 
 kii_code_t kii_ti_put_bulk_states(
-    kii_t* kii,
-    KII_CB_READ state_read_cb,
-    void* state_read_cb_data,
-    const char* opt_content_type,
-    const char* opt_content_encoding,
-    const char* opt_normalizer_host)
+        kii_t* kii,
+        KII_CB_READ state_read_cb,
+        void* state_read_cb_data,
+        const char* opt_content_type,
+        const char* opt_content_encoding,
+        const char* opt_normalizer_host)
 {
     const char* content_type = opt_content_type;
     if (opt_content_type == NULL) {
@@ -71,12 +71,12 @@ kii_code_t kii_ti_put_bulk_states(
 }
 
 kii_code_t kii_ti_patch_state(
-    kii_t* kii,
-    KII_CB_READ state_read_cb,
-    void* state_read_cb_data,
-    const char* opt_content_type,
-    const char* opt_content_encoding,
-    const char* opt_normalizer_host)
+        kii_t* kii,
+        KII_CB_READ state_read_cb,
+        void* state_read_cb_data,
+        const char* opt_content_type,
+        const char* opt_content_encoding,
+        const char* opt_normalizer_host)
 {
     const char* content_type = opt_content_type;
     if (opt_content_type == NULL) {
@@ -86,12 +86,12 @@ kii_code_t kii_ti_patch_state(
 }
 
 kii_code_t kii_ti_patch_bulk_states(
-    kii_t* kii,
-    KII_CB_READ state_read_cb,
-    void* state_read_cb_data,
-    const char* opt_content_type,
-    const char* opt_content_encoding,
-    const char* opt_normalizer_host)
+        kii_t* kii,
+        KII_CB_READ state_read_cb,
+        void* state_read_cb_data,
+        const char* opt_content_type,
+        const char* opt_content_encoding,
+        const char* opt_normalizer_host)
 {
     const char* content_type = opt_content_type;
     if (opt_content_type == NULL) {

--- a/kii/kii_ti_impl.c
+++ b/kii/kii_ti_impl.c
@@ -30,10 +30,10 @@ kii_code_t _get_anonymous_token(
     }
     // Request body.
     int content_len = snprintf(
-        kii->_rw_buff,
-        kii->_rw_buff_size,
-        "{\"grant_type\":\"client_credentials\",\"client_id\":\"%s\",\"client_secret\":\"dummy\"}",
-        kii->_app_id);
+            kii->_rw_buff,
+            kii->_rw_buff_size,
+            "{\"grant_type\":\"client_credentials\",\"client_id\":\"%s\",\"client_secret\":\"dummy\"}",
+            kii->_app_id);
     if (content_len >= kii->_rw_buff_size) {
         _req_headers_free_all(kii);
         return KII_ERR_TOO_LARGE_DATA;
@@ -126,10 +126,10 @@ kii_code_t _onboard(
     jkii_escape_str(password, esc_pass, sizeof(esc_vid));
 
     content_len += snprintf(
-        kii->_rw_buff,
-        kii->_rw_buff_size,
-        "{\"vendorThingID\":\"%s\",\"thingPassword\":\"%s\"",
-        esc_vid, esc_pass);
+            kii->_rw_buff,
+            kii->_rw_buff_size,
+            "{\"vendorThingID\":\"%s\",\"thingPassword\":\"%s\"",
+            esc_vid, esc_pass);
     if (content_len >= kii->_rw_buff_size) {
         _req_headers_free_all(kii);
         return KII_ERR_TOO_LARGE_DATA;
@@ -233,12 +233,12 @@ kii_code_t _onboard(
     fields[0].type = JKII_FIELD_TYPE_STRING;
     fields[0].field_copy.string = kii->_author.access_token;
     fields[0].field_copy_buff_size = sizeof(kii->_author.access_token) /
-            sizeof(kii->_author.access_token[0]);
+        sizeof(kii->_author.access_token[0]);
     fields[1].name = "thingID";
     fields[1].type = JKII_FIELD_TYPE_STRING;
     fields[1].field_copy.string = kii->_author.author_id;
     fields[1].field_copy_buff_size = sizeof(kii->_author.author_id) /
-            sizeof(kii->_author.author_id[0]);
+        sizeof(kii->_author.author_id[0]);
     fields[2].name = NULL;
 
     result = _jkii_read_object(kii, buff, buff_size, fields);
@@ -280,10 +280,10 @@ kii_code_t _put_firmware_version(
 
     // Request body.
     int content_len = snprintf(
-        kii->_rw_buff,
-        kii->_rw_buff_size,
-        "{\"firmwareVersion\":\"%s\"}",
-        firmware_version);
+            kii->_rw_buff,
+            kii->_rw_buff_size,
+            "{\"firmwareVersion\":\"%s\"}",
+            firmware_version);
     if (content_len >= kii->_rw_buff_size) {
         _req_headers_free_all(kii);
         return KII_ERR_TOO_LARGE_DATA;

--- a/tests/large_test/khc/get_test.cpp
+++ b/tests/large_test/khc/get_test.cpp
@@ -7,54 +7,54 @@
 #include "test_callbacks.h"
 
 TEST_CASE( "HTTP Get" ) {
-  khc http;
-  khc_init(&http);
-  khc_set_host(&http, "api-jp.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_method(&http, "");
-  khc_set_req_headers(&http, NULL);
+    khc http;
+    khc_init(&http);
+    khc_set_host(&http, "api-jp.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_method(&http, "");
+    khc_set_req_headers(&http, NULL);
 
-  ebisu::ltest::ssl::SSLData s_ctx;
-  khc_set_cb_sock_connect(&http, ebisu::ltest::ssl::cb_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, ebisu::ltest::ssl::cb_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, ebisu::ltest::ssl::cb_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, ebisu::ltest::ssl::cb_close, &s_ctx);
+    ebisu::ltest::ssl::SSLData s_ctx;
+    khc_set_cb_sock_connect(&http, ebisu::ltest::ssl::cb_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, ebisu::ltest::ssl::cb_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, ebisu::ltest::ssl::cb_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, ebisu::ltest::ssl::cb_close, &s_ctx);
 
-  khct::cb::IOCtx io_ctx;
-  khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+    khct::cb::IOCtx io_ctx;
+    khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
-  int on_read_called = 0;
-  io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
-    ++on_read_called;
-    // No req body.
-    return 0;
-  };
+    int on_read_called = 0;
+    io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
+        ++on_read_called;
+        // No req body.
+        return 0;
+    };
 
-  int on_header_called = 0;
-  io_ctx.on_header = [=, &on_header_called](char *buffer, size_t size, void *userdata) {
-    ++on_header_called;
-    // Ignore resp headers.
-    char str[size + 1];
-    strncpy(str, buffer, size);
-    str[size] = '\0';
-    printf("%s\n", str);
-    return size;
-  };
+    int on_header_called = 0;
+    io_ctx.on_header = [=, &on_header_called](char *buffer, size_t size, void *userdata) {
+        ++on_header_called;
+        // Ignore resp headers.
+        char str[size + 1];
+        strncpy(str, buffer, size);
+        str[size] = '\0';
+        printf("%s\n", str);
+        return size;
+    };
 
-  int on_write_called = 0;
-  io_ctx.on_write = [=, &on_write_called](char *buffer, size_t size, void *userdata) {
-    ++on_write_called;
-    REQUIRE ( size == 2 );
-    REQUIRE ( strncmp(buffer, "{}", 2) == 0 );
-    return size;
-  };
+    int on_write_called = 0;
+    io_ctx.on_write = [=, &on_write_called](char *buffer, size_t size, void *userdata) {
+        ++on_write_called;
+        REQUIRE ( size == 2 );
+        REQUIRE ( strncmp(buffer, "{}", 2) == 0 );
+        return size;
+    };
 
-  khc_code res = khc_perform(&http);
-  REQUIRE( res == KHC_ERR_OK );
-  REQUIRE( khc_get_status_code(&http) == 404 );
-  REQUIRE( on_read_called == 1 );
-  REQUIRE( on_header_called > 1 );
-  REQUIRE( on_write_called == 1 );
+    khc_code res = khc_perform(&http);
+    REQUIRE( res == KHC_ERR_OK );
+    REQUIRE( khc_get_status_code(&http) == 404 );
+    REQUIRE( on_read_called == 1 );
+    REQUIRE( on_header_called > 1 );
+    REQUIRE( on_write_called == 1 );
 }

--- a/tests/large_test/khc/post_test.cpp
+++ b/tests/large_test/khc/post_test.cpp
@@ -7,92 +7,92 @@
 #include <sstream>
 
 TEST_CASE( "HTTP Post" ) {
-  khc http;
-  khc_init(&http);
+    khc http;
+    khc_init(&http);
 
-  std::string app_id = "1ud4iv020xa8";
-  std::string username = "pass-1234";
-  std::string password = "1234";
-  std::string path = "/api/apps/" + app_id + "/oauth2/token";
-  std::string host = "api-jp.kii.com";
-  std::string x_kii_appid = "X-Kii-Appid: " + app_id;
-  std::string x_kii_appkey = "X-Kii-Appkey: dummy";
-  std::string content_type = "Content-Type: application/vnd.kii.OauthTokenRequest+json";
+    std::string app_id = "1ud4iv020xa8";
+    std::string username = "pass-1234";
+    std::string password = "1234";
+    std::string path = "/api/apps/" + app_id + "/oauth2/token";
+    std::string host = "api-jp.kii.com";
+    std::string x_kii_appid = "X-Kii-Appid: " + app_id;
+    std::string x_kii_appkey = "X-Kii-Appkey: dummy";
+    std::string content_type = "Content-Type: application/vnd.kii.OauthTokenRequest+json";
 
-  khc_set_host(&http, host.c_str());
-  khc_set_method(&http, "POST");
-  khc_set_path(&http, path.c_str());
+    khc_set_host(&http, host.c_str());
+    khc_set_method(&http, "POST");
+    khc_set_path(&http, path.c_str());
 
-  // Prepare Req Body.
-  picojson::object o;
-  o.insert(std::make_pair("username", username));
-  o.insert(std::make_pair("password", password));
-  o.insert(std::make_pair("grant_type", "password"));
-  picojson::value v(o);
-  std::string req_body = v.serialize();
-  size_t body_len = req_body.length();
+    // Prepare Req Body.
+    picojson::object o;
+    o.insert(std::make_pair("username", username));
+    o.insert(std::make_pair("password", password));
+    o.insert(std::make_pair("grant_type", "password"));
+    picojson::value v(o);
+    std::string req_body = v.serialize();
+    size_t body_len = req_body.length();
 
-  // Prepare Req Headers.
-  khc_slist* headers = NULL;
-  headers = khc_slist_append(headers, x_kii_appid.c_str(), x_kii_appid.length());
-  headers = khc_slist_append(headers, content_type.c_str(), content_type.length());
-  headers = khc_slist_append(headers, x_kii_appkey.c_str(), x_kii_appkey.length());
+    // Prepare Req Headers.
+    khc_slist* headers = NULL;
+    headers = khc_slist_append(headers, x_kii_appid.c_str(), x_kii_appid.length());
+    headers = khc_slist_append(headers, content_type.c_str(), content_type.length());
+    headers = khc_slist_append(headers, x_kii_appkey.c_str(), x_kii_appkey.length());
 
-  khc_set_req_headers(&http, headers);
+    khc_set_req_headers(&http, headers);
 
-  ebisu::ltest::ssl::SSLData s_ctx;
-  khc_set_cb_sock_connect(&http, ebisu::ltest::ssl::cb_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, ebisu::ltest::ssl::cb_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, ebisu::ltest::ssl::cb_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, ebisu::ltest::ssl::cb_close, &s_ctx);
+    ebisu::ltest::ssl::SSLData s_ctx;
+    khc_set_cb_sock_connect(&http, ebisu::ltest::ssl::cb_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, ebisu::ltest::ssl::cb_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, ebisu::ltest::ssl::cb_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, ebisu::ltest::ssl::cb_close, &s_ctx);
 
-  khct::cb::IOCtx io_ctx;
-  khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+    khct::cb::IOCtx io_ctx;
+    khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
-  int on_read_called = 0;
-  std::istringstream iss(req_body);
-  io_ctx.on_read = [=, &on_read_called, &iss](char *buffer, size_t size, void *userdata) {
-    ++on_read_called;
-    return iss.read(buffer, size).gcount();
-  };
+    int on_read_called = 0;
+    std::istringstream iss(req_body);
+    io_ctx.on_read = [=, &on_read_called, &iss](char *buffer, size_t size, void *userdata) {
+        ++on_read_called;
+        return iss.read(buffer, size).gcount();
+    };
 
-  int on_header_called = 0;
-  io_ctx.on_header = [=, &on_header_called](char *buffer, size_t size, void *userdata) {
-    ++on_header_called;
-    // Ignore resp headers.
-    char str[size + 1];
-    strncpy(str, buffer, size);
-    str[size] = '\0';
-    printf("%s\n", str);
-    return size;
-  };
+    int on_header_called = 0;
+    io_ctx.on_header = [=, &on_header_called](char *buffer, size_t size, void *userdata) {
+        ++on_header_called;
+        // Ignore resp headers.
+        char str[size + 1];
+        strncpy(str, buffer, size);
+        str[size] = '\0';
+        printf("%s\n", str);
+        return size;
+    };
 
-  int on_write_called = 0;
-  std::ostringstream oss;
-  io_ctx.on_write = [=, &on_write_called, &oss](char *buffer, size_t size, void *userdata) {
-    ++on_write_called;
-    oss.write(buffer, size);
-    return size;
-  };
+    int on_write_called = 0;
+    std::ostringstream oss;
+    io_ctx.on_write = [=, &on_write_called, &oss](char *buffer, size_t size, void *userdata) {
+        ++on_write_called;
+        oss.write(buffer, size);
+        return size;
+    };
 
-  khc_code res = khc_perform(&http);
-  khc_slist_free_all(headers);
-  REQUIRE( khc_get_status_code(&http) == 200 );
+    khc_code res = khc_perform(&http);
+    khc_slist_free_all(headers);
+    REQUIRE( khc_get_status_code(&http) == 200 );
 
-  // Parse response body.
-  auto resp_body = oss.str();
-  auto err_str = picojson::parse(v, resp_body);
-  REQUIRE ( err_str.empty() );
-  REQUIRE ( v.is<picojson::object>() );
-  picojson::object obj = v.get<picojson::object>();
-  auto access_token = obj.at("access_token");
-  REQUIRE ( access_token.is<std::string>() );
-  REQUIRE ( !access_token.get<std::string>().empty() );
-  
-  REQUIRE( res == KHC_ERR_OK );
-  REQUIRE( on_read_called == 2 );
-  REQUIRE( on_header_called > 1 );
-  REQUIRE( on_write_called == 2 );
+    // Parse response body.
+    auto resp_body = oss.str();
+    auto err_str = picojson::parse(v, resp_body);
+    REQUIRE ( err_str.empty() );
+    REQUIRE ( v.is<picojson::object>() );
+    picojson::object obj = v.get<picojson::object>();
+    auto access_token = obj.at("access_token");
+    REQUIRE ( access_token.is<std::string>() );
+    REQUIRE ( !access_token.get<std::string>().empty() );
+
+    REQUIRE( res == KHC_ERR_OK );
+    REQUIRE( on_read_called == 2 );
+    REQUIRE( on_header_called > 1 );
+    REQUIRE( on_write_called == 2 );
 }

--- a/tests/large_test/kii/object_test.cpp
+++ b/tests/large_test/kii/object_test.cpp
@@ -115,14 +115,14 @@ TEST_CASE("Object Tests")
             }
             SECTION("Upload Download Body") {
                 std::string body(
-                    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+                        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
                 );
                 std::istringstream iss(body);
                 std::function<size_t(char *buffer, size_t size, void *userdata)>
                     on_read = [=, &iss](char *buffer, size_t size, void *userdata)
-                {
-                    return iss.read(buffer, size).gcount();
-                };
+                    {
+                        return iss.read(buffer, size).gcount();
+                    };
                 kiiltest::RWFunc ctx;
                 ctx.on_read = on_read;
                 kii_code_t upload_res = kii_upload_object_body(&kii, &bucket, obj_id.id, "text/plain", kiiltest::read_cb, &ctx);
@@ -133,10 +133,10 @@ TEST_CASE("Object Tests")
                 std::ostringstream oss;
                 std::function<size_t(char *buffer, size_t size, void *userdata)>
                     on_write = [=, &oss](char *buffer, size_t size, void *userdata)
-                {
-                    oss.write(buffer, size);
-                    return size;
-                };
+                    {
+                        oss.write(buffer, size);
+                        return size;
+                    };
                 ctx.on_write = on_write;
                 kii_code_t download_res = kii_download_object_body(&kii, &bucket, obj_id.id, kiiltest::write_cb, &ctx);
                 REQUIRE( khc_get_status_code(&kii._khc) == 200 );

--- a/tests/small_test/jkii/src/jkii_test.cpp
+++ b/tests/small_test/jkii/src/jkii_test.cpp
@@ -73,10 +73,10 @@ TEST_CASE("KiiJson, GetObjectPositiveIntByName") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(100 == fields[0].field_copy.int_value);
@@ -97,10 +97,10 @@ TEST_CASE("KiiJson, GetObjectNegativeIntByName") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(-100 == fields[0].field_copy.int_value);
@@ -119,10 +119,10 @@ TEST_CASE("KiiJson, GetObjectPositiveLongByName") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(1099511627776 == fields[0].field_copy.long_value);
@@ -142,10 +142,10 @@ TEST_CASE("KiiJson, GetObjectNegativeLongByName") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(-1099511627776 == fields[0].field_copy.long_value);
@@ -165,10 +165,10 @@ TEST_CASE("KiiJson, GetObjectPositiveDotDoubleByName") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(fields[0].field_copy.double_value == 0.1);
@@ -188,10 +188,10 @@ TEST_CASE("KiiJson, GetObjectNegativeDotDoubleByName") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(fields[0].field_copy.double_value == -0.1);
@@ -211,10 +211,10 @@ TEST_CASE("KiiJson, GetObjectPositiveEDoubleByName") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value - 0.1));
@@ -234,10 +234,10 @@ TEST_CASE("KiiJson, GetObjectNegativeEDoubleByName") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value + 0.1));
@@ -258,10 +258,10 @@ TEST_CASE("KiiJson, GetObjectTrueByName") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(JKII_TRUE == fields[0].field_copy.boolean_value);
@@ -282,10 +282,10 @@ TEST_CASE("KiiJson, GetObjectFalseByName") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(JKII_FALSE == fields[0].field_copy.boolean_value);
@@ -309,10 +309,10 @@ TEST_CASE("KiiJson, GetObjectStringByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0 == strcmp("value1", fields[0].field_copy.string));
@@ -332,10 +332,10 @@ TEST_CASE("KiiJson, GetObjectPositiveIntByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(100 == fields[0].field_copy.int_value);
@@ -355,10 +355,10 @@ TEST_CASE("KiiJson, GetObjectNegativeIntByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(-100 == fields[0].field_copy.int_value);
@@ -378,10 +378,10 @@ TEST_CASE("KiiJson, GetObjectPositiveLongByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(1099511627776 == fields[0].field_copy.long_value);
@@ -401,10 +401,10 @@ TEST_CASE("KiiJson, GetObjectNegativeLongByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(-1099511627776 == fields[0].field_copy.long_value);
@@ -424,10 +424,10 @@ TEST_CASE("KiiJson, GetObjectPositiveDotDoubleByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value - 0.1));
@@ -447,10 +447,10 @@ TEST_CASE("KiiJson, GetObjectNegativeDotDoubleByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value + 0.1));
@@ -470,10 +470,10 @@ TEST_CASE("KiiJson, GetObjectPositiveEDoubleByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value - 0.1));
@@ -493,10 +493,10 @@ TEST_CASE("KiiJson, GetObjectNegativeEDoubleByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value + 0.1));
@@ -517,10 +517,10 @@ TEST_CASE("KiiJson, GetObjectNullByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
 }
@@ -540,10 +540,10 @@ TEST_CASE("KiiJson, GetObjectTrueByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(JKII_TRUE == fields[0].field_copy.boolean_value);
@@ -564,10 +564,10 @@ TEST_CASE("KiiJson, GetObjectFalseByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(JKII_FALSE == fields[0].field_copy.boolean_value);
@@ -590,10 +590,10 @@ TEST_CASE("KiiJson, GetObjectSecondLayerStringByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0 == strcmp("value1", fields[0].field_copy.string));
@@ -613,10 +613,10 @@ TEST_CASE("KiiJson, GetObjectSecondLayerPositiveIntByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(100 == fields[0].field_copy.int_value);
@@ -636,10 +636,10 @@ TEST_CASE("KiiJson, GetObjectSecondLayerNegativeIntByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(-100 == fields[0].field_copy.int_value);
@@ -659,10 +659,10 @@ TEST_CASE("KiiJson, GetObjectSecondLayerPositiveLongByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(1099511627776 == fields[0].field_copy.long_value);
@@ -682,10 +682,10 @@ TEST_CASE("KiiJson, GetObjectSecondLayerNegativeLongByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(-1099511627776 == fields[0].field_copy.long_value);
@@ -705,10 +705,10 @@ TEST_CASE("KiiJson, GetObjectSecondLayerPositiveDotDoubleByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value - 0.1));
@@ -728,10 +728,10 @@ TEST_CASE("KiiJson, GetObjectSecondLayerNegativeDotDoubleByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value + 0.1));
@@ -751,10 +751,10 @@ TEST_CASE("KiiJson, GetObjectSecondLayerPositiveEDoubleByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value - 0.1));
@@ -774,10 +774,10 @@ TEST_CASE("KiiJson, GetObjectSecondLayerNegativeEDoubleByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value + 0.1));
@@ -800,10 +800,10 @@ TEST_CASE("KiiJson, GetObjectThirdLayerStringByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0 == strcmp("value1", fields[0].field_copy.string));
@@ -823,10 +823,10 @@ TEST_CASE("KiiJson, GetObjectThirdLayerPositiveIntByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(100 == fields[0].field_copy.int_value);
@@ -846,10 +846,10 @@ TEST_CASE("KiiJson, GetObjectThirdLayerNegativeIntByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(-100 == fields[0].field_copy.int_value);
@@ -870,10 +870,10 @@ TEST_CASE("KiiJson, GetObjectThirdLayerPositiveLongByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(1099511627776 == fields[0].field_copy.long_value);
@@ -894,10 +894,10 @@ TEST_CASE("KiiJson, GetObjectThirdLayerNegativeLongByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(-1099511627776 == fields[0].field_copy.long_value);
@@ -917,10 +917,10 @@ TEST_CASE("KiiJson, GetObjectThirdLayerPositiveDotDoubleByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value - 0.1));
@@ -940,10 +940,10 @@ TEST_CASE("KiiJson, GetObjectThirdLayerNegativeDotDoubleByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value + 0.1));
@@ -963,10 +963,10 @@ TEST_CASE("KiiJson, GetObjectThirdLayerPositiveEDoubleByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value - (1e-1)));
@@ -986,10 +986,10 @@ TEST_CASE("KiiJson, GetObjectThirdLayerNegativeEDoubleByPath") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value - (-1e-1)));
@@ -1012,10 +1012,10 @@ TEST_CASE("KiiJson, GetArrayString") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0 == strcmp("value1", fields[0].field_copy.string));
@@ -1036,10 +1036,10 @@ TEST_CASE("KiiJson, GetArrayInt") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(100 == fields[0].field_copy.int_value);
@@ -1060,10 +1060,10 @@ TEST_CASE("KiiJson, GetArrayLong") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(1099511627776 == fields[0].field_copy.long_value);
@@ -1084,10 +1084,10 @@ TEST_CASE("KiiJson, GetArrayDouble") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0.0001 >= fabs(fields[0].field_copy.double_value - 0.1));
@@ -1108,10 +1108,10 @@ TEST_CASE("KiiJson, GetArrayIntIndex1") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(100 == fields[0].field_copy.int_value);
@@ -1132,10 +1132,10 @@ TEST_CASE("KiiJson, GetArrayNull") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
 }
@@ -1155,10 +1155,10 @@ TEST_CASE("KiiJson, GetArrayTrue") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(JKII_TRUE == fields[0].field_copy.boolean_value);
@@ -1179,10 +1179,10 @@ TEST_CASE("KiiJson, GetArrayFalse") {
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(JKII_FALSE == fields[0].field_copy.boolean_value);
@@ -1264,10 +1264,10 @@ TEST_CASE("KiiJson, GetComplexObject") {
     fields[14].path = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(JKII_FIELD_ERR_OK == fields[1].result);
@@ -1352,10 +1352,10 @@ TEST_CASE("KiiJson, PushRetrieveEndpoint") {
     fields[7].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(JKII_FIELD_ERR_OK == fields[1].result);
@@ -1404,10 +1404,10 @@ TEST_CASE("KiiJson, CommandParseTest") {
     fields[4].path = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(JKII_FIELD_ERR_OK == fields[1].result);
@@ -1430,10 +1430,10 @@ TEST_CASE("KiiJson, NoTokensTest")
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        NULL);
+            json_string,
+            strlen(json_string),
+            fields,
+            NULL);
     REQUIRE(JKII_ERR_TOKENS_SHORTAGE == res);
 }
 
@@ -1455,10 +1455,10 @@ TEST_CASE("KiiJson, TokensShortageTest")
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_TOKENS_SHORTAGE == res);
 }
 
@@ -1480,10 +1480,10 @@ TEST_CASE("KiiJson, ExactTokensTest")
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse(
-        json_string,
-        strlen(json_string),
-        fields,
-        &resource);
+            json_string,
+            strlen(json_string),
+            fields,
+            &resource);
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
     REQUIRE(0 == strcmp("value1", fields[0].field_copy.string));
@@ -1507,11 +1507,11 @@ TEST_CASE("KiiJson, AllocatorTest")
     fields[1].name = NULL;
 
     jkii_parse_err_t res = jkii_parse_with_allocator(
-        json_string,
-        strlen(json_string),
-        fields,
-        cb_alloc,
-        cb_free);
+            json_string,
+            strlen(json_string),
+            fields,
+            cb_alloc,
+            cb_free);
 
     REQUIRE(JKII_ERR_OK == res);
     REQUIRE(JKII_FIELD_ERR_OK == fields[0].result);
@@ -1534,11 +1534,11 @@ TEST_CASE("KiiJson, FailedAllocationTest")
 
 
     jkii_parse_err_t res = jkii_parse_with_allocator(
-        json_string,
-        strlen(json_string),
-        fields,
-        allocate_cb_fail,
-        cb_free);
+            json_string,
+            strlen(json_string),
+            fields,
+            allocate_cb_fail,
+            cb_free);
 
     REQUIRE(JKII_ERR_ALLOCATION == res);
 }

--- a/tests/small_test/khc/header_parser_test.cpp
+++ b/tests/small_test/khc/header_parser_test.cpp
@@ -4,163 +4,163 @@
 #include "khc_impl.h"
 
 TEST_CASE( "_contains_chunked tests" ) {
-  SECTION( "chunked exists" ) {
-    const char str[] = "chunked\r\n";
-    int res = _contains_chunked(str, strlen(str) - 2);
-    REQUIRE( res == 1);
-  }
-  SECTION( "ignore case" ) {
-    const char str[] = "ChUnkEd\r\n";
-    int res = _contains_chunked(str, strlen(str) - 2);
-    REQUIRE( res == 1);
-  }
-  SECTION( "chunked and others exist" ) {
-    const char str[] = "gzip, compress, chunked, deflate\r\n";
-    int res = _contains_chunked(str, strlen(str) - 2);
-    REQUIRE( res == 1);
-  }
-  SECTION( "chunked no exist" ) {
-    const char str[] = "gzip, compress, deflate\r\n";
-    int res = _contains_chunked(str, strlen(str) - 2);
-    REQUIRE( res == 0);
-  }
-  SECTION( "empty string" ) {
-    int res = _contains_chunked("", 0);
-    REQUIRE( res == 0);
-  }
-  SECTION( "NULL" ) {
-    int res = _contains_chunked(NULL, 0);
-    REQUIRE( res == 0);
-  }
+    SECTION( "chunked exists" ) {
+        const char str[] = "chunked\r\n";
+        int res = _contains_chunked(str, strlen(str) - 2);
+        REQUIRE( res == 1);
+    }
+    SECTION( "ignore case" ) {
+        const char str[] = "ChUnkEd\r\n";
+        int res = _contains_chunked(str, strlen(str) - 2);
+        REQUIRE( res == 1);
+    }
+    SECTION( "chunked and others exist" ) {
+        const char str[] = "gzip, compress, chunked, deflate\r\n";
+        int res = _contains_chunked(str, strlen(str) - 2);
+        REQUIRE( res == 1);
+    }
+    SECTION( "chunked no exist" ) {
+        const char str[] = "gzip, compress, deflate\r\n";
+        int res = _contains_chunked(str, strlen(str) - 2);
+        REQUIRE( res == 0);
+    }
+    SECTION( "empty string" ) {
+        int res = _contains_chunked("", 0);
+        REQUIRE( res == 0);
+    }
+    SECTION( "NULL" ) {
+        int res = _contains_chunked(NULL, 0);
+        REQUIRE( res == 0);
+    }
 }
 
 TEST_CASE( "_is_chunked_encoding tests" ) {
-  SECTION( "default pattern header" ) {
-    const char str[] = "transfer-encoding:chunked\r\n";
-    int res = _is_chunked_encoding(str, strlen(str) - 2);
-    REQUIRE( res == 1);
-  }
-  SECTION( "optional white spaces exist" ) {
-    const char str[] = "transfer-encoding: \t chunked\r\n";
-    int res = _is_chunked_encoding(str, strlen(str) - 2);
-    REQUIRE( res == 1);
-  }
-  SECTION( "ignore case" ) {
-    const char str[] = "TrAnSfeR-enCodING: chunked\r\n";
-    int res = _is_chunked_encoding(str, strlen(str) - 2);
-    REQUIRE( res == 1);
-  }
-  SECTION( "chunked and others exist" ) {
-    const char str[] = "Transfer-Encoding: gzip, chunked, compress\r\n";
-    int res = _is_chunked_encoding(str, strlen(str) - 2);
-    REQUIRE( res == 1);
-  }
-  SECTION( "other header" ) {
-    const char str[] = "Content-Length: 0\r\n";
-    int res = _is_chunked_encoding(str, strlen(str) - 2);
-    REQUIRE( res == 0);
-  }
-  SECTION( "empty string" ) {
-    int res = _is_chunked_encoding("", 0);
-    REQUIRE( res == 0);
-  }
-  SECTION( "NULL" ) {
-    int res = _is_chunked_encoding(NULL, 0);
-    REQUIRE( res == 0);
-  }
+    SECTION( "default pattern header" ) {
+        const char str[] = "transfer-encoding:chunked\r\n";
+        int res = _is_chunked_encoding(str, strlen(str) - 2);
+        REQUIRE( res == 1);
+    }
+    SECTION( "optional white spaces exist" ) {
+        const char str[] = "transfer-encoding: \t chunked\r\n";
+        int res = _is_chunked_encoding(str, strlen(str) - 2);
+        REQUIRE( res == 1);
+    }
+    SECTION( "ignore case" ) {
+        const char str[] = "TrAnSfeR-enCodING: chunked\r\n";
+        int res = _is_chunked_encoding(str, strlen(str) - 2);
+        REQUIRE( res == 1);
+    }
+    SECTION( "chunked and others exist" ) {
+        const char str[] = "Transfer-Encoding: gzip, chunked, compress\r\n";
+        int res = _is_chunked_encoding(str, strlen(str) - 2);
+        REQUIRE( res == 1);
+    }
+    SECTION( "other header" ) {
+        const char str[] = "Content-Length: 0\r\n";
+        int res = _is_chunked_encoding(str, strlen(str) - 2);
+        REQUIRE( res == 0);
+    }
+    SECTION( "empty string" ) {
+        int res = _is_chunked_encoding("", 0);
+        REQUIRE( res == 0);
+    }
+    SECTION( "NULL" ) {
+        int res = _is_chunked_encoding(NULL, 0);
+        REQUIRE( res == 0);
+    }
 }
 
 TEST_CASE( "_extract_content_length tests" ) {
-  SECTION( "default pattern header exist" ) {
-    size_t len = 0;
-    const char str[] = "content-length:123\r\n";
-    int res = _extract_content_length(str, strlen(str) - 2, &len);
-    REQUIRE( res == 1);
-    REQUIRE( len == 123);
-  }
-  SECTION( "optional white spaces exist ahead" ) {
-    size_t len = 0;
-    const char str[] = "content-length:\t \t 45678\r\n";
-    int res = _extract_content_length(str, strlen(str) - 2, &len);
-    REQUIRE( res == 1);
-    REQUIRE( len == 45678);
-  }
-  SECTION( "optional white spaces exist behind" ) {
-    size_t len = 0;
-    const char str[] = "content-length:1122 \t \r\n";
-    int res = _extract_content_length(str, strlen(str) - 2, &len);
-    REQUIRE( res == 1);
-    REQUIRE( len == 1122);
-  }
-  SECTION( "optional white spaces exist both" ) {
-    size_t len = 0;
-    const char str[] = "content-length:  \t5656\t  \r\n";
-    int res = _extract_content_length(str, strlen(str) - 2, &len);
-    REQUIRE( res == 1);
-    REQUIRE( len == 5656);
-  }
-  SECTION( "ignore case" ) {
-    size_t len = 0;
-    const char str[] = "cOnTeNt-LenGtH: 1234\r\n";
-    int res = _extract_content_length(str, strlen(str) - 2, &len);
-    REQUIRE( res == 1);
-    REQUIRE( len == 1234);
-  }
-  SECTION( "other header" ) {
-    size_t len = 0;
-    const char str[] = "Transfer-Encoding: Chunked\r\n";
-    int res = _extract_content_length(str, strlen(str) - 2, &len);
-    REQUIRE( res == 0);
-    REQUIRE( len == 0);
-  }
-  SECTION( "empty string" ) {
-    size_t len = 0;
-    int res = _extract_content_length("", 0, &len);
-    REQUIRE( res == 0);
-    REQUIRE( len == 0);
-  }
-  SECTION( "NULL" ) {
-    size_t len = 0;
-    int res = _extract_content_length(NULL, 0, &len);
-    REQUIRE( res == 0);
-    REQUIRE( len == 0);
-  }
+    SECTION( "default pattern header exist" ) {
+        size_t len = 0;
+        const char str[] = "content-length:123\r\n";
+        int res = _extract_content_length(str, strlen(str) - 2, &len);
+        REQUIRE( res == 1);
+        REQUIRE( len == 123);
+    }
+    SECTION( "optional white spaces exist ahead" ) {
+        size_t len = 0;
+        const char str[] = "content-length:\t \t 45678\r\n";
+        int res = _extract_content_length(str, strlen(str) - 2, &len);
+        REQUIRE( res == 1);
+        REQUIRE( len == 45678);
+    }
+    SECTION( "optional white spaces exist behind" ) {
+        size_t len = 0;
+        const char str[] = "content-length:1122 \t \r\n";
+        int res = _extract_content_length(str, strlen(str) - 2, &len);
+        REQUIRE( res == 1);
+        REQUIRE( len == 1122);
+    }
+    SECTION( "optional white spaces exist both" ) {
+        size_t len = 0;
+        const char str[] = "content-length:  \t5656\t  \r\n";
+        int res = _extract_content_length(str, strlen(str) - 2, &len);
+        REQUIRE( res == 1);
+        REQUIRE( len == 5656);
+    }
+    SECTION( "ignore case" ) {
+        size_t len = 0;
+        const char str[] = "cOnTeNt-LenGtH: 1234\r\n";
+        int res = _extract_content_length(str, strlen(str) - 2, &len);
+        REQUIRE( res == 1);
+        REQUIRE( len == 1234);
+    }
+    SECTION( "other header" ) {
+        size_t len = 0;
+        const char str[] = "Transfer-Encoding: Chunked\r\n";
+        int res = _extract_content_length(str, strlen(str) - 2, &len);
+        REQUIRE( res == 0);
+        REQUIRE( len == 0);
+    }
+    SECTION( "empty string" ) {
+        size_t len = 0;
+        int res = _extract_content_length("", 0, &len);
+        REQUIRE( res == 0);
+        REQUIRE( len == 0);
+    }
+    SECTION( "NULL" ) {
+        size_t len = 0;
+        int res = _extract_content_length(NULL, 0, &len);
+        REQUIRE( res == 0);
+        REQUIRE( len == 0);
+    }
 }
 
 TEST_CASE( "_read_chunk_size test" ) {
-  SECTION( "chunk size line exists" ) {
-    const char* buff = "123\r\n";
-    size_t out_size = 0;
-    int res = _read_chunk_size(buff, strlen(buff), &out_size);
-    REQUIRE( res == 1);
-    REQUIRE( out_size == 0x123 );
-  }
-  SECTION( "no hex" ) {
-    const char* buff = "1z3\r\n";
-    size_t out_size = 0;
-    int res = _read_chunk_size(buff, strlen(buff), &out_size);
-    REQUIRE( res == 1);
-    REQUIRE( out_size == 0x1 );
-  }
-  SECTION( "LF no exists" ) {
-    const char* buff = "123\r";
-    size_t out_size = 0;
-    int res = _read_chunk_size(buff, strlen(buff), &out_size);
-    REQUIRE( res == 0);
-    REQUIRE( out_size == 0 );
-  }
-  SECTION( "CRLF no exists" ) {
-    const char* buff = "123";
-    size_t out_size = 0;
-    int res = _read_chunk_size(buff, strlen(buff), &out_size);
-    REQUIRE( res == 0);
-    REQUIRE( out_size == 0 );
-  }
-  SECTION( "empty string" ) {
-    const char* buff = "";
-    size_t out_size = 0;
-    int res = _read_chunk_size(buff, strlen(buff), &out_size);
-    REQUIRE( res == 0);
-    REQUIRE( out_size == 0 );
-  }
+    SECTION( "chunk size line exists" ) {
+        const char* buff = "123\r\n";
+        size_t out_size = 0;
+        int res = _read_chunk_size(buff, strlen(buff), &out_size);
+        REQUIRE( res == 1);
+        REQUIRE( out_size == 0x123 );
+    }
+    SECTION( "no hex" ) {
+        const char* buff = "1z3\r\n";
+        size_t out_size = 0;
+        int res = _read_chunk_size(buff, strlen(buff), &out_size);
+        REQUIRE( res == 1);
+        REQUIRE( out_size == 0x1 );
+    }
+    SECTION( "LF no exists" ) {
+        const char* buff = "123\r";
+        size_t out_size = 0;
+        int res = _read_chunk_size(buff, strlen(buff), &out_size);
+        REQUIRE( res == 0);
+        REQUIRE( out_size == 0 );
+    }
+    SECTION( "CRLF no exists" ) {
+        const char* buff = "123";
+        size_t out_size = 0;
+        int res = _read_chunk_size(buff, strlen(buff), &out_size);
+        REQUIRE( res == 0);
+        REQUIRE( out_size == 0 );
+    }
+    SECTION( "empty string" ) {
+        const char* buff = "";
+        size_t out_size = 0;
+        int res = _read_chunk_size(buff, strlen(buff), &out_size);
+        REQUIRE( res == 0);
+        REQUIRE( out_size == 0 );
+    }
 }

--- a/tests/small_test/khc/http_test.cpp
+++ b/tests/small_test/khc/http_test.cpp
@@ -7,106 +7,106 @@
 
 std::istream& khct::http::read_header(std::istream &in, std::string &out)
 {
-  char c;
-  while (in.get(c).good())
-  {
-    if (c == '\r')
+    char c;
+    while (in.get(c).good())
     {
-      c = in.peek();
-      if (in.good())
-      {
-        if (c == '\n')
+        if (c == '\r')
         {
-          in.ignore();
-          break;
+            c = in.peek();
+            if (in.good())
+            {
+                if (c == '\n')
+                {
+                    in.ignore();
+                    break;
+                }
+            }
         }
-      }
+        out.append(1, c);
     }
-    out.append(1, c);
-  }
-  return in;
+    return in;
 }
 
 void khct::http::create_random_chunked_body(std::ostream &chunkedBody, std::ostream &expectBody) {
-  string baseC =
-    "0123456789"
-    " \t\r\n"
-    "abcdefghijklmnopqrstuvwxyz"
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-  random_device rd;
-  mt19937 mt(rd());
-  uniform_int_distribution<> randNum(10, 50);
-  uniform_int_distribution<> randSize(10, 200);
-  uniform_int_distribution<> randBody(0, baseC.size() - 1);
-  const char* CRLF = "\r\n";
-  for (int chunkNum = 0; chunkNum < randNum(mt); ++chunkNum) {
-    size_t chunkSize = randSize(mt);
-    chunkedBody << hex << chunkSize << CRLF;
-    for (int i = 0; i < chunkSize; ++i) {
-      const char c = baseC[randBody(mt)];
-      chunkedBody << c;
-      expectBody << c;
+    string baseC =
+        "0123456789"
+        " \t\r\n"
+        "abcdefghijklmnopqrstuvwxyz"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    random_device rd;
+    mt19937 mt(rd());
+    uniform_int_distribution<> randNum(10, 50);
+    uniform_int_distribution<> randSize(10, 200);
+    uniform_int_distribution<> randBody(0, baseC.size() - 1);
+    const char* CRLF = "\r\n";
+    for (int chunkNum = 0; chunkNum < randNum(mt); ++chunkNum) {
+        size_t chunkSize = randSize(mt);
+        chunkedBody << hex << chunkSize << CRLF;
+        for (int i = 0; i < chunkSize; ++i) {
+            const char c = baseC[randBody(mt)];
+            chunkedBody << c;
+            expectBody << c;
+        }
+        chunkedBody << CRLF;
     }
-    chunkedBody << CRLF;
-  }
-  chunkedBody << "0" << CRLF << CRLF;
+    chunkedBody << "0" << CRLF << CRLF;
 }
 
 std::string khct::http::Resp::to_string() {
-  ostringstream o;
-  vector<string> sub = headers;
+    ostringstream o;
+    vector<string> sub = headers;
 
-  if (_add_status_100) {
-    const char* CRLF = "\r\n";
-    o << sub[0];
-    o << CRLF;
-    o << sub[1];
-    o << CRLF;
-    o << CRLF;
-    sub.erase(sub.begin());
-    sub.erase(sub.begin());
-  }
+    if (_add_status_100) {
+        const char* CRLF = "\r\n";
+        o << sub[0];
+        o << CRLF;
+        o << sub[1];
+        o << CRLF;
+        o << CRLF;
+        sub.erase(sub.begin());
+        sub.erase(sub.begin());
+    }
 
-  for (string h : sub) {
-    o << h;
+    for (string h : sub) {
+        o << h;
+        o << "\r\n";
+    }
     o << "\r\n";
-  }
-  o << "\r\n";
-  o << body;
-  return o.str();
+    o << body;
+    return o.str();
 }
 
 std::istringstream khct::http::Resp::to_istringstream() {
-  return std::istringstream(this->to_string());
+    return std::istringstream(this->to_string());
 }
 
 khct::http::Resp::Resp() {}
 
 khct::http::Resp::Resp(std::istream& is, bool add_status_100) : _add_status_100(add_status_100) {
-  is.seekg(0, std::ios::end);
-  std::streampos length = is.tellg();
-  is.seekg(0, std::ios::beg);
+    is.seekg(0, std::ios::end);
+    std::streampos length = is.tellg();
+    is.seekg(0, std::ios::beg);
 
-  if (add_status_100) {
-    this->headers.push_back("HTTP/1.1 100 Continue");
-    this->headers.push_back("Host: api.kii.com");
-  }
-  while(is.tellg() < length && is.good()) {
-    std::string header = "";
-    read_header(is, header);
-    if (header == "") {
-      break;
+    if (add_status_100) {
+        this->headers.push_back("HTTP/1.1 100 Continue");
+        this->headers.push_back("Host: api.kii.com");
     }
-    this->headers.push_back(header);
-  }
-  // Read body
-  char* buffer = new char[1024];
-  std::ostringstream os;
-  while (is.tellg() < length && is.good()) {
-    is.read(buffer, 1024);
-    size_t len = is.gcount();
-    os.write(buffer, len);
-  }
-  delete[] buffer;
-  this->body = os.str();
+    while(is.tellg() < length && is.good()) {
+        std::string header = "";
+        read_header(is, header);
+        if (header == "") {
+            break;
+        }
+        this->headers.push_back(header);
+    }
+    // Read body
+    char* buffer = new char[1024];
+    std::ostringstream os;
+    while (is.tellg() < length && is.good()) {
+        is.read(buffer, 1024);
+        size_t len = is.gcount();
+        os.write(buffer, len);
+    }
+    delete[] buffer;
+    this->body = os.str();
 }

--- a/tests/small_test/khc/http_test.h
+++ b/tests/small_test/khc/http_test.h
@@ -19,14 +19,14 @@ void create_random_chunked_body(std::ostream &chunkedBody, std::ostream &expectB
 }
 
 struct khct::http::Resp {
-  bool _add_status_100 = false;
+    bool _add_status_100 = false;
 
-  std::vector<std::string> headers;
-  std::string body;
-  std::string to_string();
-  std::istringstream to_istringstream();
-  Resp();
-  Resp(std::istream& is, bool add_status_100 = false);
+    std::vector<std::string> headers;
+    std::string body;
+    std::string to_string();
+    std::istringstream to_istringstream();
+    Resp();
+    Resp(std::istream& is, bool add_status_100 = false);
 };
 }
 

--- a/tests/small_test/khc/response_chunk_test.cpp
+++ b/tests/small_test/khc/response_chunk_test.cpp
@@ -9,534 +9,534 @@
 #include <string.h>
 
 TEST_CASE( "HTTP chunked response test" ) {
-  khc http;
-  khc_init(&http);
-  const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
+    khc http;
+    khc_init(&http);
+    const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
 
-  ifstream ifs;
-  ifs.open("./data/resp-login-chunked.txt");
+    ifstream ifs;
+    ifs.open("./data/resp-login-chunked.txt");
 
-  khct::http::Resp resp(ifs);
+    khct::http::Resp resp(ifs);
 
-  ifs.close();
+    ifs.close();
 
-  khc_set_host(&http, "api.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_path(&http, "/api/apps");
-  khc_set_req_headers(&http, NULL);
+    khc_set_host(&http, "api.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_path(&http, "/api/apps");
+    khc_set_req_headers(&http, NULL);
 
-  khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
+    khct::cb::SockCtx s_ctx;
+    khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
 
-  khct::cb::IOCtx io_ctx;
-  khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+    khct::cb::IOCtx io_ctx;
+    khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
-  int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
-    ++on_connect_called;
-    REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
-    REQUIRE( strlen(host) == strlen("api.kii.com") );
-    REQUIRE( port == 443 );
-    return KHC_SOCK_OK;
-  };
+    int on_connect_called = 0;
+    s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+        ++on_connect_called;
+        REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
+        REQUIRE( strlen(host) == strlen("api.kii.com") );
+        REQUIRE( port == 443 );
+        return KHC_SOCK_OK;
+    };
 
-  int on_send_called = 0;
-  s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    ++on_send_called;
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
+    int on_send_called = 0;
+    s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        ++on_send_called;
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
 
-  int on_read_called = 0;
-  io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
-    ++on_read_called;
-    REQUIRE( size == buff_size );
-    return 0;
-  };
+    int on_read_called = 0;
+    io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
+        ++on_read_called;
+        REQUIRE( size == buff_size );
+        return 0;
+    };
 
-  int on_recv_called = 0;
-  auto is = resp.to_istringstream();
-  s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    ++on_recv_called;
-    if (on_recv_called == 1)
-      REQUIRE( length_to_read == 255 );
-    if (on_recv_called == 2)
-      REQUIRE( length_to_read == 236 );
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
+    int on_recv_called = 0;
+    auto is = resp.to_istringstream();
+    s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        ++on_recv_called;
+        if (on_recv_called == 1)
+            REQUIRE( length_to_read == 255 );
+        if (on_recv_called == 2)
+            REQUIRE( length_to_read == 236 );
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
+    };
 
-  int on_header_called = 0;
-  io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
-    const char* header = resp.headers[on_header_called].c_str();
-    size_t len = strlen(header);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, header, len) == 0 );
-    ++on_header_called;
-    return size;
-  };
+    int on_header_called = 0;
+    io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
+        const char* header = resp.headers[on_header_called].c_str();
+        size_t len = strlen(header);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, header, len) == 0 );
+        ++on_header_called;
+        return size;
+    };
 
-  ostringstream oss;
-  int on_write_called = 0;
-  io_ctx.on_write = [=, &oss, &on_write_called](char *buffer, size_t size, void *userdata) {
-    ++on_write_called;
-    oss.write(buffer, size);
-    return size;
-  };
+    ostringstream oss;
+    int on_write_called = 0;
+    io_ctx.on_write = [=, &oss, &on_write_called](char *buffer, size_t size, void *userdata) {
+        ++on_write_called;
+        oss.write(buffer, size);
+        return size;
+    };
 
-  int on_close_called = 0;
-  s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
-    ++on_close_called;
-    return KHC_SOCK_OK;
-  };
+    int on_close_called = 0;
+    s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
+        ++on_close_called;
+        return KHC_SOCK_OK;
+    };
 
-  khc_code res = khc_perform(&http);
-  REQUIRE( res == KHC_ERR_OK );
-  REQUIRE( khc_get_status_code(&http) == 200 );
-  REQUIRE( on_connect_called == 1 );
-  REQUIRE( on_send_called == 5 );
-  REQUIRE( on_read_called == 1 );
-  REQUIRE( on_recv_called == 4 );
-  REQUIRE( on_header_called == 12 );
-  REQUIRE( on_write_called >= 6 );
-  REQUIRE( on_close_called == 1 );
+    khc_code res = khc_perform(&http);
+    REQUIRE( res == KHC_ERR_OK );
+    REQUIRE( khc_get_status_code(&http) == 200 );
+    REQUIRE( on_connect_called == 1 );
+    REQUIRE( on_send_called == 5 );
+    REQUIRE( on_read_called == 1 );
+    REQUIRE( on_recv_called == 4 );
+    REQUIRE( on_header_called == 12 );
+    REQUIRE( on_write_called >= 6 );
+    REQUIRE( on_close_called == 1 );
 
-  string chunkedBody =
-    "{"
-    "  \"id\" : \"b56270b00022-171b-7e11-b35e-0911a10d\","
-    "  \"access_token\" : \"cHltZmFtc3cxMnJn._I4i4fNNTjRfWia9juCpRgipPUNWD1-6bobnfJvQPms\","
-    "  \"expires_in\" : 2147483646,"
-    "  \"token_type\" : \"Bearer\""
-    "}";
-  REQUIRE( chunkedBody == oss.str() );
+    string chunkedBody =
+        "{"
+        "  \"id\" : \"b56270b00022-171b-7e11-b35e-0911a10d\","
+        "  \"access_token\" : \"cHltZmFtc3cxMnJn._I4i4fNNTjRfWia9juCpRgipPUNWD1-6bobnfJvQPms\","
+        "  \"expires_in\" : 2147483646,"
+        "  \"token_type\" : \"Bearer\""
+        "}";
+    REQUIRE( chunkedBody == oss.str() );
 }
 
 TEST_CASE( "small buffer size test" ) {
-  khc http;
-  khc_init(&http);
-  const size_t buff_size = 10;
-  char buff[buff_size];
+    khc http;
+    khc_init(&http);
+    const size_t buff_size = 10;
+    char buff[buff_size];
 
-  ifstream ifs;
-  ifs.open("./data/resp-login-chunked.txt");
+    ifstream ifs;
+    ifs.open("./data/resp-login-chunked.txt");
 
-  khct::http::Resp resp(ifs);
+    khct::http::Resp resp(ifs);
 
-  ifs.close();
+    ifs.close();
 
-  khc_set_host(&http, "api.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_path(&http, "/api/apps");
-  khc_set_req_headers(&http, NULL);
-  khc_set_stream_buff(&http, buff, buff_size);
+    khc_set_host(&http, "api.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_path(&http, "/api/apps");
+    khc_set_req_headers(&http, NULL);
+    khc_set_stream_buff(&http, buff, buff_size);
 
-  khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
+    khct::cb::SockCtx s_ctx;
+    khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
 
-  khct::cb::IOCtx io_ctx;
-  khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+    khct::cb::IOCtx io_ctx;
+    khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
-  int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
-    ++on_connect_called;
-    REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
-    REQUIRE( strlen(host) == strlen("api.kii.com") );
-    REQUIRE( port == 443 );
-    return KHC_SOCK_OK;
-  };
+    int on_connect_called = 0;
+    s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+        ++on_connect_called;
+        REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
+        REQUIRE( strlen(host) == strlen("api.kii.com") );
+        REQUIRE( port == 443 );
+        return KHC_SOCK_OK;
+    };
 
-  int on_send_called = 0;
-  s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    ++on_send_called;
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
+    int on_send_called = 0;
+    s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        ++on_send_called;
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
 
-  int on_read_called = 0;
-  io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
-    ++on_read_called;
-    REQUIRE( size == buff_size );
-    return 0;
-  };
+    int on_read_called = 0;
+    io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
+        ++on_read_called;
+        REQUIRE( size == buff_size );
+        return 0;
+    };
 
-  int on_recv_called = 0;
-  auto is = resp.to_istringstream();
-  s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    ++on_recv_called;
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
+    int on_recv_called = 0;
+    auto is = resp.to_istringstream();
+    s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        ++on_recv_called;
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
+    };
 
-  int on_header_called = 0;
-  io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
-    const char* header = resp.headers[on_header_called].c_str();
-    size_t len = strlen(header);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, header, len) == 0 );
-    ++on_header_called;
-    return size;
-  };
+    int on_header_called = 0;
+    io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
+        const char* header = resp.headers[on_header_called].c_str();
+        size_t len = strlen(header);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, header, len) == 0 );
+        ++on_header_called;
+        return size;
+    };
 
-  ostringstream oss;
-  int on_write_called = 0;
-  io_ctx.on_write = [=, &oss, &on_write_called](char *buffer, size_t size, void *userdata) {
-    ++on_write_called;
-    oss.write(buffer, size);
-    return size;
-  };
+    ostringstream oss;
+    int on_write_called = 0;
+    io_ctx.on_write = [=, &oss, &on_write_called](char *buffer, size_t size, void *userdata) {
+        ++on_write_called;
+        oss.write(buffer, size);
+        return size;
+    };
 
-  int on_close_called = 0;
-  s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
-    ++on_close_called;
-    return KHC_SOCK_OK;
-  };
+    int on_close_called = 0;
+    s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
+        ++on_close_called;
+        return KHC_SOCK_OK;
+    };
 
-  khc_code res = khc_perform(&http);
-  REQUIRE( res == KHC_ERR_OK );
-  REQUIRE( khc_get_status_code(&http) == 200 );
-  REQUIRE( on_connect_called == 1 );
-  REQUIRE( on_send_called == 5 );
-  REQUIRE( on_read_called == 1 );
-  REQUIRE( on_recv_called > 0 );
-  REQUIRE( on_header_called == 12 );
-  REQUIRE( on_write_called > 0 );
-  REQUIRE( on_close_called == 1 );
+    khc_code res = khc_perform(&http);
+    REQUIRE( res == KHC_ERR_OK );
+    REQUIRE( khc_get_status_code(&http) == 200 );
+    REQUIRE( on_connect_called == 1 );
+    REQUIRE( on_send_called == 5 );
+    REQUIRE( on_read_called == 1 );
+    REQUIRE( on_recv_called > 0 );
+    REQUIRE( on_header_called == 12 );
+    REQUIRE( on_write_called > 0 );
+    REQUIRE( on_close_called == 1 );
 
-  string chunkedBody =
-    "{"
-    "  \"id\" : \"b56270b00022-171b-7e11-b35e-0911a10d\","
-    "  \"access_token\" : \"cHltZmFtc3cxMnJn._I4i4fNNTjRfWia9juCpRgipPUNWD1-6bobnfJvQPms\","
-    "  \"expires_in\" : 2147483646,"
-    "  \"token_type\" : \"Bearer\""
-    "}";
-  REQUIRE( chunkedBody == oss.str() );
+    string chunkedBody =
+        "{"
+        "  \"id\" : \"b56270b00022-171b-7e11-b35e-0911a10d\","
+        "  \"access_token\" : \"cHltZmFtc3cxMnJn._I4i4fNNTjRfWia9juCpRgipPUNWD1-6bobnfJvQPms\","
+        "  \"expires_in\" : 2147483646,"
+        "  \"token_type\" : \"Bearer\""
+        "}";
+    REQUIRE( chunkedBody == oss.str() );
 }
 
 TEST_CASE( "random buffer size test" ) {
-  khc http;
-  khc_init(&http);
-  random_device rd;
-  mt19937 mt(rd());
-  uniform_int_distribution<> randSize(10, 100);
-  const size_t buff_size = randSize(mt);
-  char buff[buff_size];
-  cout << "Random Buffer Size: " << buff_size << endl;
+    khc http;
+    khc_init(&http);
+    random_device rd;
+    mt19937 mt(rd());
+    uniform_int_distribution<> randSize(10, 100);
+    const size_t buff_size = randSize(mt);
+    char buff[buff_size];
+    cout << "Random Buffer Size: " << buff_size << endl;
 
-  ifstream ifs;
-  ifs.open("./data/resp-login-chunked.txt");
+    ifstream ifs;
+    ifs.open("./data/resp-login-chunked.txt");
 
-  khct::http::Resp resp(ifs);
+    khct::http::Resp resp(ifs);
 
-  ifs.close();
+    ifs.close();
 
-  khc_set_host(&http, "api.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_path(&http, "/api/apps");
-  khc_set_req_headers(&http, NULL);
-  khc_set_stream_buff(&http, buff, buff_size);
+    khc_set_host(&http, "api.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_path(&http, "/api/apps");
+    khc_set_req_headers(&http, NULL);
+    khc_set_stream_buff(&http, buff, buff_size);
 
-  khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
+    khct::cb::SockCtx s_ctx;
+    khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
 
-  khct::cb::IOCtx io_ctx;
-  khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+    khct::cb::IOCtx io_ctx;
+    khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
-  int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
-    ++on_connect_called;
-    REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
-    REQUIRE( strlen(host) == strlen("api.kii.com") );
-    REQUIRE( port == 443 );
-    return KHC_SOCK_OK;
-  };
+    int on_connect_called = 0;
+    s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+        ++on_connect_called;
+        REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
+        REQUIRE( strlen(host) == strlen("api.kii.com") );
+        REQUIRE( port == 443 );
+        return KHC_SOCK_OK;
+    };
 
-  int on_send_called = 0;
-  s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    ++on_send_called;
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
+    int on_send_called = 0;
+    s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        ++on_send_called;
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
 
-  int on_read_called = 0;
-  io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
-    ++on_read_called;
-    REQUIRE( size == buff_size );
-    return 0;
-  };
+    int on_read_called = 0;
+    io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
+        ++on_read_called;
+        REQUIRE( size == buff_size );
+        return 0;
+    };
 
-  int on_recv_called = 0;
-  auto is = resp.to_istringstream();
-  s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    ++on_recv_called;
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
+    int on_recv_called = 0;
+    auto is = resp.to_istringstream();
+    s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        ++on_recv_called;
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
+    };
 
-  int on_header_called = 0;
-  io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
-    const char* header = resp.headers[on_header_called].c_str();
-    size_t len = strlen(header);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, header, len) == 0 );
-    ++on_header_called;
-    return size;
-  };
+    int on_header_called = 0;
+    io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
+        const char* header = resp.headers[on_header_called].c_str();
+        size_t len = strlen(header);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, header, len) == 0 );
+        ++on_header_called;
+        return size;
+    };
 
-  ostringstream oss;
-  int on_write_called = 0;
-  io_ctx.on_write = [=, &oss, &on_write_called](char *buffer, size_t size, void *userdata) {
-    ++on_write_called;
-    oss.write(buffer, size);
-    return size;
-  };
+    ostringstream oss;
+    int on_write_called = 0;
+    io_ctx.on_write = [=, &oss, &on_write_called](char *buffer, size_t size, void *userdata) {
+        ++on_write_called;
+        oss.write(buffer, size);
+        return size;
+    };
 
-  int on_close_called = 0;
-  s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
-    ++on_close_called;
-    return KHC_SOCK_OK;
-  };
+    int on_close_called = 0;
+    s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
+        ++on_close_called;
+        return KHC_SOCK_OK;
+    };
 
-  khc_code res = khc_perform(&http);
-  REQUIRE( res == KHC_ERR_OK );
-  REQUIRE( khc_get_status_code(&http) == 200 );
-  REQUIRE( on_connect_called == 1 );
-  REQUIRE( on_send_called == 5 );
-  REQUIRE( on_read_called == 1 );
-  REQUIRE( on_recv_called > 0 );
-  REQUIRE( on_header_called == 12 );
-  REQUIRE( on_write_called > 0 );
-  REQUIRE( on_close_called == 1 );
+    khc_code res = khc_perform(&http);
+    REQUIRE( res == KHC_ERR_OK );
+    REQUIRE( khc_get_status_code(&http) == 200 );
+    REQUIRE( on_connect_called == 1 );
+    REQUIRE( on_send_called == 5 );
+    REQUIRE( on_read_called == 1 );
+    REQUIRE( on_recv_called > 0 );
+    REQUIRE( on_header_called == 12 );
+    REQUIRE( on_write_called > 0 );
+    REQUIRE( on_close_called == 1 );
 
-  string chunkedBody =
-    "{"
-    "  \"id\" : \"b56270b00022-171b-7e11-b35e-0911a10d\","
-    "  \"access_token\" : \"cHltZmFtc3cxMnJn._I4i4fNNTjRfWia9juCpRgipPUNWD1-6bobnfJvQPms\","
-    "  \"expires_in\" : 2147483646,"
-    "  \"token_type\" : \"Bearer\""
-    "}";
-  REQUIRE( chunkedBody == oss.str() );
+    string chunkedBody =
+        "{"
+        "  \"id\" : \"b56270b00022-171b-7e11-b35e-0911a10d\","
+        "  \"access_token\" : \"cHltZmFtc3cxMnJn._I4i4fNNTjRfWia9juCpRgipPUNWD1-6bobnfJvQPms\","
+        "  \"expires_in\" : 2147483646,"
+        "  \"token_type\" : \"Bearer\""
+        "}";
+    REQUIRE( chunkedBody == oss.str() );
 }
 
 TEST_CASE( "random chunk body test" ) {
-  khc http;
-  khc_init(&http);
+    khc http;
+    khc_init(&http);
 
-  ifstream ifs;
-  ifs.open("./data/resp-login-chunked-headers.txt");
+    ifstream ifs;
+    ifs.open("./data/resp-login-chunked-headers.txt");
 
-  khct::http::Resp resp(ifs);
+    khct::http::Resp resp(ifs);
 
-  ifs.close();
+    ifs.close();
 
-  ostringstream responseBody;
-  ostringstream expectBody;
-  khct::http::create_random_chunked_body(responseBody, expectBody);
-  resp.body = responseBody.str();
+    ostringstream responseBody;
+    ostringstream expectBody;
+    khct::http::create_random_chunked_body(responseBody, expectBody);
+    resp.body = responseBody.str();
 
-  ofstream ofs("tmp_random_chunk_response.txt");
-  ofs << resp.to_string();
-  ofs.close();
+    ofstream ofs("tmp_random_chunk_response.txt");
+    ofs << resp.to_string();
+    ofs.close();
 
-  khc_set_host(&http, "api.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_path(&http, "/api/apps");
-  khc_set_req_headers(&http, NULL);
+    khc_set_host(&http, "api.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_path(&http, "/api/apps");
+    khc_set_req_headers(&http, NULL);
 
-  khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
+    khct::cb::SockCtx s_ctx;
+    khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
 
-  khct::cb::IOCtx io_ctx;
-  khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+    khct::cb::IOCtx io_ctx;
+    khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
-  int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
-    ++on_connect_called;
-    REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
-    REQUIRE( strlen(host) == strlen("api.kii.com") );
-    REQUIRE( port == 443 );
-    return KHC_SOCK_OK;
-  };
+    int on_connect_called = 0;
+    s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+        ++on_connect_called;
+        REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
+        REQUIRE( strlen(host) == strlen("api.kii.com") );
+        REQUIRE( port == 443 );
+        return KHC_SOCK_OK;
+    };
 
-  int on_send_called = 0;
-  s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    ++on_send_called;
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
+    int on_send_called = 0;
+    s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        ++on_send_called;
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
 
-  int on_read_called = 0;
-  io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
-    ++on_read_called;
-    REQUIRE( size == DEFAULT_STREAM_BUFF_SIZE);
-    return 0;
-  };
+    int on_read_called = 0;
+    io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
+        ++on_read_called;
+        REQUIRE( size == DEFAULT_STREAM_BUFF_SIZE);
+        return 0;
+    };
 
-  int on_recv_called = 0;
-  auto is = resp.to_istringstream();
-  s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    ++on_recv_called;
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
+    int on_recv_called = 0;
+    auto is = resp.to_istringstream();
+    s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        ++on_recv_called;
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
+    };
 
-  int on_header_called = 0;
-  io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
-    const char* header = resp.headers[on_header_called].c_str();
-    size_t len = strlen(header);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, header, len) == 0 );
-    ++on_header_called;
-    return size;
-  };
+    int on_header_called = 0;
+    io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
+        const char* header = resp.headers[on_header_called].c_str();
+        size_t len = strlen(header);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, header, len) == 0 );
+        ++on_header_called;
+        return size;
+    };
 
-  ostringstream oss;
-  int on_write_called = 0;
-  io_ctx.on_write = [=, &oss, &on_write_called](char *buffer, size_t size, void *userdata) {
-    ++on_write_called;
-    oss.write(buffer, size);
-    return size;
-  };
+    ostringstream oss;
+    int on_write_called = 0;
+    io_ctx.on_write = [=, &oss, &on_write_called](char *buffer, size_t size, void *userdata) {
+        ++on_write_called;
+        oss.write(buffer, size);
+        return size;
+    };
 
-  int on_close_called = 0;
-  s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
-    ++on_close_called;
-    return KHC_SOCK_OK;
-  };
+    int on_close_called = 0;
+    s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
+        ++on_close_called;
+        return KHC_SOCK_OK;
+    };
 
-  khc_code res = khc_perform(&http);
-  REQUIRE( res == KHC_ERR_OK );
-  REQUIRE( khc_get_status_code(&http) == 200 );
-  REQUIRE( on_connect_called == 1 );
-  REQUIRE( on_send_called > 0 );
-  REQUIRE( on_read_called > 0 );
-  REQUIRE( on_recv_called > 0 );
-  REQUIRE( on_header_called == 12 );
-  REQUIRE( on_write_called > 0 );
-  REQUIRE( on_close_called == 1 );
+    khc_code res = khc_perform(&http);
+    REQUIRE( res == KHC_ERR_OK );
+    REQUIRE( khc_get_status_code(&http) == 200 );
+    REQUIRE( on_connect_called == 1 );
+    REQUIRE( on_send_called > 0 );
+    REQUIRE( on_read_called > 0 );
+    REQUIRE( on_recv_called > 0 );
+    REQUIRE( on_header_called == 12 );
+    REQUIRE( on_write_called > 0 );
+    REQUIRE( on_close_called == 1 );
 
-  REQUIRE( expectBody.str() == oss.str() );
+    REQUIRE( expectBody.str() == oss.str() );
 }
 
 TEST_CASE( "HTTP response 400 test(chunked)" ) {
-  khc http;
-  khc_init(&http);
-  const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
+    khc http;
+    khc_init(&http);
+    const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
 
-  string expectBody = "dummy body.";
-  stringstream ss;
-  ss << "HTTP/1.1 400 Bad Request\r\nTransfer-Encoding: chunked\r\n\r\n";
-  ss << hex << expectBody.size() << "\r\n" << expectBody << "\r\n0\r\n\r\n";
+    string expectBody = "dummy body.";
+    stringstream ss;
+    ss << "HTTP/1.1 400 Bad Request\r\nTransfer-Encoding: chunked\r\n\r\n";
+    ss << hex << expectBody.size() << "\r\n" << expectBody << "\r\n0\r\n\r\n";
 
-  khct::http::Resp resp(ss);
+    khct::http::Resp resp(ss);
 
-  khc_set_host(&http, "api.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_path(&http, "/api/apps");
-  khc_set_req_headers(&http, NULL);
+    khc_set_host(&http, "api.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_path(&http, "/api/apps");
+    khc_set_req_headers(&http, NULL);
 
-  khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
+    khct::cb::SockCtx s_ctx;
+    khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
 
-  khct::cb::IOCtx io_ctx;
-  // no set cb_read.
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+    khct::cb::IOCtx io_ctx;
+    // no set cb_read.
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
-  int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
-    ++on_connect_called;
-    REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
-    REQUIRE( strlen(host) == strlen("api.kii.com") );
-    REQUIRE( port == 443 );
-    return KHC_SOCK_OK;
-  };
+    int on_connect_called = 0;
+    s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+        ++on_connect_called;
+        REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
+        REQUIRE( strlen(host) == strlen("api.kii.com") );
+        REQUIRE( port == 443 );
+        return KHC_SOCK_OK;
+    };
 
-  int on_send_called = 0;
-  s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    ++on_send_called;
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
+    int on_send_called = 0;
+    s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        ++on_send_called;
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
 
-  int on_read_called = 0;
-  io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
-    ++on_read_called;
-    FAIL();
-    return 0;
-  };
+    int on_read_called = 0;
+    io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
+        ++on_read_called;
+        FAIL();
+        return 0;
+    };
 
-  int on_recv_called = 0;
-  auto is = resp.to_istringstream();
-  s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    ++on_recv_called;
-    if (on_recv_called == 1) {
-        // recv header.
-        REQUIRE( length_to_read == 255 );
-    } else {
-        // recv body(= 0).
-        REQUIRE( length_to_read == 1024 );
-    }
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
+    int on_recv_called = 0;
+    auto is = resp.to_istringstream();
+    s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        ++on_recv_called;
+        if (on_recv_called == 1) {
+            // recv header.
+            REQUIRE( length_to_read == 255 );
+        } else {
+            // recv body(= 0).
+            REQUIRE( length_to_read == 1024 );
+        }
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
+    };
 
-  int on_header_called = 0;
-  io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
-    const char* header = resp.headers[on_header_called].c_str();
-    size_t len = strlen(header);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, header, len) == 0 );
-    ++on_header_called;
-    return size;
-  };
+    int on_header_called = 0;
+    io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
+        const char* header = resp.headers[on_header_called].c_str();
+        size_t len = strlen(header);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, header, len) == 0 );
+        ++on_header_called;
+        return size;
+    };
 
-  ostringstream oss;
-  int on_write_called = 0;
-  io_ctx.on_write = [=, &oss, &on_write_called](char *buffer, size_t size, void *userdata) {
-    ++on_write_called;
-    oss.write(buffer, size);
-    return size;
-  };
+    ostringstream oss;
+    int on_write_called = 0;
+    io_ctx.on_write = [=, &oss, &on_write_called](char *buffer, size_t size, void *userdata) {
+        ++on_write_called;
+        oss.write(buffer, size);
+        return size;
+    };
 
-  int on_close_called = 0;
-  s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
-    ++on_close_called;
-    return KHC_SOCK_OK;
-  };
+    int on_close_called = 0;
+    s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
+        ++on_close_called;
+        return KHC_SOCK_OK;
+    };
 
-  khc_code res = khc_perform(&http);
-  REQUIRE( res == KHC_ERR_OK );
-  REQUIRE( khc_get_status_code(&http) == 400 );
-  REQUIRE( on_connect_called == 1 );
-  REQUIRE( on_send_called == 3 );
-  REQUIRE( on_read_called == 0 );
-  REQUIRE( on_recv_called == 2 );
-  REQUIRE( on_header_called == 2 );
-  REQUIRE( on_write_called == 1 );
-  REQUIRE( on_close_called == 1 );
+    khc_code res = khc_perform(&http);
+    REQUIRE( res == KHC_ERR_OK );
+    REQUIRE( khc_get_status_code(&http) == 400 );
+    REQUIRE( on_connect_called == 1 );
+    REQUIRE( on_send_called == 3 );
+    REQUIRE( on_read_called == 0 );
+    REQUIRE( on_recv_called == 2 );
+    REQUIRE( on_header_called == 2 );
+    REQUIRE( on_write_called == 1 );
+    REQUIRE( on_close_called == 1 );
 
-  REQUIRE( expectBody == oss.str() );
+    REQUIRE( expectBody == oss.str() );
 }

--- a/tests/small_test/khc/response_test.cpp
+++ b/tests/small_test/khc/response_test.cpp
@@ -7,414 +7,414 @@
 #include <string.h>
 
 TEST_CASE( "HTTP response test" ) {
-  khc http;
-  khc_init(&http);
-  const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
+    khc http;
+    khc_init(&http);
+    const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
 
-  ifstream ifs;
-  ifs.open("./data/resp-login.txt");
+    ifstream ifs;
+    ifs.open("./data/resp-login.txt");
 
-  khct::http::Resp resp(ifs);
+    khct::http::Resp resp(ifs);
 
-  ifs.close();
+    ifs.close();
 
-  khc_set_host(&http, "api.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_path(&http, "/api/apps");
-  khc_set_req_headers(&http, NULL);
+    khc_set_host(&http, "api.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_path(&http, "/api/apps");
+    khc_set_req_headers(&http, NULL);
 
-  khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
+    khct::cb::SockCtx s_ctx;
+    khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
 
-  khct::cb::IOCtx io_ctx;
-  // no set cb_read.
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+    khct::cb::IOCtx io_ctx;
+    // no set cb_read.
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
-  int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
-    ++on_connect_called;
-    REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
-    REQUIRE( strlen(host) == strlen("api.kii.com") );
-    REQUIRE( port == 443 );
-    return KHC_SOCK_OK;
-  };
+    int on_connect_called = 0;
+    s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+        ++on_connect_called;
+        REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
+        REQUIRE( strlen(host) == strlen("api.kii.com") );
+        REQUIRE( port == 443 );
+        return KHC_SOCK_OK;
+    };
 
-  int on_send_called = 0;
-  s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    ++on_send_called;
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
+    int on_send_called = 0;
+    s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        ++on_send_called;
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
 
-  int on_read_called = 0;
-  io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
-    ++on_read_called;
-    FAIL();
-    return 0;
-  };
+    int on_read_called = 0;
+    io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
+        ++on_read_called;
+        FAIL();
+        return 0;
+    };
 
-  int on_recv_called = 0;
-  auto is = resp.to_istringstream();
-  s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    ++on_recv_called;
-    if (on_recv_called == 1)
-      REQUIRE( length_to_read == 255 );
-    if (on_recv_called == 2)
-      REQUIRE( length_to_read == 236 );
-    if (on_recv_called == 3)
-      REQUIRE( length_to_read == 1024 );
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
+    int on_recv_called = 0;
+    auto is = resp.to_istringstream();
+    s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        ++on_recv_called;
+        if (on_recv_called == 1)
+            REQUIRE( length_to_read == 255 );
+        if (on_recv_called == 2)
+            REQUIRE( length_to_read == 236 );
+        if (on_recv_called == 3)
+            REQUIRE( length_to_read == 1024 );
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
+    };
 
-  int on_header_called = 0;
-  io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
-    const char* header = resp.headers[on_header_called].c_str();
-    size_t len = strlen(header);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, header, len) == 0 );
-    ++on_header_called;
-    return size;
-  };
+    int on_header_called = 0;
+    io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
+        const char* header = resp.headers[on_header_called].c_str();
+        size_t len = strlen(header);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, header, len) == 0 );
+        ++on_header_called;
+        return size;
+    };
 
-  istringstream iss = istringstream(resp.body);
-  int on_write_called = 0;
-  io_ctx.on_write = [=, &iss, &on_write_called](char *buffer, size_t size, void *userdata) {
-    ++on_write_called;
-    char body_buffer[size];
-    memset(body_buffer, '\0', size);
-    iss.read((char*)body_buffer, size);
-    REQUIRE ( strncmp(buffer, body_buffer, size) == 0 );
-    return size;
-  };
+    istringstream iss = istringstream(resp.body);
+    int on_write_called = 0;
+    io_ctx.on_write = [=, &iss, &on_write_called](char *buffer, size_t size, void *userdata) {
+        ++on_write_called;
+        char body_buffer[size];
+        memset(body_buffer, '\0', size);
+        iss.read((char*)body_buffer, size);
+        REQUIRE ( strncmp(buffer, body_buffer, size) == 0 );
+        return size;
+    };
 
-  int on_close_called = 0;
-  s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
-    ++on_close_called;
-    return KHC_SOCK_OK;
-  };
+    int on_close_called = 0;
+    s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
+        ++on_close_called;
+        return KHC_SOCK_OK;
+    };
 
-  khc_code res = khc_perform(&http);
-  REQUIRE( res == KHC_ERR_OK );
-  REQUIRE( khc_get_status_code(&http) == 200 );
-  REQUIRE( on_connect_called == 1 );
-  REQUIRE( on_send_called == 3 );
-  REQUIRE( on_read_called == 0 );
-  REQUIRE( on_recv_called == 4 );
-  REQUIRE( on_header_called == 12 );
-  REQUIRE( on_write_called > 0 );
-  REQUIRE( on_close_called == 1 );
+    khc_code res = khc_perform(&http);
+    REQUIRE( res == KHC_ERR_OK );
+    REQUIRE( khc_get_status_code(&http) == 200 );
+    REQUIRE( on_connect_called == 1 );
+    REQUIRE( on_send_called == 3 );
+    REQUIRE( on_read_called == 0 );
+    REQUIRE( on_recv_called == 4 );
+    REQUIRE( on_header_called == 12 );
+    REQUIRE( on_write_called > 0 );
+    REQUIRE( on_close_called == 1 );
 }
 
 TEST_CASE( "Ignore HTTP status 100" ) {
-  khc http;
-  khc_init(&http);
-  const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
+    khc http;
+    khc_init(&http);
+    const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
 
-  ifstream ifs;
-  ifs.open("./data/resp-login.txt");
+    ifstream ifs;
+    ifs.open("./data/resp-login.txt");
 
-  khct::http::Resp resp(ifs, true);
+    khct::http::Resp resp(ifs, true);
 
-  ifs.close();
+    ifs.close();
 
-  khc_set_host(&http, "api.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_path(&http, "/api/apps");
-  khc_set_req_headers(&http, NULL);
+    khc_set_host(&http, "api.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_path(&http, "/api/apps");
+    khc_set_req_headers(&http, NULL);
 
-  khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
+    khct::cb::SockCtx s_ctx;
+    khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
 
-  khct::cb::IOCtx io_ctx;
-  // no set cb_read.
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+    khct::cb::IOCtx io_ctx;
+    // no set cb_read.
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
-  int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
-    ++on_connect_called;
-    REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
-    REQUIRE( strlen(host) == strlen("api.kii.com") );
-    REQUIRE( port == 443 );
-    return KHC_SOCK_OK;
-  };
+    int on_connect_called = 0;
+    s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+        ++on_connect_called;
+        REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
+        REQUIRE( strlen(host) == strlen("api.kii.com") );
+        REQUIRE( port == 443 );
+        return KHC_SOCK_OK;
+    };
 
-  int on_send_called = 0;
-  s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    ++on_send_called;
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
+    int on_send_called = 0;
+    s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        ++on_send_called;
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
 
-  int on_read_called = 0;
-  io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
-    ++on_read_called;
-    FAIL();
-    return 0;
-  };
+    int on_read_called = 0;
+    io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
+        ++on_read_called;
+        FAIL();
+        return 0;
+    };
 
-  int on_recv_called = 0;
-  auto is = resp.to_istringstream();
-  s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    ++on_recv_called;
-    REQUIRE( length_to_read > 0 );
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
+    int on_recv_called = 0;
+    auto is = resp.to_istringstream();
+    s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        ++on_recv_called;
+        REQUIRE( length_to_read > 0 );
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
+    };
 
-  int on_header_called = 0;
-  io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
-    const char* header = resp.headers[on_header_called].c_str();
-    size_t len = strlen(header);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, header, len) == 0 );
-    ++on_header_called;
-    return size;
-  };
+    int on_header_called = 0;
+    io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
+        const char* header = resp.headers[on_header_called].c_str();
+        size_t len = strlen(header);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, header, len) == 0 );
+        ++on_header_called;
+        return size;
+    };
 
-  istringstream iss = istringstream(resp.body);
-  int on_write_called = 0;
-  io_ctx.on_write = [=, &iss, &on_write_called](char *buffer, size_t size, void *userdata) {
-    ++on_write_called;
-    char body_buffer[size];
-    memset(body_buffer, '\0', size);
-    iss.read((char*)body_buffer, size);
-    REQUIRE ( strncmp(buffer, body_buffer, size) == 0 );
-    return size;
-  };
+    istringstream iss = istringstream(resp.body);
+    int on_write_called = 0;
+    io_ctx.on_write = [=, &iss, &on_write_called](char *buffer, size_t size, void *userdata) {
+        ++on_write_called;
+        char body_buffer[size];
+        memset(body_buffer, '\0', size);
+        iss.read((char*)body_buffer, size);
+        REQUIRE ( strncmp(buffer, body_buffer, size) == 0 );
+        return size;
+    };
 
-  int on_close_called = 0;
-  s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
-    ++on_close_called;
-    return KHC_SOCK_OK;
-  };
+    int on_close_called = 0;
+    s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
+        ++on_close_called;
+        return KHC_SOCK_OK;
+    };
 
-  khc_code res = khc_perform(&http);
-  REQUIRE( res == KHC_ERR_OK );
-  REQUIRE( khc_get_status_code(&http) == 200 );
-  REQUIRE( on_connect_called == 1 );
-  REQUIRE( on_send_called == 3 );
-  REQUIRE( on_read_called == 0 );
-  REQUIRE( on_recv_called == 5 );
-  REQUIRE( on_header_called == 14 );
-  REQUIRE( on_write_called == 2 );
-  REQUIRE( on_close_called == 1 );
+    khc_code res = khc_perform(&http);
+    REQUIRE( res == KHC_ERR_OK );
+    REQUIRE( khc_get_status_code(&http) == 200 );
+    REQUIRE( on_connect_called == 1 );
+    REQUIRE( on_send_called == 3 );
+    REQUIRE( on_read_called == 0 );
+    REQUIRE( on_recv_called == 5 );
+    REQUIRE( on_header_called == 14 );
+    REQUIRE( on_write_called == 2 );
+    REQUIRE( on_close_called == 1 );
 }
 
 TEST_CASE( "Small resp header skip test" ) {
-  khc http;
-  khc_init(&http);
-  const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
-  const size_t resp_header_buff_size = 120;
-  char resp_header_buff[resp_header_buff_size];
+    khc http;
+    khc_init(&http);
+    const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
+    const size_t resp_header_buff_size = 120;
+    char resp_header_buff[resp_header_buff_size];
 
-  ifstream ifs;
-  ifs.open("./data/resp-login.txt");
+    ifstream ifs;
+    ifs.open("./data/resp-login.txt");
 
-  khct::http::Resp resp(ifs);
+    khct::http::Resp resp(ifs);
 
-  ifs.close();
+    ifs.close();
 
-  khc_set_host(&http, "api.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_path(&http, "/api/apps");
-  khc_set_req_headers(&http, NULL);
-  khc_set_resp_header_buff(&http, resp_header_buff, resp_header_buff_size);
+    khc_set_host(&http, "api.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_path(&http, "/api/apps");
+    khc_set_req_headers(&http, NULL);
+    khc_set_resp_header_buff(&http, resp_header_buff, resp_header_buff_size);
 
-  khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
+    khct::cb::SockCtx s_ctx;
+    khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
 
-  khct::cb::IOCtx io_ctx;
-  // no set cb_read.
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+    khct::cb::IOCtx io_ctx;
+    // no set cb_read.
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
-  int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
-    ++on_connect_called;
-    REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
-    REQUIRE( strlen(host) == strlen("api.kii.com") );
-    REQUIRE( port == 443 );
-    return KHC_SOCK_OK;
-  };
+    int on_connect_called = 0;
+    s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+        ++on_connect_called;
+        REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
+        REQUIRE( strlen(host) == strlen("api.kii.com") );
+        REQUIRE( port == 443 );
+        return KHC_SOCK_OK;
+    };
 
-  int on_send_called = 0;
-  s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    ++on_send_called;
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
+    int on_send_called = 0;
+    s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        ++on_send_called;
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
 
-  int on_read_called = 0;
-  io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
-    ++on_read_called;
-    FAIL();
-    return 0;
-  };
+    int on_read_called = 0;
+    io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
+        ++on_read_called;
+        FAIL();
+        return 0;
+    };
 
-  int on_recv_called = 0;
-  auto is = resp.to_istringstream();
-  s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    ++on_recv_called;
-    if (on_recv_called == 1)
-      REQUIRE( length_to_read == resp_header_buff_size - 1 );
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
+    int on_recv_called = 0;
+    auto is = resp.to_istringstream();
+    s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        ++on_recv_called;
+        if (on_recv_called == 1)
+            REQUIRE( length_to_read == resp_header_buff_size - 1 );
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
+    };
 
-  int on_header_called = 0;
-  io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
-    int skip = 0;
-    if (on_header_called > 2) {
-      skip = 1;
-    }
-    const char* header = resp.headers[on_header_called + skip].c_str();
-    size_t len = strlen(header);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, header, len) == 0 );
-    ++on_header_called;
-    return size;
-  };
+    int on_header_called = 0;
+    io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
+        int skip = 0;
+        if (on_header_called > 2) {
+            skip = 1;
+        }
+        const char* header = resp.headers[on_header_called + skip].c_str();
+        size_t len = strlen(header);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, header, len) == 0 );
+        ++on_header_called;
+        return size;
+    };
 
-  istringstream iss = istringstream(resp.body);
-  int on_write_called = 0;
-  io_ctx.on_write = [=, &iss, &on_write_called](char *buffer, size_t size, void *userdata) {
-    ++on_write_called;
-    char body_buffer[size];
-    memset(body_buffer, '\0', size);
-    iss.read((char*)body_buffer, size);
-    REQUIRE ( strncmp(buffer, body_buffer, size) == 0 );
-    return size;
-  };
+    istringstream iss = istringstream(resp.body);
+    int on_write_called = 0;
+    io_ctx.on_write = [=, &iss, &on_write_called](char *buffer, size_t size, void *userdata) {
+        ++on_write_called;
+        char body_buffer[size];
+        memset(body_buffer, '\0', size);
+        iss.read((char*)body_buffer, size);
+        REQUIRE ( strncmp(buffer, body_buffer, size) == 0 );
+        return size;
+    };
 
-  int on_close_called = 0;
-  s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
-    ++on_close_called;
-    return KHC_SOCK_OK;
-  };
+    int on_close_called = 0;
+    s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
+        ++on_close_called;
+        return KHC_SOCK_OK;
+    };
 
-  khc_code res = khc_perform(&http);
-  REQUIRE( res == KHC_ERR_OK );
-  REQUIRE( khc_get_status_code(&http) == 200 );
-  REQUIRE( on_connect_called == 1 );
-  REQUIRE( on_send_called == 3 );
-  REQUIRE( on_read_called == 0 );
-  REQUIRE( on_recv_called == 7 );
-  REQUIRE( on_header_called == 11 );
-  REQUIRE( on_write_called > 0 );
-  REQUIRE( on_close_called == 1 );
+    khc_code res = khc_perform(&http);
+    REQUIRE( res == KHC_ERR_OK );
+    REQUIRE( khc_get_status_code(&http) == 200 );
+    REQUIRE( on_connect_called == 1 );
+    REQUIRE( on_send_called == 3 );
+    REQUIRE( on_read_called == 0 );
+    REQUIRE( on_recv_called == 7 );
+    REQUIRE( on_header_called == 11 );
+    REQUIRE( on_write_called > 0 );
+    REQUIRE( on_close_called == 1 );
 }
 
 TEST_CASE( "HTTP response 400 test" ) {
-  khc http;
-  khc_init(&http);
-  const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
+    khc http;
+    khc_init(&http);
+    const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
 
-  stringstream ss;
-  ss << "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\n\r\ndummy body.";
+    stringstream ss;
+    ss << "HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\n\r\ndummy body.";
 
-  khct::http::Resp resp(ss);
+    khct::http::Resp resp(ss);
 
-  khc_set_host(&http, "api.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_path(&http, "/api/apps");
-  khc_set_req_headers(&http, NULL);
+    khc_set_host(&http, "api.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_path(&http, "/api/apps");
+    khc_set_req_headers(&http, NULL);
 
-  khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
+    khct::cb::SockCtx s_ctx;
+    khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
 
-  khct::cb::IOCtx io_ctx;
-  // no set cb_read.
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+    khct::cb::IOCtx io_ctx;
+    // no set cb_read.
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
 
-  int on_connect_called = 0;
-  s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
-    ++on_connect_called;
-    REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
-    REQUIRE( strlen(host) == strlen("api.kii.com") );
-    REQUIRE( port == 443 );
-    return KHC_SOCK_OK;
-  };
+    int on_connect_called = 0;
+    s_ctx.on_connect = [=, &on_connect_called](void* socket_context, const char* host, unsigned int port) {
+        ++on_connect_called;
+        REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
+        REQUIRE( strlen(host) == strlen("api.kii.com") );
+        REQUIRE( port == 443 );
+        return KHC_SOCK_OK;
+    };
 
-  int on_send_called = 0;
-  s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    ++on_send_called;
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
+    int on_send_called = 0;
+    s_ctx.on_send = [=, &on_send_called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        ++on_send_called;
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
 
-  int on_read_called = 0;
-  io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
-    ++on_read_called;
-    FAIL();
-    return 0;
-  };
+    int on_read_called = 0;
+    io_ctx.on_read = [=, &on_read_called](char *buffer, size_t size, void *userdata) {
+        ++on_read_called;
+        FAIL();
+        return 0;
+    };
 
-  int on_recv_called = 0;
-  auto is = resp.to_istringstream();
-  s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    ++on_recv_called;
-    if (on_recv_called == 1) {
-        // recv header.
-        REQUIRE( length_to_read == 255 );
-    } else {
-        // recv body(= 0).
-        REQUIRE( length_to_read == 1024 );
-    }
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
+    int on_recv_called = 0;
+    auto is = resp.to_istringstream();
+    s_ctx.on_recv = [=, &on_recv_called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        ++on_recv_called;
+        if (on_recv_called == 1) {
+            // recv header.
+            REQUIRE( length_to_read == 255 );
+        } else {
+            // recv body(= 0).
+            REQUIRE( length_to_read == 1024 );
+        }
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
+    };
 
-  int on_header_called = 0;
-  io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
-    const char* header = resp.headers[on_header_called].c_str();
-    size_t len = strlen(header);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, header, len) == 0 );
-    ++on_header_called;
-    return size;
-  };
+    int on_header_called = 0;
+    io_ctx.on_header = [=, &on_header_called, &resp](char *buffer, size_t size, void *userdata) {
+        const char* header = resp.headers[on_header_called].c_str();
+        size_t len = strlen(header);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, header, len) == 0 );
+        ++on_header_called;
+        return size;
+    };
 
-  istringstream iss = istringstream(resp.body);
-  int on_write_called = 0;
-  io_ctx.on_write = [=, &iss, &on_write_called](char *buffer, size_t size, void *userdata) {
-    ++on_write_called;
-    char body_buffer[size];
-    memset(body_buffer, '\0', size);
-    iss.read((char*)body_buffer, size);
-    REQUIRE ( strncmp(buffer, body_buffer, size) == 0 );
-    return size;
-  };
+    istringstream iss = istringstream(resp.body);
+    int on_write_called = 0;
+    io_ctx.on_write = [=, &iss, &on_write_called](char *buffer, size_t size, void *userdata) {
+        ++on_write_called;
+        char body_buffer[size];
+        memset(body_buffer, '\0', size);
+        iss.read((char*)body_buffer, size);
+        REQUIRE ( strncmp(buffer, body_buffer, size) == 0 );
+        return size;
+    };
 
-  int on_close_called = 0;
-  s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
-    ++on_close_called;
-    return KHC_SOCK_OK;
-  };
+    int on_close_called = 0;
+    s_ctx.on_close = [=, &on_close_called](void* socket_ctx) {
+        ++on_close_called;
+        return KHC_SOCK_OK;
+    };
 
-  khc_code res = khc_perform(&http);
-  REQUIRE( res == KHC_ERR_OK );
-  REQUIRE( khc_get_status_code(&http) == 400 );
-  REQUIRE( on_connect_called == 1 );
-  REQUIRE( on_send_called == 3 );
-  REQUIRE( on_read_called == 0 );
-  REQUIRE( on_recv_called == 2 );
-  REQUIRE( on_header_called == 2 );
-  REQUIRE( on_write_called == 1 );
-  REQUIRE( on_close_called == 1 );
+    khc_code res = khc_perform(&http);
+    REQUIRE( res == KHC_ERR_OK );
+    REQUIRE( khc_get_status_code(&http) == 400 );
+    REQUIRE( on_connect_called == 1 );
+    REQUIRE( on_send_called == 3 );
+    REQUIRE( on_read_called == 0 );
+    REQUIRE( on_recv_called == 2 );
+    REQUIRE( on_header_called == 2 );
+    REQUIRE( on_write_called == 1 );
+    REQUIRE( on_close_called == 1 );
 }

--- a/tests/small_test/khc/slist_test.cpp
+++ b/tests/small_test/khc/slist_test.cpp
@@ -3,78 +3,78 @@
 #include "khc.h"
 
 TEST_CASE( "slist append (1)" ) {
-  khc_slist* list = NULL;
-  khc_slist* appended = khc_slist_append(list, "aaaaa", 5);
-  REQUIRE( appended != NULL );
-  REQUIRE( strlen(appended->data) == 5 );
-  REQUIRE( strncmp(appended->data, "aaaaa", 5) == 0 );
-  REQUIRE ( appended->next == NULL );
-  khc_slist_free_all(appended);
+    khc_slist* list = NULL;
+    khc_slist* appended = khc_slist_append(list, "aaaaa", 5);
+    REQUIRE( appended != NULL );
+    REQUIRE( strlen(appended->data) == 5 );
+    REQUIRE( strncmp(appended->data, "aaaaa", 5) == 0 );
+    REQUIRE ( appended->next == NULL );
+    khc_slist_free_all(appended);
 }
 
 TEST_CASE( "slist append (2)" ) {
-  khc_slist* list = NULL;
-  khc_slist* appended = khc_slist_append(list, "aaaaa", 5);
-  REQUIRE( appended != NULL );
-  REQUIRE( strlen(appended->data) == 5 );
-  REQUIRE( strncmp(appended->data, "aaaaa", 5) == 0 );
-  appended = khc_slist_append(appended, "bbbb", 4);
-  khc_slist* next = appended->next;
-  REQUIRE ( next != NULL );
-  REQUIRE( strlen(next->data) == 4 );
-  REQUIRE( strncmp(next->data, "bbbb", 4) == 0 );
-  REQUIRE( next->next == NULL );
-  khc_slist_free_all(appended);
+    khc_slist* list = NULL;
+    khc_slist* appended = khc_slist_append(list, "aaaaa", 5);
+    REQUIRE( appended != NULL );
+    REQUIRE( strlen(appended->data) == 5 );
+    REQUIRE( strncmp(appended->data, "aaaaa", 5) == 0 );
+    appended = khc_slist_append(appended, "bbbb", 4);
+    khc_slist* next = appended->next;
+    REQUIRE ( next != NULL );
+    REQUIRE( strlen(next->data) == 4 );
+    REQUIRE( strncmp(next->data, "bbbb", 4) == 0 );
+    REQUIRE( next->next == NULL );
+    khc_slist_free_all(appended);
 }
 
 typedef struct {
-  const char* alloc_requested_str;
-  size_t alloc_requested_str_len;
-  khc_slist* free_requested_node;
+    const char* alloc_requested_str;
+    size_t alloc_requested_str_len;
+    khc_slist* free_requested_node;
 } slist_alloc_ctx;
 
 khc_slist* cb_alloc(const char* str, size_t len, void* data) {
-  slist_alloc_ctx* ctx = (slist_alloc_ctx*)data;
-  ctx->alloc_requested_str = str;
-  ctx->alloc_requested_str_len = len;
+    slist_alloc_ctx* ctx = (slist_alloc_ctx*)data;
+    ctx->alloc_requested_str = str;
+    ctx->alloc_requested_str_len = len;
 
-  char* copy = (char*)malloc(len + 1);
-  if (copy == NULL) {
-    return NULL;
-  }
-  khc_slist* node = (khc_slist*)malloc(sizeof(khc_slist));
-  if (node == NULL) {
-    free(copy);
-    return NULL;
-  }
-  strncpy(copy, str, len);
-  copy[len] = '\0';
-  node->data = copy;
-  node->next = NULL;
-  return node;
+    char* copy = (char*)malloc(len + 1);
+    if (copy == NULL) {
+        return NULL;
+    }
+    khc_slist* node = (khc_slist*)malloc(sizeof(khc_slist));
+    if (node == NULL) {
+        free(copy);
+        return NULL;
+    }
+    strncpy(copy, str, len);
+    copy[len] = '\0';
+    node->data = copy;
+    node->next = NULL;
+    return node;
 }
 
 void cb_free(khc_slist* node, void* data) {
-  slist_alloc_ctx* ctx = (slist_alloc_ctx*)data;
-  ctx->free_requested_node = node;
-  free(node->data);
-  free(node);
+    slist_alloc_ctx* ctx = (slist_alloc_ctx*)data;
+    ctx->free_requested_node = node;
+    free(node->data);
+    free(node);
 }
 
 TEST_CASE( "slist append (3)" ) {
-  khc_slist* list = NULL;
-  slist_alloc_ctx ctx;
-  memset(&ctx, 0, sizeof(slist_alloc_ctx));
-  const char str[] = "aaaaa";
-  khc_slist* appended = khc_slist_append_using_cb_alloc(list, str, 5, cb_alloc, &ctx);
-  REQUIRE( appended != NULL );
-  REQUIRE( strlen(appended->data) == 5 );
-  REQUIRE( strncmp(appended->data, str, 5) == 0 );
-  REQUIRE ( appended->next == NULL );
+    khc_slist* list = NULL;
+    slist_alloc_ctx ctx;
+    memset(&ctx, 0, sizeof(slist_alloc_ctx));
+    const char str[] = "aaaaa";
+    khc_slist* appended = khc_slist_append_using_cb_alloc(list, str, 5, cb_alloc, &ctx);
+    REQUIRE( appended != NULL );
+    REQUIRE( strlen(appended->data) == 5 );
+    REQUIRE( strncmp(appended->data, str, 5) == 0 );
+    REQUIRE ( appended->next == NULL );
 
-  REQUIRE( ctx.alloc_requested_str == str );
-  REQUIRE( ctx.alloc_requested_str_len == 5 );
+    REQUIRE( ctx.alloc_requested_str == str );
+    REQUIRE( ctx.alloc_requested_str_len == 5 );
 
-  khc_slist_free_all_using_cb_free(appended, cb_free, &ctx);
-  REQUIRE( ctx.free_requested_node == appended );
+    khc_slist_free_all_using_cb_free(appended, cb_free, &ctx);
+    REQUIRE( ctx.free_requested_node == appended );
 }

--- a/tests/small_test/khc/state_trans_test.cpp
+++ b/tests/small_test/khc/state_trans_test.cpp
@@ -9,1693 +9,1693 @@
 #include <sstream>
 
 TEST_CASE( "HTTP minimal" ) {
-  khc http;
-  khc_init(&http);
-  const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
-  const size_t resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
-
-  khct::http::Resp resp;
-  resp.headers = { "HTTP/1.0 200 OK" };
-
-  khc_set_host(&http, "api.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_path(&http, "/api/apps");
-  khc_set_req_headers(&http, NULL);
-
-  khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
-
-  khct::cb::IOCtx io_ctx;
-  // no set cb_read.
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
-
-  khc_state_idle(&http);
-  REQUIRE( http._state == KHC_STATE_CONNECT );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  bool called = false;
-  s_ctx.on_connect = [=, &called](void* socket_context, const char* host, unsigned int port) {
-    called = true;
-    REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
-    REQUIRE( strlen(host) == strlen("api.kii.com") );
-    REQUIRE( port == 443 );
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_connect(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_LINE );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char req_line[] = "GET https://api.kii.com/api/apps HTTP/1.1\r\n";
-    REQUIRE( length == strlen(req_line) );
-    REQUIRE( strncmp(buffer, req_line, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_req_line(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HOST_HEADER );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char host_hdr[] = "HOST: api.kii.com\r\n";
-    REQUIRE( length == strlen(host_hdr) );
-    REQUIRE( strncmp(buffer, host_hdr, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_host_header(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HEADER );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  khc_state_req_header(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HEADER_END );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    REQUIRE( length == 40 );
-    REQUIRE( strncmp(buffer, "Content-Length: 0\r\nConnection: Close\r\n\r\n", 40) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_req_header_end(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_STATUS_READ );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  auto is = resp.to_istringstream();
-  s_ctx.on_recv = [=, &called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    called = true;
-    REQUIRE( length_to_read == resp_header_buff_size - 1 );
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_resp_status_read(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_STATUS_PARSE );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-  char buffer[resp_header_buff_size];
-  size_t len = resp.to_istringstream().read((char*)&buffer, resp_header_buff_size - 1).gcount();
-  REQUIRE( http._resp_header_read_size == len );
-  REQUIRE( called );
-
-  khc_state_resp_status_parse(&http);
-  REQUIRE( khc_get_status_code(&http) == 200 );
-  REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
-
-  called = false;
-  io_ctx.on_header = [=, &called, &resp](char *buffer, size_t size, void *userdata) {
-    called = true;
-    const char* status_line = resp.headers[0].c_str();
-    size_t len = strlen(status_line);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, status_line, len) == 0 );
-    return size;
-  };
-
-  khc_state_resp_header_callback(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  khc_state_resp_header_callback(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_BODY_FRAGMENT );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  khc_state_resp_body_fragment(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_BODY_READ );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  called = false;
-  s_ctx.on_recv = [=, &called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    called = true;
-    REQUIRE( length_to_read == buff_size);
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
-  khc_state_resp_body_read(&http);
-  REQUIRE( http._state == KHC_STATE_CLOSE );
-  REQUIRE( http._read_end == 1 );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_close = [=, &called](void* socket_ctx) {
-    called = true;
-    return KHC_SOCK_OK;
-  };
-  khc_state_close(&http);
-  REQUIRE( http._state == KHC_STATE_FINISHED );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-}
-
-TEST_CASE( "HTTP 1.1 chunked minimal" ) {
-  khc http;
-  khc_init(&http);
-  const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
-  const size_t resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
-
-  khct::http::Resp resp;
-  resp.headers = {
-    "HTTP/1.1 200 OK",
-    "Host: api.kii.com",
-    "Transfer-Encoding: chunked",
-  };
-  resp.body = "0\r\n\r\n";
-
-  khc_set_host(&http, "api.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_path(&http, "/api/apps");
-  khc_set_req_headers(&http, NULL);
-
-  khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
-
-  khct::cb::IOCtx io_ctx;
-  khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
-
-  khc_state_idle(&http);
-  REQUIRE( http._state == KHC_STATE_CONNECT );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  bool called = false;
-  s_ctx.on_connect = [=, &called](void* socket_context, const char* host, unsigned int port) {
-    called = true;
-    REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
-    REQUIRE( strlen(host) == strlen("api.kii.com") );
-    REQUIRE( port == 443 );
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_connect(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_LINE );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char req_line[] = "GET https://api.kii.com/api/apps HTTP/1.1\r\n";
-    REQUIRE( length == strlen(req_line) );
-    REQUIRE( strncmp(buffer, req_line, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_req_line(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HOST_HEADER );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char host_hdr[] = "HOST: api.kii.com\r\n";
-    REQUIRE( length == strlen(host_hdr) );
-    REQUIRE( strncmp(buffer, host_hdr, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_host_header(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HEADER );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  khc_state_req_header(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HEADER_END );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    REQUIRE( length == 49 );
-    REQUIRE( strncmp(buffer, "Transfer-Encoding: chunked\r\nConnection: Close\r\n\r\n", 49) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_req_header_end(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_READ );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  io_ctx.on_read = [=, &called](char *buffer, size_t size, void *userdata) {
-    called = true;
-    REQUIRE( size == buff_size );
-    const char body[] = "http body";
-    strncpy(buffer, body, strlen(body));
-    return strlen(body);
-  };
-  khc_state_req_body_read(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_SIZE );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( http._read_req_end == 0 );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char body[] = "9\r\n";
-    REQUIRE( length == strlen(body) );
-    REQUIRE( strncmp(buffer, body, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_body_send_size(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char body[] = "http body";
-    REQUIRE( length == strlen(body) );
-    REQUIRE( strncmp(buffer, body, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_body_send(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_CRLF );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char body[] = "\r\n";
-    REQUIRE( length == strlen(body) );
-    REQUIRE( strncmp(buffer, body, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_body_send_crlf(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_READ );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  io_ctx.on_read = [=, &called](char *buffer, size_t size, void *userdata) {
-    called = true;
-    REQUIRE( size == buff_size );
-    return 0;
-  };
-  khc_state_req_body_read(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_SIZE );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( http._read_req_end == 1 );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char body[] = "0\r\n";
-    REQUIRE( length == strlen(body) );
-    REQUIRE( strncmp(buffer, body, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_body_send_size(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_CRLF );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char body[] = "\r\n";
-    REQUIRE( length == strlen(body) );
-    REQUIRE( strncmp(buffer, body, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_body_send_crlf(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_STATUS_READ );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  auto is = resp.to_istringstream();
-  s_ctx.on_recv = [=, &called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    called = true;
-    REQUIRE( length_to_read == resp_header_buff_size - 1 );
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_resp_status_read(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_STATUS_PARSE );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-  char buffer[resp_header_buff_size];
-  size_t len = resp.to_istringstream().read((char*)&buffer, resp_header_buff_size - 1).gcount();
-  REQUIRE( http._resp_header_read_size == len );
-  REQUIRE( called );
-
-  khc_state_resp_status_parse(&http);
-  REQUIRE( khc_get_status_code(&http) == 200 );
-  REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
-
-  called = false;
-  io_ctx.on_header = [=, &called, &resp](char *buffer, size_t size, void *userdata) {
-    called = true;
-    const char* status_line = resp.headers[0].c_str();
-    size_t len = strlen(status_line);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, status_line, len) == 0 );
-    return size;
-  };
-
-  khc_state_resp_header_callback(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
-  REQUIRE( http._chunked_resp == 0 );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  io_ctx.on_header = [=, &called, &resp](char *buffer, size_t size, void *userdata) {
-    called = true;
-    const char* host_line = resp.headers[1].c_str();
-    size_t len = strlen(host_line);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, host_line, len) == 0 );
-    return size;
-  };
-
-  khc_state_resp_header_callback(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
-  REQUIRE( http._chunked_resp == 0 );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  io_ctx.on_header = [=, &called, &resp](char *buffer, size_t size, void *userdata) {
-    called = true;
-    const char* chunked_line = resp.headers[2].c_str();
-    size_t len = strlen(chunked_line);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, chunked_line, len) == 0 );
-    return size;
-  };
-
-  khc_state_resp_header_callback(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
-  REQUIRE( http._chunk_size == 0 );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  khc_state_resp_header_callback(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE );
-  REQUIRE( http._chunk_size == 0 );
-  REQUIRE( http._body_read_size == 0 );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  khc_state_resp_body_parse_chunk_size(&http);
-  REQUIRE( http._state == KHC_STATE_READ_CHUNK_SIZE_FROM_HEADER_BUFF );
-  REQUIRE( http._chunk_size == 0 );
-  REQUIRE( http._body_read_size == 0 );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  khc_state_read_chunk_size_from_header_buff(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE );
-  REQUIRE( http._chunk_size == 0 );
-  REQUIRE( http._body_read_size == 5 );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  khc_state_resp_body_parse_chunk_size(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_BODY_SKIP_TRAILERS );
-  REQUIRE( http._chunk_size == 0 );
-  REQUIRE( http._body_read_size == 2 );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  called = false;
-  s_ctx.on_recv = [=, &called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    called = true;
-    *out_actual_length = 0;
-    return KHC_SOCK_OK;
-  };
-  khc_state_resp_body_skip_trailers(&http);
-  REQUIRE( http._state == KHC_STATE_CLOSE );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_close = [=, &called](void* socket_ctx) {
-    called = true;
-    return KHC_SOCK_OK;
-  };
-  khc_state_close(&http);
-  REQUIRE( http._state == KHC_STATE_FINISHED );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-}
-
-TEST_CASE( "Socket send partial" ) {
-  khc http;
-  khc_init(&http);
-  const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
-  const size_t resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
-
-  khct::http::Resp resp;
-  resp.headers = { "HTTP/1.0 200 OK" };
-
-  char req_header[] = "X-KII-dummy-Header: test partial.";
-  khc_slist* req_headers = NULL;
-  req_headers = khc_slist_append(req_headers, req_header, strlen(req_header));
-
-  khc_set_host(&http, "api.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_path(&http, "/api/apps");
-  khc_set_req_headers(&http, req_headers);
-
-  khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
-
-  khct::cb::IOCtx io_ctx;
-  khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
-
-  khc_state_idle(&http);
-  REQUIRE( http._state == KHC_STATE_CONNECT );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  bool called = false;
-  s_ctx.on_connect = [=, &called](void* socket_context, const char* host, unsigned int port) {
-    called = true;
-    REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
-    REQUIRE( strlen(host) == strlen("api.kii.com") );
-    REQUIRE( port == 443 );
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_connect(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_LINE );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char req_line[] = "GET https://api.kii.";
-    size_t req_len = strlen(req_line);
-    REQUIRE( length > req_len );
-    REQUIRE( strncmp(buffer, req_line, req_len) == 0 );
-    *out_sent_length = req_len;
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_req_line(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_LINE );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char req_line[] = "com/api/apps HT";
-    size_t req_len = strlen(req_line);
-    REQUIRE( length > req_len );
-    REQUIRE( strncmp(buffer, req_line, req_len) == 0 );
-    *out_sent_length = req_len;
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_req_line(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_LINE );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char req_line[] = "TP/1.1\r\n";
-    size_t req_len = strlen(req_line);
-    REQUIRE( length == req_len );
-    REQUIRE( strncmp(buffer, req_line, req_len) == 0 );
-    *out_sent_length = req_len;
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_req_line(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HOST_HEADER );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char host_hdr[] = "HOST: api.";
-    size_t host_len = strlen(host_hdr);
-    REQUIRE( length > host_len );
-    REQUIRE( strncmp(buffer, host_hdr, host_len) == 0 );
-    *out_sent_length = host_len;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_host_header(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HOST_HEADER );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char host_hdr[] = "kii.com\r\n";
-    size_t host_len = strlen(host_hdr);
-    REQUIRE( length == host_len );
-    REQUIRE( strncmp(buffer, host_hdr, host_len) == 0 );
-    *out_sent_length = host_len;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_host_header(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HEADER );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  khc_state_req_header(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HEADER_SEND );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char hdr[] = "X-KII-dummy-";
-    size_t len = strlen(hdr);
-    REQUIRE( length > len );
-    REQUIRE( strncmp(buffer, hdr, len) == 0 );
-    *out_sent_length = len;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_header_send(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HEADER_SEND );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char hdr[] = "Header: test p";
-    size_t len = strlen(hdr);
-    REQUIRE( length > len );
-    REQUIRE( strncmp(buffer, hdr, len) == 0 );
-    *out_sent_length = len;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_header_send(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HEADER_SEND );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char hdr[] = "artial.";
-    size_t len = strlen(hdr);
-    REQUIRE( length == len );
-    REQUIRE( strncmp(buffer, hdr, len) == 0 );
-    *out_sent_length = len;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_header_send(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HEADER_SEND_CRLF );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char hdr[] = "\r\n";
-    size_t len = strlen(hdr);
-    REQUIRE( length == len );
-    REQUIRE( strncmp(buffer, hdr, len) == 0 );
-    *out_sent_length = len;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_header_send_crlf(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HEADER );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  khc_state_req_header(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HEADER_END );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char hdr[] = "Transfer-Encoding: chunked\r\n";
-    size_t len = strlen(hdr);
-    REQUIRE( length > len );
-    REQUIRE( strncmp(buffer, hdr, len) == 0 );
-    *out_sent_length = len;
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_req_header_end(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_HEADER_END );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char hdr[] = "Connection: Close\r\n\r\n";
-    size_t len = strlen(hdr);
-    REQUIRE( length == len );
-    REQUIRE( strncmp(buffer, hdr, len) == 0 );
-    *out_sent_length = len;
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_req_header_end(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_READ );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  io_ctx.on_read = [=, &called](char *buffer, size_t size, void *userdata) {
-    called = true;
-    REQUIRE( size == buff_size );
-    const char body[] = "http body";
-    strncpy(buffer, body, strlen(body));
-    return strlen(body);
-  };
-  khc_state_req_body_read(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_SIZE );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( http._read_req_end == 0 );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char body[] = "9\r\n";
-    REQUIRE( length == strlen(body) );
-    REQUIRE( strncmp(buffer, body, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_body_send_size(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char body[] = "http body";
-    REQUIRE( length == strlen(body) );
-    REQUIRE( strncmp(buffer, body, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_body_send(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_CRLF );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char body[] = "\r\n";
-    REQUIRE( length == strlen(body) );
-    REQUIRE( strncmp(buffer, body, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_body_send_crlf(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_READ );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  io_ctx.on_read = [=, &called](char *buffer, size_t size, void *userdata) {
-    called = true;
-    REQUIRE( size == buff_size );
-    return 0;
-  };
-  khc_state_req_body_read(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_SIZE );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( http._read_req_end == 1 );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char body[] = "0\r\n";
-    REQUIRE( length == strlen(body) );
-    REQUIRE( strncmp(buffer, body, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_body_send_size(&http);
-  REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_CRLF );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-    called = true;
-    const char body[] = "\r\n";
-    REQUIRE( length == strlen(body) );
-    REQUIRE( strncmp(buffer, body, length) == 0 );
-    *out_sent_length = length;
-    return KHC_SOCK_OK;
-  };
-  khc_state_req_body_send_crlf(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_STATUS_READ );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  auto is = resp.to_istringstream();
-  s_ctx.on_recv = [=, &called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    called = true;
-    REQUIRE( length_to_read == resp_header_buff_size - 1 );
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
-
-  khc_state_resp_status_read(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_STATUS_PARSE );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-  char buffer[resp_header_buff_size];
-  size_t len = resp.to_istringstream().read((char*)&buffer, resp_header_buff_size - 1).gcount();
-  REQUIRE( http._resp_header_read_size == len );
-  REQUIRE( called );
-
-  khc_state_resp_status_parse(&http);
-  REQUIRE( khc_get_status_code(&http) == 200 );
-  REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
-
-  called = false;
-  io_ctx.on_header = [=, &called, &resp](char *buffer, size_t size, void *userdata) {
-    called = true;
-    const char* status_line = resp.headers[0].c_str();
-    size_t len = strlen(status_line);
-    REQUIRE( size == len );
-    REQUIRE( strncmp(buffer, status_line, len) == 0 );
-    return size;
-  };
-
-  khc_state_resp_header_callback(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  khc_state_resp_header_callback(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_BODY_FRAGMENT );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  khc_state_resp_body_fragment(&http);
-  REQUIRE( http._state == KHC_STATE_RESP_BODY_READ );
-  REQUIRE( http._read_end == 0 );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  called = false;
-  s_ctx.on_recv = [=, &called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-    called = true;
-    REQUIRE( length_to_read == buff_size);
-    *out_actual_length = is.read(buffer, length_to_read).gcount();
-    return KHC_SOCK_OK;
-  };
-  khc_state_resp_body_read(&http);
-  REQUIRE( http._state == KHC_STATE_CLOSE );
-  REQUIRE( http._read_end == 1 );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  called = false;
-  s_ctx.on_close = [=, &called](void* socket_ctx) {
-    called = true;
-    return KHC_SOCK_OK;
-  };
-  khc_state_close(&http);
-  REQUIRE( http._state == KHC_STATE_FINISHED );
-  REQUIRE( http._result == KHC_ERR_OK );
-  REQUIRE( called );
-
-  khc_slist_free_all(req_headers);
-}
-
-TEST_CASE( "state abnormal tests." ) {
-  khc http;
-  khc_init(&http);
-  const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
-  const size_t resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
-  char stream_buff[buff_size];
-  char resp_header_buff[resp_header_buff_size];
-
-  khc_set_host(&http, "api.kii.com");
-  khc_set_method(&http, "GET");
-  khc_set_path(&http, "/api/apps");
-  khc_set_req_headers(&http, NULL);
-  khc_set_stream_buff(&http, stream_buff, buff_size);
-  khc_set_resp_header_buff(&http, resp_header_buff, resp_header_buff_size);
-
-  khct::cb::SockCtx s_ctx;
-  khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
-  khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
-  khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
-  khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
-
-  khct::cb::IOCtx io_ctx;
-  // no set cb_read.
-  khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
-  khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
-
-  khc_state_idle(&http);
-  REQUIRE( http._state == KHC_STATE_CONNECT );
-  REQUIRE( http._result == KHC_ERR_OK );
-
-  bool called;
-  SECTION("state connect retry.") {
-    called = false;
-    s_ctx.on_connect = [=, &called](void* socket_context, const char* host, unsigned int port) {
-      called = true;
-      return KHC_SOCK_AGAIN;
-    };
-
-    khc_state_connect(&http);
+    khc http;
+    khc_init(&http);
+    const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
+    const size_t resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
+
+    khct::http::Resp resp;
+    resp.headers = { "HTTP/1.0 200 OK" };
+
+    khc_set_host(&http, "api.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_path(&http, "/api/apps");
+    khc_set_req_headers(&http, NULL);
+
+    khct::cb::SockCtx s_ctx;
+    khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
+
+    khct::cb::IOCtx io_ctx;
+    // no set cb_read.
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+
+    khc_state_idle(&http);
     REQUIRE( http._state == KHC_STATE_CONNECT );
     REQUIRE( http._result == KHC_ERR_OK );
-    REQUIRE( called );
-  }
 
-  SECTION("state connect failed.") {
-    called = false;
+    bool called = false;
     s_ctx.on_connect = [=, &called](void* socket_context, const char* host, unsigned int port) {
-      called = true;
-      return KHC_SOCK_FAIL;
+        called = true;
+        REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
+        REQUIRE( strlen(host) == strlen("api.kii.com") );
+        REQUIRE( port == 443 );
+        return KHC_SOCK_OK;
     };
 
     khc_state_connect(&http);
-    REQUIRE( http._state == KHC_STATE_FINISHED );
-    REQUIRE( http._result == KHC_ERR_SOCK_CONNECT );
+    REQUIRE( http._state == KHC_STATE_REQ_LINE );
+    REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("state req line retry.") {
-    http._state = KHC_STATE_REQ_LINE;
 
     called = false;
     s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
+        called = true;
+        const char req_line[] = "GET https://api.kii.com/api/apps HTTP/1.1\r\n";
+        REQUIRE( length == strlen(req_line) );
+        REQUIRE( strncmp(buffer, req_line, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
+
+    khc_state_req_line(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_HOST_HEADER );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        const char host_hdr[] = "HOST: api.kii.com\r\n";
+        REQUIRE( length == strlen(host_hdr) );
+        REQUIRE( strncmp(buffer, host_hdr, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
+    khc_state_req_host_header(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_HEADER );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    khc_state_req_header(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_HEADER_END );
+    REQUIRE( http._result == KHC_ERR_OK );
+
+    called = false;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        REQUIRE( length == 40 );
+        REQUIRE( strncmp(buffer, "Content-Length: 0\r\nConnection: Close\r\n\r\n", 40) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
+
+    khc_state_req_header_end(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_STATUS_READ );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    auto is = resp.to_istringstream();
+    s_ctx.on_recv = [=, &called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        called = true;
+        REQUIRE( length_to_read == resp_header_buff_size - 1 );
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
+    };
+
+    khc_state_resp_status_read(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_STATUS_PARSE );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
+    char buffer[resp_header_buff_size];
+    size_t len = resp.to_istringstream().read((char*)&buffer, resp_header_buff_size - 1).gcount();
+    REQUIRE( http._resp_header_read_size == len );
+    REQUIRE( called );
+
+    khc_state_resp_status_parse(&http);
+    REQUIRE( khc_get_status_code(&http) == 200 );
+    REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
+
+    called = false;
+    io_ctx.on_header = [=, &called, &resp](char *buffer, size_t size, void *userdata) {
+        called = true;
+        const char* status_line = resp.headers[0].c_str();
+        size_t len = strlen(status_line);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, status_line, len) == 0 );
+        return size;
+    };
+
+    khc_state_resp_header_callback(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    khc_state_resp_header_callback(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_BODY_FRAGMENT );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
+
+    khc_state_resp_body_fragment(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_BODY_READ );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
+
+    called = false;
+    s_ctx.on_recv = [=, &called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        called = true;
+        REQUIRE( length_to_read == buff_size);
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
+    };
+    khc_state_resp_body_read(&http);
+    REQUIRE( http._state == KHC_STATE_CLOSE );
+    REQUIRE( http._read_end == 1 );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    s_ctx.on_close = [=, &called](void* socket_ctx) {
+        called = true;
+        return KHC_SOCK_OK;
+    };
+    khc_state_close(&http);
+    REQUIRE( http._state == KHC_STATE_FINISHED );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+}
+
+TEST_CASE( "HTTP 1.1 chunked minimal" ) {
+    khc http;
+    khc_init(&http);
+    const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
+    const size_t resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
+
+    khct::http::Resp resp;
+    resp.headers = {
+        "HTTP/1.1 200 OK",
+        "Host: api.kii.com",
+        "Transfer-Encoding: chunked",
+    };
+    resp.body = "0\r\n\r\n";
+
+    khc_set_host(&http, "api.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_path(&http, "/api/apps");
+    khc_set_req_headers(&http, NULL);
+
+    khct::cb::SockCtx s_ctx;
+    khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
+
+    khct::cb::IOCtx io_ctx;
+    khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+
+    khc_state_idle(&http);
+    REQUIRE( http._state == KHC_STATE_CONNECT );
+    REQUIRE( http._result == KHC_ERR_OK );
+
+    bool called = false;
+    s_ctx.on_connect = [=, &called](void* socket_context, const char* host, unsigned int port) {
+        called = true;
+        REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
+        REQUIRE( strlen(host) == strlen("api.kii.com") );
+        REQUIRE( port == 443 );
+        return KHC_SOCK_OK;
+    };
+
+    khc_state_connect(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_LINE );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        const char req_line[] = "GET https://api.kii.com/api/apps HTTP/1.1\r\n";
+        REQUIRE( length == strlen(req_line) );
+        REQUIRE( strncmp(buffer, req_line, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
+
+    khc_state_req_line(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_HOST_HEADER );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        const char host_hdr[] = "HOST: api.kii.com\r\n";
+        REQUIRE( length == strlen(host_hdr) );
+        REQUIRE( strncmp(buffer, host_hdr, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
+    khc_state_req_host_header(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_HEADER );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    khc_state_req_header(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_HEADER_END );
+    REQUIRE( http._result == KHC_ERR_OK );
+
+    called = false;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        REQUIRE( length == 49 );
+        REQUIRE( strncmp(buffer, "Transfer-Encoding: chunked\r\nConnection: Close\r\n\r\n", 49) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
+
+    khc_state_req_header_end(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_BODY_READ );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    io_ctx.on_read = [=, &called](char *buffer, size_t size, void *userdata) {
+        called = true;
+        REQUIRE( size == buff_size );
+        const char body[] = "http body";
+        strncpy(buffer, body, strlen(body));
+        return strlen(body);
+    };
+    khc_state_req_body_read(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_SIZE );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( http._read_req_end == 0 );
+    REQUIRE( called );
+
+    called = false;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        const char body[] = "9\r\n";
+        REQUIRE( length == strlen(body) );
+        REQUIRE( strncmp(buffer, body, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
+    khc_state_req_body_send_size(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        const char body[] = "http body";
+        REQUIRE( length == strlen(body) );
+        REQUIRE( strncmp(buffer, body, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
+    khc_state_req_body_send(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_CRLF );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        const char body[] = "\r\n";
+        REQUIRE( length == strlen(body) );
+        REQUIRE( strncmp(buffer, body, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
+    khc_state_req_body_send_crlf(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_BODY_READ );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    io_ctx.on_read = [=, &called](char *buffer, size_t size, void *userdata) {
+        called = true;
+        REQUIRE( size == buff_size );
+        return 0;
+    };
+    khc_state_req_body_read(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_SIZE );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( http._read_req_end == 1 );
+    REQUIRE( called );
+
+    called = false;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        const char body[] = "0\r\n";
+        REQUIRE( length == strlen(body) );
+        REQUIRE( strncmp(buffer, body, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
+    khc_state_req_body_send_size(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_CRLF );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        const char body[] = "\r\n";
+        REQUIRE( length == strlen(body) );
+        REQUIRE( strncmp(buffer, body, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
+    khc_state_req_body_send_crlf(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_STATUS_READ );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    auto is = resp.to_istringstream();
+    s_ctx.on_recv = [=, &called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        called = true;
+        REQUIRE( length_to_read == resp_header_buff_size - 1 );
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
+    };
+
+    khc_state_resp_status_read(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_STATUS_PARSE );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
+    char buffer[resp_header_buff_size];
+    size_t len = resp.to_istringstream().read((char*)&buffer, resp_header_buff_size - 1).gcount();
+    REQUIRE( http._resp_header_read_size == len );
+    REQUIRE( called );
+
+    khc_state_resp_status_parse(&http);
+    REQUIRE( khc_get_status_code(&http) == 200 );
+    REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
+
+    called = false;
+    io_ctx.on_header = [=, &called, &resp](char *buffer, size_t size, void *userdata) {
+        called = true;
+        const char* status_line = resp.headers[0].c_str();
+        size_t len = strlen(status_line);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, status_line, len) == 0 );
+        return size;
+    };
+
+    khc_state_resp_header_callback(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
+    REQUIRE( http._chunked_resp == 0 );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    io_ctx.on_header = [=, &called, &resp](char *buffer, size_t size, void *userdata) {
+        called = true;
+        const char* host_line = resp.headers[1].c_str();
+        size_t len = strlen(host_line);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, host_line, len) == 0 );
+        return size;
+    };
+
+    khc_state_resp_header_callback(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
+    REQUIRE( http._chunked_resp == 0 );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    io_ctx.on_header = [=, &called, &resp](char *buffer, size_t size, void *userdata) {
+        called = true;
+        const char* chunked_line = resp.headers[2].c_str();
+        size_t len = strlen(chunked_line);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, chunked_line, len) == 0 );
+        return size;
+    };
+
+    khc_state_resp_header_callback(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
+    REQUIRE( http._chunk_size == 0 );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
+
+    khc_state_resp_header_callback(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE );
+    REQUIRE( http._chunk_size == 0 );
+    REQUIRE( http._body_read_size == 0 );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
+
+    khc_state_resp_body_parse_chunk_size(&http);
+    REQUIRE( http._state == KHC_STATE_READ_CHUNK_SIZE_FROM_HEADER_BUFF );
+    REQUIRE( http._chunk_size == 0 );
+    REQUIRE( http._body_read_size == 0 );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
+
+    khc_state_read_chunk_size_from_header_buff(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_BODY_PARSE_CHUNK_SIZE );
+    REQUIRE( http._chunk_size == 0 );
+    REQUIRE( http._body_read_size == 5 );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
+
+    khc_state_resp_body_parse_chunk_size(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_BODY_SKIP_TRAILERS );
+    REQUIRE( http._chunk_size == 0 );
+    REQUIRE( http._body_read_size == 2 );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
+
+    called = false;
+    s_ctx.on_recv = [=, &called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        called = true;
+        *out_actual_length = 0;
+        return KHC_SOCK_OK;
+    };
+    khc_state_resp_body_skip_trailers(&http);
+    REQUIRE( http._state == KHC_STATE_CLOSE );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    s_ctx.on_close = [=, &called](void* socket_ctx) {
+        called = true;
+        return KHC_SOCK_OK;
+    };
+    khc_state_close(&http);
+    REQUIRE( http._state == KHC_STATE_FINISHED );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+}
+
+TEST_CASE( "Socket send partial" ) {
+    khc http;
+    khc_init(&http);
+    const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
+    const size_t resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
+
+    khct::http::Resp resp;
+    resp.headers = { "HTTP/1.0 200 OK" };
+
+    char req_header[] = "X-KII-dummy-Header: test partial.";
+    khc_slist* req_headers = NULL;
+    req_headers = khc_slist_append(req_headers, req_header, strlen(req_header));
+
+    khc_set_host(&http, "api.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_path(&http, "/api/apps");
+    khc_set_req_headers(&http, req_headers);
+
+    khct::cb::SockCtx s_ctx;
+    khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
+
+    khct::cb::IOCtx io_ctx;
+    khc_set_cb_read(&http, khct::cb::cb_read, &io_ctx);
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+
+    khc_state_idle(&http);
+    REQUIRE( http._state == KHC_STATE_CONNECT );
+    REQUIRE( http._result == KHC_ERR_OK );
+
+    bool called = false;
+    s_ctx.on_connect = [=, &called](void* socket_context, const char* host, unsigned int port) {
+        called = true;
+        REQUIRE( strncmp(host, "api.kii.com", strlen("api.kii.com")) == 0 );
+        REQUIRE( strlen(host) == strlen("api.kii.com") );
+        REQUIRE( port == 443 );
+        return KHC_SOCK_OK;
+    };
+
+    khc_state_connect(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_LINE );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        const char req_line[] = "GET https://api.kii.";
+        size_t req_len = strlen(req_line);
+        REQUIRE( length > req_len );
+        REQUIRE( strncmp(buffer, req_line, req_len) == 0 );
+        *out_sent_length = req_len;
+        return KHC_SOCK_OK;
     };
 
     khc_state_req_line(&http);
     REQUIRE( http._state == KHC_STATE_REQ_LINE );
     REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("state req line failed.") {
-    http._state = KHC_STATE_REQ_LINE;
 
     called = false;
     s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
+        called = true;
+        const char req_line[] = "com/api/apps HT";
+        size_t req_len = strlen(req_line);
+        REQUIRE( length > req_len );
+        REQUIRE( strncmp(buffer, req_line, req_len) == 0 );
+        *out_sent_length = req_len;
+        return KHC_SOCK_OK;
     };
 
     khc_state_req_line(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+    REQUIRE( http._state == KHC_STATE_REQ_LINE );
+    REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("state req host header retry.") {
-    http._state = KHC_STATE_REQ_HOST_HEADER;
 
     called = false;
     s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
+        called = true;
+        const char req_line[] = "TP/1.1\r\n";
+        size_t req_len = strlen(req_line);
+        REQUIRE( length == req_len );
+        REQUIRE( strncmp(buffer, req_line, req_len) == 0 );
+        *out_sent_length = req_len;
+        return KHC_SOCK_OK;
     };
 
+    khc_state_req_line(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_HOST_HEADER );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
+
+    called = false;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        const char host_hdr[] = "HOST: api.";
+        size_t host_len = strlen(host_hdr);
+        REQUIRE( length > host_len );
+        REQUIRE( strncmp(buffer, host_hdr, host_len) == 0 );
+        *out_sent_length = host_len;
+        return KHC_SOCK_OK;
+    };
     khc_state_req_host_header(&http);
     REQUIRE( http._state == KHC_STATE_REQ_HOST_HEADER );
     REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("state req host header failed.") {
-    http._state = KHC_STATE_REQ_HOST_HEADER;
 
     called = false;
     s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
+        called = true;
+        const char host_hdr[] = "kii.com\r\n";
+        size_t host_len = strlen(host_hdr);
+        REQUIRE( length == host_len );
+        REQUIRE( strncmp(buffer, host_hdr, host_len) == 0 );
+        *out_sent_length = host_len;
+        return KHC_SOCK_OK;
     };
-
     khc_state_req_host_header(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+    REQUIRE( http._state == KHC_STATE_REQ_HEADER );
+    REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
 
-  SECTION("state req header send retry.") {
-    http._state = KHC_STATE_REQ_HEADER_SEND;
-    http._sent_length = 0;
-    khc_slist header;
-    header.data = (char*)"dummy";
-    header.next = NULL;
-    http._current_req_header = &header;
+    khc_state_req_header(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_HEADER_SEND );
+    REQUIRE( http._result == KHC_ERR_OK );
 
     called = false;
     s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
+        called = true;
+        const char hdr[] = "X-KII-dummy-";
+        size_t len = strlen(hdr);
+        REQUIRE( length > len );
+        REQUIRE( strncmp(buffer, hdr, len) == 0 );
+        *out_sent_length = len;
+        return KHC_SOCK_OK;
     };
-
     khc_state_req_header_send(&http);
     REQUIRE( http._state == KHC_STATE_REQ_HEADER_SEND );
     REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("state req header send failed.") {
-    http._state = KHC_STATE_REQ_HEADER_SEND;
-    http._sent_length = 0;
-    khc_slist header;
-    header.data = (char*)"dummy";
-    header.next = NULL;
-    http._current_req_header = &header;
 
     called = false;
     s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
+        called = true;
+        const char hdr[] = "Header: test p";
+        size_t len = strlen(hdr);
+        REQUIRE( length > len );
+        REQUIRE( strncmp(buffer, hdr, len) == 0 );
+        *out_sent_length = len;
+        return KHC_SOCK_OK;
     };
-
     khc_state_req_header_send(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+    REQUIRE( http._state == KHC_STATE_REQ_HEADER_SEND );
+    REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("state req header send crlf retry.") {
-    http._state = KHC_STATE_REQ_HEADER_SEND_CRLF;
 
     called = false;
     s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
+        called = true;
+        const char hdr[] = "artial.";
+        size_t len = strlen(hdr);
+        REQUIRE( length == len );
+        REQUIRE( strncmp(buffer, hdr, len) == 0 );
+        *out_sent_length = len;
+        return KHC_SOCK_OK;
     };
-
-    khc_state_req_header_send_crlf(&http);
+    khc_state_req_header_send(&http);
     REQUIRE( http._state == KHC_STATE_REQ_HEADER_SEND_CRLF );
     REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("state req header send crlf failed.") {
-    http._state = KHC_STATE_REQ_HEADER_SEND_CRLF;
 
     called = false;
     s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
+        called = true;
+        const char hdr[] = "\r\n";
+        size_t len = strlen(hdr);
+        REQUIRE( length == len );
+        REQUIRE( strncmp(buffer, hdr, len) == 0 );
+        *out_sent_length = len;
+        return KHC_SOCK_OK;
     };
-
     khc_state_req_header_send_crlf(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+    REQUIRE( http._state == KHC_STATE_REQ_HEADER );
+    REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
 
-  SECTION("state req header end retry.") {
-    http._state = KHC_STATE_REQ_HEADER_END;
+    khc_state_req_header(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_HEADER_END );
+    REQUIRE( http._result == KHC_ERR_OK );
 
     called = false;
     s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
+        called = true;
+        const char hdr[] = "Transfer-Encoding: chunked\r\n";
+        size_t len = strlen(hdr);
+        REQUIRE( length > len );
+        REQUIRE( strncmp(buffer, hdr, len) == 0 );
+        *out_sent_length = len;
+        return KHC_SOCK_OK;
     };
 
     khc_state_req_header_end(&http);
     REQUIRE( http._state == KHC_STATE_REQ_HEADER_END );
     REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("state req header end failed.") {
-    http._state = KHC_STATE_REQ_HEADER_END;
 
     called = false;
     s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
+        called = true;
+        const char hdr[] = "Connection: Close\r\n\r\n";
+        size_t len = strlen(hdr);
+        REQUIRE( length == len );
+        REQUIRE( strncmp(buffer, hdr, len) == 0 );
+        *out_sent_length = len;
+        return KHC_SOCK_OK;
     };
 
     khc_state_req_header_end(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_SEND );
-    REQUIRE( called );
-  }
-
-  SECTION("state req body send size retry.") {
-    http._state = KHC_STATE_REQ_BODY_SEND_SIZE;
-    http._read_size = 1234;
-
-    called = false;
-    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
-    };
-
-    khc_state_req_body_send_size(&http);
-    REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_SIZE );
+    REQUIRE( http._state == KHC_STATE_REQ_BODY_READ );
     REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("state req body send size failed.") {
-    http._state = KHC_STATE_REQ_BODY_SEND_SIZE;
-    http._read_size = 1234;
 
     called = false;
-    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
+    io_ctx.on_read = [=, &called](char *buffer, size_t size, void *userdata) {
+        called = true;
+        REQUIRE( size == buff_size );
+        const char body[] = "http body";
+        strncpy(buffer, body, strlen(body));
+        return strlen(body);
     };
-
-    khc_state_req_body_send_size(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+    khc_state_req_body_read(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_SIZE );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( http._read_req_end == 0 );
     REQUIRE( called );
-  }
-
-  SECTION("state req body send retry.") {
-    http._state = KHC_STATE_REQ_BODY_SEND;
-    http._read_size = 1234;
-    http._sent_length = 0;
 
     called = false;
     s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
+        called = true;
+        const char body[] = "9\r\n";
+        REQUIRE( length == strlen(body) );
+        REQUIRE( strncmp(buffer, body, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
     };
-
-    khc_state_req_body_send(&http);
+    khc_state_req_body_send_size(&http);
     REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND );
     REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("state req body send failed.") {
-    http._state = KHC_STATE_REQ_BODY_SEND;
-    http._read_size = 1234;
-    http._sent_length = 0;
 
     called = false;
     s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
+        called = true;
+        const char body[] = "http body";
+        REQUIRE( length == strlen(body) );
+        REQUIRE( strncmp(buffer, body, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
     };
-
     khc_state_req_body_send(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_SEND );
-    REQUIRE( called );
-  }
-
-  SECTION("state req body send crlf retry.") {
-    http._state = KHC_STATE_REQ_BODY_SEND_CRLF;
-    http._sent_length = 0;
-
-    called = false;
-    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
-    };
-
-    khc_state_req_body_send_crlf(&http);
     REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_CRLF );
     REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("state req body send crlf failed.") {
-    http._state = KHC_STATE_REQ_BODY_SEND_CRLF;
-    http._sent_length = 0;
 
     called = false;
     s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
+        called = true;
+        const char body[] = "\r\n";
+        REQUIRE( length == strlen(body) );
+        REQUIRE( strncmp(buffer, body, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
     };
-
     khc_state_req_body_send_crlf(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+    REQUIRE( http._state == KHC_STATE_REQ_BODY_READ );
+    REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("resp status read no crlf.") {
-    http._state = KHC_STATE_RESP_STATUS_READ;
-    http._resp_header_read_size = 0;
 
     called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      strcpy(buffer, "no crlf");
-      *out_actual_length = strlen(buffer);
-      return KHC_SOCK_OK;
+    io_ctx.on_read = [=, &called](char *buffer, size_t size, void *userdata) {
+        called = true;
+        REQUIRE( size == buff_size );
+        return 0;
     };
-
-    khc_state_resp_status_read(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_TOO_LARGE_DATA );
+    khc_state_req_body_read(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_SIZE );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( http._read_req_end == 1 );
     REQUIRE( called );
-  }
-
-  SECTION("resp status read retry.") {
-    http._state = KHC_STATE_RESP_STATUS_READ;
-    http._resp_header_read_size = 0;
 
     called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        const char body[] = "0\r\n";
+        REQUIRE( length == strlen(body) );
+        REQUIRE( strncmp(buffer, body, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
     };
+    khc_state_req_body_send_size(&http);
+    REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_CRLF );
+    REQUIRE( http._result == KHC_ERR_OK );
+    REQUIRE( called );
 
-    khc_state_resp_status_read(&http);
+    called = false;
+    s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+        called = true;
+        const char body[] = "\r\n";
+        REQUIRE( length == strlen(body) );
+        REQUIRE( strncmp(buffer, body, length) == 0 );
+        *out_sent_length = length;
+        return KHC_SOCK_OK;
+    };
+    khc_state_req_body_send_crlf(&http);
     REQUIRE( http._state == KHC_STATE_RESP_STATUS_READ );
     REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("resp status read failed.") {
-    http._state = KHC_STATE_RESP_STATUS_READ;
-    http._resp_header_read_size = 0;
 
     called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
-    };
-
-    khc_state_resp_status_read(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_RECV );
-    REQUIRE( called );
-  }
-
-  SECTION("resp status parse no number.") {
-    http._state = KHC_STATE_RESP_STATUS_READ;
-    http._resp_header_read_size = 0;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      strcpy(buffer, "HTTP/1.1 abc no number status\r\n");
-      *out_actual_length = strlen(buffer);
-      return KHC_SOCK_OK;
+    auto is = resp.to_istringstream();
+    s_ctx.on_recv = [=, &called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        called = true;
+        REQUIRE( length_to_read == resp_header_buff_size - 1 );
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
     };
 
     khc_state_resp_status_read(&http);
     REQUIRE( http._state == KHC_STATE_RESP_STATUS_PARSE );
+    REQUIRE( http._read_end == 0 );
     REQUIRE( http._result == KHC_ERR_OK );
+    char buffer[resp_header_buff_size];
+    size_t len = resp.to_istringstream().read((char*)&buffer, resp_header_buff_size - 1).gcount();
+    REQUIRE( http._resp_header_read_size == len );
     REQUIRE( called );
 
     khc_state_resp_status_parse(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_FAIL );
-  }
-
-  SECTION("resp header read retry.") {
-    http._state = KHC_STATE_RESP_HEADER_READ;
-    http._resp_header_read_size = 0;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
-    };
-
-    khc_state_resp_header_read(&http);
-    REQUIRE( http._state == KHC_STATE_RESP_HEADER_READ );
-    REQUIRE( http._result == KHC_ERR_OK );
-    REQUIRE( called );
-  }
-
-  SECTION("resp header read failed.") {
-    http._state = KHC_STATE_RESP_HEADER_READ;
-    http._resp_header_read_size = 0;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
-    };
-
-    khc_state_resp_header_read(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_RECV );
-    REQUIRE( called );
-  }
-
-  SECTION("resp header callback failed.") {
-    http._state = KHC_STATE_RESP_HEADER_READ;
-    http._resp_header_read_size = 0;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      strcpy(buffer, "X-HEADER: dummy value\r\n");
-      *out_actual_length = strlen(buffer);
-      return KHC_SOCK_OK;
-    };
-
-    khc_state_resp_header_read(&http);
+    REQUIRE( khc_get_status_code(&http) == 200 );
     REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
-    REQUIRE( http._result == KHC_ERR_OK );
-    REQUIRE( called );
 
     called = false;
-    io_ctx.on_header = [=, &called](char *buffer, size_t size, void *userdata) {
-      called = true;
-      REQUIRE( size > 0 );
-      return 0;
+    io_ctx.on_header = [=, &called, &resp](char *buffer, size_t size, void *userdata) {
+        called = true;
+        const char* status_line = resp.headers[0].c_str();
+        size_t len = strlen(status_line);
+        REQUIRE( size == len );
+        REQUIRE( strncmp(buffer, status_line, len) == 0 );
+        return size;
     };
 
     khc_state_resp_header_callback(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_HEADER_CALLBACK );
-    REQUIRE( called );
-  }
-
-  SECTION("resp header skip retry.") {
-    http._state = KHC_STATE_RESP_HEADER_SKIP;
-    char sbuff[15];
-    strcpy(sbuff, "X-Dummy: dummy");
-    khc_set_resp_header_buff(&http, sbuff, 14);
-    http._resp_header_read_size = 14;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
-    };
-
-    khc_state_resp_header_skip(&http);
-    REQUIRE( http._state == KHC_STATE_RESP_HEADER_SKIP );
+    REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
+    REQUIRE( http._read_end == 0 );
     REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
 
-  SECTION("resp header skip failed.") {
-    http._state = KHC_STATE_RESP_HEADER_SKIP;
-    char sbuff[15];
-    strcpy(sbuff, "X-Dummy: dummy");
-    khc_set_resp_header_buff(&http, sbuff, 14);
-    http._resp_header_read_size = 14;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
-    };
-
-    khc_state_resp_header_skip(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_RECV );
-    REQUIRE( called );
-  }
-
-  SECTION("resp header skip failed by Content-Length.") {
-    http._state = KHC_STATE_RESP_HEADER_SKIP;
-    char sbuff[20];
-    strcpy(sbuff, "Content-Length: 200");
-    khc_set_resp_header_buff(&http, sbuff, 19);
-    http._resp_header_read_size = 19;
-
-    khc_state_resp_header_skip(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_HEADER_CALLBACK );
-  }
-
-  SECTION("resp header skip failed by Transfer-Encoding.") {
-    http._state = KHC_STATE_RESP_HEADER_SKIP;
-    char sbuff[27];
-    strcpy(sbuff, "Transfer-Encoding: chunked");
-    khc_set_resp_header_buff(&http, sbuff, 26);
-    http._resp_header_read_size = 26;
-
-    khc_state_resp_header_skip(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_HEADER_CALLBACK );
-  }
-
-  SECTION("resp body fragment failed.") {
-    http._state = KHC_STATE_RESP_BODY_FRAGMENT;
-    http._resp_header_read_size = 10;
-
-    called = false;
-    io_ctx.on_write = [=, &called](char *buffer, size_t size, void *userdata) {
-      called = true;
-      REQUIRE( size > 0 );
-      return 0;
-    };
+    khc_state_resp_header_callback(&http);
+    REQUIRE( http._state == KHC_STATE_RESP_BODY_FRAGMENT );
+    REQUIRE( http._read_end == 0 );
+    REQUIRE( http._result == KHC_ERR_OK );
 
     khc_state_resp_body_fragment(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_WRITE_CALLBACK );
-    REQUIRE( called );
-  }
-
-  SECTION("read chunk size from header buff failed.") {
-    http._state = KHC_STATE_READ_CHUNK_SIZE_FROM_HEADER_BUFF;
-    char sbuff[10];
-    khc_set_stream_buff(&http, sbuff, 10);
-    http._body_read_size = 256;
-
-    khc_state_read_chunk_size_from_header_buff(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_TOO_LARGE_DATA );
-  }
-
-  SECTION("read chunk body from header buff failed.") {
-    http._state = KHC_STATE_READ_CHUNK_BODY_FROM_HEADER_BUFF;
-    char sbuff[10];
-    khc_set_stream_buff(&http, sbuff, 10);
-    http._body_read_size = 256;
-
-    khc_state_read_chunk_body_from_header_buff(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_TOO_LARGE_DATA );
-  }
-
-  SECTION("resp body read retry.") {
-    http._state = KHC_STATE_RESP_BODY_READ;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
-    };
-
-    khc_state_resp_body_read(&http);
     REQUIRE( http._state == KHC_STATE_RESP_BODY_READ );
+    REQUIRE( http._read_end == 0 );
     REQUIRE( http._result == KHC_ERR_OK );
-    REQUIRE( called );
-  }
-
-  SECTION("resp body read failed.") {
-    http._state = KHC_STATE_RESP_BODY_READ;
 
     called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
+    s_ctx.on_recv = [=, &called, &resp, &is](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+        called = true;
+        REQUIRE( length_to_read == buff_size);
+        *out_actual_length = is.read(buffer, length_to_read).gcount();
+        return KHC_SOCK_OK;
     };
-
     khc_state_resp_body_read(&http);
     REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_RECV );
-    REQUIRE( called );
-  }
-
-  SECTION("resp body callback failed.") {
-    http._state = KHC_STATE_RESP_BODY_CALLBACK;
-    http._body_read_size = 10;
-
-    called = false;
-    io_ctx.on_write = [=, &called](char *buffer, size_t size, void *userdata) {
-      called = true;
-      REQUIRE( size > 0 );
-      return 0;
-    };
-
-    khc_state_resp_body_callback(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_WRITE_CALLBACK );
-    REQUIRE( called );
-  }
-
-  SECTION("resp body read chunk size retry.") {
-    http._state = KHC_STATE_RESP_BODY_READ_CHUNK_SIZE;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
-    };
-
-    khc_state_resp_body_read_chunk_size(&http);
-    REQUIRE( http._state == KHC_STATE_RESP_BODY_READ_CHUNK_SIZE );
+    REQUIRE( http._read_end == 1 );
     REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
-
-  SECTION("resp body read chunk size failed.") {
-    http._state = KHC_STATE_RESP_BODY_READ_CHUNK_SIZE;
 
     called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
+    s_ctx.on_close = [=, &called](void* socket_ctx) {
+        called = true;
+        return KHC_SOCK_OK;
     };
-
-    khc_state_resp_body_read_chunk_size(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_RECV );
-    REQUIRE( called );
-  }
-
-  SECTION("resp body read chunk size no buffer space.") {
-    http._state = KHC_STATE_RESP_BODY_READ_CHUNK_SIZE;
-    char sbuff[10];
-    khc_set_stream_buff(&http, sbuff, 10);
-    http._body_read_size = 256;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      *out_actual_length = length_to_read;
-      return KHC_SOCK_OK;
-    };
-
-    khc_state_resp_body_read_chunk_size(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_TOO_LARGE_DATA );
-    REQUIRE( called == false );
-  }
-
-  SECTION("resp body parse chunk body failed.") {
-    http._state = KHC_STATE_RESP_BODY_PARSE_CHUNK_BODY;
-    http._chunk_size = 10;
-    http._body_read_size = 10;
-    http._chunk_size_written = 0;
-
-    called = false;
-    io_ctx.on_write = [=, &called](char *buffer, size_t size, void *userdata) {
-      called = true;
-      REQUIRE( size > 0 );
-      return 0;
-    };
-
-    khc_state_resp_body_parse_chunk_body(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_WRITE_CALLBACK );
-    REQUIRE( called );
-  }
-
-  SECTION("resp body read chunk body retry.") {
-    http._state = KHC_STATE_RESP_BODY_READ_CHUNK_BODY;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
-    };
-
-    khc_state_resp_body_read_chunk_body(&http);
-    REQUIRE( http._state == KHC_STATE_RESP_BODY_READ_CHUNK_BODY );
-    REQUIRE( http._result == KHC_ERR_OK );
-    REQUIRE( called );
-  }
-
-  SECTION("resp body read chunk body failed.") {
-    http._state = KHC_STATE_RESP_BODY_READ_CHUNK_BODY;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
-    };
-
-    khc_state_resp_body_read_chunk_body(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_RECV );
-    REQUIRE( called );
-  }
-
-  SECTION("resp body read chunk body failed by recv 0.") {
-    http._state = KHC_STATE_RESP_BODY_READ_CHUNK_BODY;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      *out_actual_length = 0;
-      return KHC_SOCK_OK;
-    };
-
-    khc_state_resp_body_read_chunk_body(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_FAIL );
-    REQUIRE( called );
-  }
-
-  SECTION("resp body skip chunk body crlf retry.") {
-    http._state = KHC_STATE_RESP_BODY_SKIP_CHUNK_BODY_CRLF;
-    http._body_read_size = 0;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
-    };
-
-    khc_state_resp_body_skip_chunk_body_crlf(&http);
-    REQUIRE( http._state == KHC_STATE_RESP_BODY_SKIP_CHUNK_BODY_CRLF );
-    REQUIRE( http._result == KHC_ERR_OK );
-    REQUIRE( called );
-  }
-
-  SECTION("resp body skip chunk body crlf failed.") {
-    http._state = KHC_STATE_RESP_BODY_SKIP_CHUNK_BODY_CRLF;
-    http._body_read_size = 0;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
-    };
-
-    khc_state_resp_body_skip_chunk_body_crlf(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_RECV );
-    REQUIRE( called );
-  }
-
-  SECTION("resp body skip chunk body crlf failed by recv 0.") {
-    http._state = KHC_STATE_RESP_BODY_SKIP_CHUNK_BODY_CRLF;
-    http._body_read_size = 0;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      *out_actual_length = 0;
-      return KHC_SOCK_OK;
-    };
-
-    khc_state_resp_body_skip_chunk_body_crlf(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_FAIL );
-    REQUIRE( called );
-  }
-
-  SECTION("resp body skip trailers retry.") {
-    http._state = KHC_STATE_RESP_BODY_SKIP_TRAILERS;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_AGAIN;
-    };
-
-    khc_state_resp_body_skip_trailers(&http);
-    REQUIRE( http._state == KHC_STATE_RESP_BODY_SKIP_TRAILERS );
-    REQUIRE( http._result == KHC_ERR_OK );
-    REQUIRE( called );
-  }
-
-  SECTION("resp body skip trailers failed.") {
-    http._state = KHC_STATE_RESP_BODY_SKIP_TRAILERS;
-
-    called = false;
-    s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-      called = true;
-      return KHC_SOCK_FAIL;
-    };
-
-    khc_state_resp_body_skip_trailers(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_SOCK_RECV );
-    REQUIRE( called );
-  }
-
-  SECTION("close retry.") {
-    http._state = KHC_STATE_CLOSE;
-
-    called = false;
-    s_ctx.on_close = [=, &called](void* socket_context) {
-      called = true;
-      return KHC_SOCK_AGAIN;
-    };
-
-    khc_state_close(&http);
-    REQUIRE( http._state == KHC_STATE_CLOSE );
-    REQUIRE( http._result == KHC_ERR_OK );
-    REQUIRE( called );
-  }
-
-  SECTION("close failed.") {
-    http._state = KHC_STATE_CLOSE;
-
-    called = false;
-    s_ctx.on_close = [=, &called](void* socket_context) {
-      called = true;
-      return KHC_SOCK_FAIL;
-    };
-
     khc_state_close(&http);
     REQUIRE( http._state == KHC_STATE_FINISHED );
-    REQUIRE( http._result == KHC_ERR_SOCK_CLOSE );
+    REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-  }
+
+    khc_slist_free_all(req_headers);
+}
+
+TEST_CASE( "state abnormal tests." ) {
+    khc http;
+    khc_init(&http);
+    const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
+    const size_t resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
+    char stream_buff[buff_size];
+    char resp_header_buff[resp_header_buff_size];
+
+    khc_set_host(&http, "api.kii.com");
+    khc_set_method(&http, "GET");
+    khc_set_path(&http, "/api/apps");
+    khc_set_req_headers(&http, NULL);
+    khc_set_stream_buff(&http, stream_buff, buff_size);
+    khc_set_resp_header_buff(&http, resp_header_buff, resp_header_buff_size);
+
+    khct::cb::SockCtx s_ctx;
+    khc_set_cb_sock_connect(&http, khct::cb::mock_connect, &s_ctx);
+    khc_set_cb_sock_send(&http, khct::cb::mock_send, &s_ctx);
+    khc_set_cb_sock_recv(&http, khct::cb::mock_recv, &s_ctx);
+    khc_set_cb_sock_close(&http, khct::cb::mock_close, &s_ctx);
+
+    khct::cb::IOCtx io_ctx;
+    // no set cb_read.
+    khc_set_cb_write(&http, khct::cb::cb_write, &io_ctx);
+    khc_set_cb_header(&http, khct::cb::cb_header, &io_ctx);
+
+    khc_state_idle(&http);
+    REQUIRE( http._state == KHC_STATE_CONNECT );
+    REQUIRE( http._result == KHC_ERR_OK );
+
+    bool called;
+    SECTION("state connect retry.") {
+        called = false;
+        s_ctx.on_connect = [=, &called](void* socket_context, const char* host, unsigned int port) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_connect(&http);
+        REQUIRE( http._state == KHC_STATE_CONNECT );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("state connect failed.") {
+        called = false;
+        s_ctx.on_connect = [=, &called](void* socket_context, const char* host, unsigned int port) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_connect(&http);
+        REQUIRE( http._state == KHC_STATE_FINISHED );
+        REQUIRE( http._result == KHC_ERR_SOCK_CONNECT );
+        REQUIRE( called );
+    }
+
+    SECTION("state req line retry.") {
+        http._state = KHC_STATE_REQ_LINE;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_req_line(&http);
+        REQUIRE( http._state == KHC_STATE_REQ_LINE );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("state req line failed.") {
+        http._state = KHC_STATE_REQ_LINE;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_req_line(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+        REQUIRE( called );
+    }
+
+    SECTION("state req host header retry.") {
+        http._state = KHC_STATE_REQ_HOST_HEADER;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_req_host_header(&http);
+        REQUIRE( http._state == KHC_STATE_REQ_HOST_HEADER );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("state req host header failed.") {
+        http._state = KHC_STATE_REQ_HOST_HEADER;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_req_host_header(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+        REQUIRE( called );
+    }
+
+    SECTION("state req header send retry.") {
+        http._state = KHC_STATE_REQ_HEADER_SEND;
+        http._sent_length = 0;
+        khc_slist header;
+        header.data = (char*)"dummy";
+        header.next = NULL;
+        http._current_req_header = &header;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_req_header_send(&http);
+        REQUIRE( http._state == KHC_STATE_REQ_HEADER_SEND );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("state req header send failed.") {
+        http._state = KHC_STATE_REQ_HEADER_SEND;
+        http._sent_length = 0;
+        khc_slist header;
+        header.data = (char*)"dummy";
+        header.next = NULL;
+        http._current_req_header = &header;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_req_header_send(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+        REQUIRE( called );
+    }
+
+    SECTION("state req header send crlf retry.") {
+        http._state = KHC_STATE_REQ_HEADER_SEND_CRLF;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_req_header_send_crlf(&http);
+        REQUIRE( http._state == KHC_STATE_REQ_HEADER_SEND_CRLF );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("state req header send crlf failed.") {
+        http._state = KHC_STATE_REQ_HEADER_SEND_CRLF;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_req_header_send_crlf(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+        REQUIRE( called );
+    }
+
+    SECTION("state req header end retry.") {
+        http._state = KHC_STATE_REQ_HEADER_END;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_req_header_end(&http);
+        REQUIRE( http._state == KHC_STATE_REQ_HEADER_END );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("state req header end failed.") {
+        http._state = KHC_STATE_REQ_HEADER_END;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_req_header_end(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+        REQUIRE( called );
+    }
+
+    SECTION("state req body send size retry.") {
+        http._state = KHC_STATE_REQ_BODY_SEND_SIZE;
+        http._read_size = 1234;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_req_body_send_size(&http);
+        REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_SIZE );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("state req body send size failed.") {
+        http._state = KHC_STATE_REQ_BODY_SEND_SIZE;
+        http._read_size = 1234;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_req_body_send_size(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+        REQUIRE( called );
+    }
+
+    SECTION("state req body send retry.") {
+        http._state = KHC_STATE_REQ_BODY_SEND;
+        http._read_size = 1234;
+        http._sent_length = 0;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_req_body_send(&http);
+        REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("state req body send failed.") {
+        http._state = KHC_STATE_REQ_BODY_SEND;
+        http._read_size = 1234;
+        http._sent_length = 0;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_req_body_send(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+        REQUIRE( called );
+    }
+
+    SECTION("state req body send crlf retry.") {
+        http._state = KHC_STATE_REQ_BODY_SEND_CRLF;
+        http._sent_length = 0;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_req_body_send_crlf(&http);
+        REQUIRE( http._state == KHC_STATE_REQ_BODY_SEND_CRLF );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("state req body send crlf failed.") {
+        http._state = KHC_STATE_REQ_BODY_SEND_CRLF;
+        http._sent_length = 0;
+
+        called = false;
+        s_ctx.on_send = [=, &called](void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_req_body_send_crlf(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_SEND );
+        REQUIRE( called );
+    }
+
+    SECTION("resp status read no crlf.") {
+        http._state = KHC_STATE_RESP_STATUS_READ;
+        http._resp_header_read_size = 0;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            strcpy(buffer, "no crlf");
+            *out_actual_length = strlen(buffer);
+            return KHC_SOCK_OK;
+        };
+
+        khc_state_resp_status_read(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_TOO_LARGE_DATA );
+        REQUIRE( called );
+    }
+
+    SECTION("resp status read retry.") {
+        http._state = KHC_STATE_RESP_STATUS_READ;
+        http._resp_header_read_size = 0;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_resp_status_read(&http);
+        REQUIRE( http._state == KHC_STATE_RESP_STATUS_READ );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("resp status read failed.") {
+        http._state = KHC_STATE_RESP_STATUS_READ;
+        http._resp_header_read_size = 0;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_resp_status_read(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_RECV );
+        REQUIRE( called );
+    }
+
+    SECTION("resp status parse no number.") {
+        http._state = KHC_STATE_RESP_STATUS_READ;
+        http._resp_header_read_size = 0;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            strcpy(buffer, "HTTP/1.1 abc no number status\r\n");
+            *out_actual_length = strlen(buffer);
+            return KHC_SOCK_OK;
+        };
+
+        khc_state_resp_status_read(&http);
+        REQUIRE( http._state == KHC_STATE_RESP_STATUS_PARSE );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+
+        khc_state_resp_status_parse(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_FAIL );
+    }
+
+    SECTION("resp header read retry.") {
+        http._state = KHC_STATE_RESP_HEADER_READ;
+        http._resp_header_read_size = 0;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_resp_header_read(&http);
+        REQUIRE( http._state == KHC_STATE_RESP_HEADER_READ );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("resp header read failed.") {
+        http._state = KHC_STATE_RESP_HEADER_READ;
+        http._resp_header_read_size = 0;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_resp_header_read(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_RECV );
+        REQUIRE( called );
+    }
+
+    SECTION("resp header callback failed.") {
+        http._state = KHC_STATE_RESP_HEADER_READ;
+        http._resp_header_read_size = 0;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            strcpy(buffer, "X-HEADER: dummy value\r\n");
+            *out_actual_length = strlen(buffer);
+            return KHC_SOCK_OK;
+        };
+
+        khc_state_resp_header_read(&http);
+        REQUIRE( http._state == KHC_STATE_RESP_HEADER_CALLBACK );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+
+        called = false;
+        io_ctx.on_header = [=, &called](char *buffer, size_t size, void *userdata) {
+            called = true;
+            REQUIRE( size > 0 );
+            return 0;
+        };
+
+        khc_state_resp_header_callback(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_HEADER_CALLBACK );
+        REQUIRE( called );
+    }
+
+    SECTION("resp header skip retry.") {
+        http._state = KHC_STATE_RESP_HEADER_SKIP;
+        char sbuff[15];
+        strcpy(sbuff, "X-Dummy: dummy");
+        khc_set_resp_header_buff(&http, sbuff, 14);
+        http._resp_header_read_size = 14;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_resp_header_skip(&http);
+        REQUIRE( http._state == KHC_STATE_RESP_HEADER_SKIP );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("resp header skip failed.") {
+        http._state = KHC_STATE_RESP_HEADER_SKIP;
+        char sbuff[15];
+        strcpy(sbuff, "X-Dummy: dummy");
+        khc_set_resp_header_buff(&http, sbuff, 14);
+        http._resp_header_read_size = 14;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_resp_header_skip(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_RECV );
+        REQUIRE( called );
+    }
+
+    SECTION("resp header skip failed by Content-Length.") {
+        http._state = KHC_STATE_RESP_HEADER_SKIP;
+        char sbuff[20];
+        strcpy(sbuff, "Content-Length: 200");
+        khc_set_resp_header_buff(&http, sbuff, 19);
+        http._resp_header_read_size = 19;
+
+        khc_state_resp_header_skip(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_HEADER_CALLBACK );
+    }
+
+    SECTION("resp header skip failed by Transfer-Encoding.") {
+        http._state = KHC_STATE_RESP_HEADER_SKIP;
+        char sbuff[27];
+        strcpy(sbuff, "Transfer-Encoding: chunked");
+        khc_set_resp_header_buff(&http, sbuff, 26);
+        http._resp_header_read_size = 26;
+
+        khc_state_resp_header_skip(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_HEADER_CALLBACK );
+    }
+
+    SECTION("resp body fragment failed.") {
+        http._state = KHC_STATE_RESP_BODY_FRAGMENT;
+        http._resp_header_read_size = 10;
+
+        called = false;
+        io_ctx.on_write = [=, &called](char *buffer, size_t size, void *userdata) {
+            called = true;
+            REQUIRE( size > 0 );
+            return 0;
+        };
+
+        khc_state_resp_body_fragment(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_WRITE_CALLBACK );
+        REQUIRE( called );
+    }
+
+    SECTION("read chunk size from header buff failed.") {
+        http._state = KHC_STATE_READ_CHUNK_SIZE_FROM_HEADER_BUFF;
+        char sbuff[10];
+        khc_set_stream_buff(&http, sbuff, 10);
+        http._body_read_size = 256;
+
+        khc_state_read_chunk_size_from_header_buff(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_TOO_LARGE_DATA );
+    }
+
+    SECTION("read chunk body from header buff failed.") {
+        http._state = KHC_STATE_READ_CHUNK_BODY_FROM_HEADER_BUFF;
+        char sbuff[10];
+        khc_set_stream_buff(&http, sbuff, 10);
+        http._body_read_size = 256;
+
+        khc_state_read_chunk_body_from_header_buff(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_TOO_LARGE_DATA );
+    }
+
+    SECTION("resp body read retry.") {
+        http._state = KHC_STATE_RESP_BODY_READ;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_resp_body_read(&http);
+        REQUIRE( http._state == KHC_STATE_RESP_BODY_READ );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("resp body read failed.") {
+        http._state = KHC_STATE_RESP_BODY_READ;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_resp_body_read(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_RECV );
+        REQUIRE( called );
+    }
+
+    SECTION("resp body callback failed.") {
+        http._state = KHC_STATE_RESP_BODY_CALLBACK;
+        http._body_read_size = 10;
+
+        called = false;
+        io_ctx.on_write = [=, &called](char *buffer, size_t size, void *userdata) {
+            called = true;
+            REQUIRE( size > 0 );
+            return 0;
+        };
+
+        khc_state_resp_body_callback(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_WRITE_CALLBACK );
+        REQUIRE( called );
+    }
+
+    SECTION("resp body read chunk size retry.") {
+        http._state = KHC_STATE_RESP_BODY_READ_CHUNK_SIZE;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_resp_body_read_chunk_size(&http);
+        REQUIRE( http._state == KHC_STATE_RESP_BODY_READ_CHUNK_SIZE );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("resp body read chunk size failed.") {
+        http._state = KHC_STATE_RESP_BODY_READ_CHUNK_SIZE;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_resp_body_read_chunk_size(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_RECV );
+        REQUIRE( called );
+    }
+
+    SECTION("resp body read chunk size no buffer space.") {
+        http._state = KHC_STATE_RESP_BODY_READ_CHUNK_SIZE;
+        char sbuff[10];
+        khc_set_stream_buff(&http, sbuff, 10);
+        http._body_read_size = 256;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            *out_actual_length = length_to_read;
+            return KHC_SOCK_OK;
+        };
+
+        khc_state_resp_body_read_chunk_size(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_TOO_LARGE_DATA );
+        REQUIRE( called == false );
+    }
+
+    SECTION("resp body parse chunk body failed.") {
+        http._state = KHC_STATE_RESP_BODY_PARSE_CHUNK_BODY;
+        http._chunk_size = 10;
+        http._body_read_size = 10;
+        http._chunk_size_written = 0;
+
+        called = false;
+        io_ctx.on_write = [=, &called](char *buffer, size_t size, void *userdata) {
+            called = true;
+            REQUIRE( size > 0 );
+            return 0;
+        };
+
+        khc_state_resp_body_parse_chunk_body(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_WRITE_CALLBACK );
+        REQUIRE( called );
+    }
+
+    SECTION("resp body read chunk body retry.") {
+        http._state = KHC_STATE_RESP_BODY_READ_CHUNK_BODY;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_resp_body_read_chunk_body(&http);
+        REQUIRE( http._state == KHC_STATE_RESP_BODY_READ_CHUNK_BODY );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("resp body read chunk body failed.") {
+        http._state = KHC_STATE_RESP_BODY_READ_CHUNK_BODY;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_resp_body_read_chunk_body(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_RECV );
+        REQUIRE( called );
+    }
+
+    SECTION("resp body read chunk body failed by recv 0.") {
+        http._state = KHC_STATE_RESP_BODY_READ_CHUNK_BODY;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            *out_actual_length = 0;
+            return KHC_SOCK_OK;
+        };
+
+        khc_state_resp_body_read_chunk_body(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_FAIL );
+        REQUIRE( called );
+    }
+
+    SECTION("resp body skip chunk body crlf retry.") {
+        http._state = KHC_STATE_RESP_BODY_SKIP_CHUNK_BODY_CRLF;
+        http._body_read_size = 0;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_resp_body_skip_chunk_body_crlf(&http);
+        REQUIRE( http._state == KHC_STATE_RESP_BODY_SKIP_CHUNK_BODY_CRLF );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("resp body skip chunk body crlf failed.") {
+        http._state = KHC_STATE_RESP_BODY_SKIP_CHUNK_BODY_CRLF;
+        http._body_read_size = 0;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_resp_body_skip_chunk_body_crlf(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_RECV );
+        REQUIRE( called );
+    }
+
+    SECTION("resp body skip chunk body crlf failed by recv 0.") {
+        http._state = KHC_STATE_RESP_BODY_SKIP_CHUNK_BODY_CRLF;
+        http._body_read_size = 0;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            *out_actual_length = 0;
+            return KHC_SOCK_OK;
+        };
+
+        khc_state_resp_body_skip_chunk_body_crlf(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_FAIL );
+        REQUIRE( called );
+    }
+
+    SECTION("resp body skip trailers retry.") {
+        http._state = KHC_STATE_RESP_BODY_SKIP_TRAILERS;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_resp_body_skip_trailers(&http);
+        REQUIRE( http._state == KHC_STATE_RESP_BODY_SKIP_TRAILERS );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("resp body skip trailers failed.") {
+        http._state = KHC_STATE_RESP_BODY_SKIP_TRAILERS;
+
+        called = false;
+        s_ctx.on_recv = [=, &called](void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_resp_body_skip_trailers(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_SOCK_RECV );
+        REQUIRE( called );
+    }
+
+    SECTION("close retry.") {
+        http._state = KHC_STATE_CLOSE;
+
+        called = false;
+        s_ctx.on_close = [=, &called](void* socket_context) {
+            called = true;
+            return KHC_SOCK_AGAIN;
+        };
+
+        khc_state_close(&http);
+        REQUIRE( http._state == KHC_STATE_CLOSE );
+        REQUIRE( http._result == KHC_ERR_OK );
+        REQUIRE( called );
+    }
+
+    SECTION("close failed.") {
+        http._state = KHC_STATE_CLOSE;
+
+        called = false;
+        s_ctx.on_close = [=, &called](void* socket_context) {
+            called = true;
+            return KHC_SOCK_FAIL;
+        };
+
+        khc_state_close(&http);
+        REQUIRE( http._state == KHC_STATE_FINISHED );
+        REQUIRE( http._result == KHC_ERR_SOCK_CLOSE );
+        REQUIRE( called );
+    }
 }

--- a/tests/small_test/khc/testtest.cpp
+++ b/tests/small_test/khc/testtest.cpp
@@ -4,11 +4,11 @@
 #include <sstream>
 
 TEST_CASE( "temp" ) {
-  std::string respStr = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nbody";
-  std::istringstream iss(respStr);
-  std::istream& is(iss);
-  khct::http::Resp resp = khct::http::Resp(is);
-  REQUIRE( resp.headers[0] == "HTTP/1.1 200 OK" );
-  REQUIRE( resp.headers[1] == "Content-Type: text/plain" );
-  REQUIRE( resp.body == "body" );
+    std::string respStr = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nbody";
+    std::istringstream iss(respStr);
+    std::istream& is(iss);
+    khct::http::Resp resp = khct::http::Resp(is);
+    REQUIRE( resp.headers[0] == "HTTP/1.1 200 OK" );
+    REQUIRE( resp.headers[1] == "Content-Type: text/plain" );
+    REQUIRE( resp.body == "body" );
 }

--- a/tests/small_test/tio/command_parser_test.cpp
+++ b/tests/small_test/tio/command_parser_test.cpp
@@ -16,15 +16,15 @@ TEST_CASE( "_get_object_in_array" ) {
 
     SECTION("Get object at index 0") {
         _cmd_parser_code_t p_res = _get_object_in_array(
-            &resource,
-            NULL,
-            NULL,
-            json_arr,
-            strlen(json_arr),
-            0,
-            &obj_str,
-            &obj_str_len
-            );
+                &resource,
+                NULL,
+                NULL,
+                json_arr,
+                strlen(json_arr),
+                0,
+                &obj_str,
+                &obj_str_len
+                );
         REQUIRE( p_res == _CMD_PARSE_OK );
         REQUIRE( obj_str_len == 7);
         char obj_str_copy[obj_str_len+1];
@@ -34,15 +34,15 @@ TEST_CASE( "_get_object_in_array" ) {
 
     SECTION("Get object at index 1") {
         _cmd_parser_code_t p_res = _get_object_in_array(
-            &resource,
-            NULL,
-            NULL,
-            json_arr,
-            strlen(json_arr),
-            1,
-            &obj_str,
-            &obj_str_len
-            );
+                &resource,
+                NULL,
+                NULL,
+                json_arr,
+                strlen(json_arr),
+                1,
+                &obj_str,
+                &obj_str_len
+                );
         REQUIRE( p_res == _CMD_PARSE_OK );
         REQUIRE( obj_str_len == 7);
         char obj_str_copy[obj_str_len+1];
@@ -52,15 +52,15 @@ TEST_CASE( "_get_object_in_array" ) {
 
     SECTION("Get object at index 2") {
         _cmd_parser_code_t p_res = _get_object_in_array(
-            &resource,
-            NULL,
-            NULL,
-            json_arr,
-            strlen(json_arr),
-            2,
-            &obj_str,
-            &obj_str_len
-            );
+                &resource,
+                NULL,
+                NULL,
+                json_arr,
+                strlen(json_arr),
+                2,
+                &obj_str,
+                &obj_str_len
+                );
         REQUIRE( p_res == _CMD_PARSE_ARRAY_OUT_OF_INDEX );
     }
 }
@@ -75,14 +75,14 @@ TEST_CASE( "_parse_first_kv" ) {
         size_t out_value_len = 0;
         jsmntype_t out_value_type = JSMN_OBJECT;
         _cmd_parser_code_t p_res = _parse_first_kv(
-            json_obj,
-            strlen(json_obj),
-            &out_key,
-            &out_key_len,
-            &out_value,
-            &out_value_len,
-            &out_value_type);
-        
+                json_obj,
+                strlen(json_obj),
+                &out_key,
+                &out_key_len,
+                &out_value,
+                &out_value_len,
+                &out_value_type);
+
         REQUIRE( p_res == _CMD_PARSE_OK );
 
         // Check key.
@@ -117,13 +117,13 @@ TEST_CASE( "_parse_action_object" ) {
         const char json_str[] = "[{\"setPower\":{\"power\":true}}]";
         const char alias[] = "myalias";
         _cmd_parser_code_t p_res = _parse_action(
-            &handler,
-            alias,
-            strlen(alias),
-            json_str,
-            strlen(json_str),
-            0,
-            &action);
+                &handler,
+                alias,
+                strlen(alias),
+                json_str,
+                strlen(json_str),
+                0,
+                &action);
 
         REQUIRE( p_res == _CMD_PARSE_OK );
 

--- a/tests/test_callbacks.h
+++ b/tests/test_callbacks.h
@@ -5,58 +5,58 @@ namespace khct {
 namespace cb {
 
 struct SockCtx {
-  std::function<khc_sock_code_t(void* socket_context, const char* host, unsigned int port)> on_connect;
-  std::function<khc_sock_code_t(void* socket_context, const char* buffer, size_t length, size_t* out_sent_length)> on_send;
-  std::function<khc_sock_code_t(void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length)> on_recv;
-  std::function<khc_sock_code_t(void* socket_context)> on_close;
+    std::function<khc_sock_code_t(void* socket_context, const char* host, unsigned int port)> on_connect;
+    std::function<khc_sock_code_t(void* socket_context, const char* buffer, size_t length, size_t* out_sent_length)> on_send;
+    std::function<khc_sock_code_t(void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length)> on_recv;
+    std::function<khc_sock_code_t(void* socket_context)> on_close;
 };
 
 struct IOCtx {
-  std::function<size_t(char *buffer, size_t size, void *userdata)> on_read;
-  std::function<size_t(char *buffer, size_t size, void *userdata)> on_header;
-  std::function<size_t(char *buffer, size_t size, void *userdata)> on_write;
+    std::function<size_t(char *buffer, size_t size, void *userdata)> on_read;
+    std::function<size_t(char *buffer, size_t size, void *userdata)> on_header;
+    std::function<size_t(char *buffer, size_t size, void *userdata)> on_write;
 };
 
 inline khc_sock_code_t mock_connect(void* socket_context, const char* host, unsigned int port) {
-  SockCtx* ctx = (SockCtx*)socket_context;
-  return ctx->on_connect(socket_context, host, port);
+    SockCtx* ctx = (SockCtx*)socket_context;
+    return ctx->on_connect(socket_context, host, port);
 }
 
 inline khc_sock_code_t mock_send (void* socket_context, const char* buffer, size_t length, size_t* out_sent_length) {
-  SockCtx* ctx = (SockCtx*)socket_context;
-  return ctx->on_send(socket_context, buffer, length, out_sent_length);
+    SockCtx* ctx = (SockCtx*)socket_context;
+    return ctx->on_send(socket_context, buffer, length, out_sent_length);
 }
 
 inline khc_sock_code_t mock_recv(void* socket_context, char* buffer, size_t length_to_read, size_t* out_actual_length) {
-  SockCtx* ctx = (SockCtx*)socket_context;
-  return ctx->on_recv(socket_context, buffer, length_to_read, out_actual_length);
+    SockCtx* ctx = (SockCtx*)socket_context;
+    return ctx->on_recv(socket_context, buffer, length_to_read, out_actual_length);
 }
 
 inline khc_sock_code_t mock_close(void* socket_context) {
-  SockCtx* ctx = (SockCtx*)socket_context;
-  return ctx->on_close(socket_context);
+    SockCtx* ctx = (SockCtx*)socket_context;
+    return ctx->on_close(socket_context);
 }
 
 inline size_t cb_write(char *buffer, size_t size, void *userdata) {
-  IOCtx* ctx = (IOCtx*)(userdata);
-  return ctx->on_write(buffer, size, userdata);
+    IOCtx* ctx = (IOCtx*)(userdata);
+    return ctx->on_write(buffer, size, userdata);
 }
 
 inline size_t cb_read(char *buffer, size_t size, void *userdata) {
-  IOCtx* ctx = (IOCtx*)(userdata);
-  return ctx->on_read(buffer, size, userdata);
+    IOCtx* ctx = (IOCtx*)(userdata);
+    return ctx->on_read(buffer, size, userdata);
 }
 
 inline size_t cb_header(char *buffer, size_t size, void *userdata) {
-  IOCtx* ctx = (IOCtx*)(userdata);
-  return ctx->on_header(buffer, size, userdata);
+    IOCtx* ctx = (IOCtx*)(userdata);
+    return ctx->on_header(buffer, size, userdata);
 }
 
 inline void cb_delay_ms(unsigned int msec, void *userdata) {
 }
 
 struct PushCtx {
-  std::function<void(const char *message, size_t message_length)> on_push;
+    std::function<void(const char *message, size_t message_length)> on_push;
 };
 
 inline void cb_push(const char* message, size_t message_length, void *userdata) {

--- a/tio/command_parser.c
+++ b/tio/command_parser.c
@@ -6,14 +6,14 @@
 #include <stdlib.h>
 
 _cmd_parser_code_t _get_object_in_array(
-    jkii_resource_t* resource,
-    JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE cb_free,
-    const char* json_array,
-    size_t json_array_length,
-    size_t index,
-    char** out_object,
-    size_t* out_object_length)
+        jkii_resource_t* resource,
+        JKII_CB_RESOURCE_ALLOC cb_alloc,
+        JKII_CB_RESOURCE_FREE cb_free,
+        const char* json_array,
+        size_t json_array_length,
+        size_t index,
+        char** out_object,
+        size_t* out_object_length)
 {
     char idx_str[32];
     int len = snprintf(idx_str, 32, "/[%lu]", (unsigned long)index);
@@ -47,13 +47,13 @@ _cmd_parser_code_t _get_object_in_array(
 }
 
 _cmd_parser_code_t _parse_first_kv(
-    const char* object,
-    size_t object_length,
-    char** out_key,
-    size_t* out_key_length,
-    char** out_value,
-    size_t* out_value_length,
-    jsmntype_t* out_value_type)
+        const char* object,
+        size_t object_length,
+        char** out_key,
+        size_t* out_key_length,
+        char** out_value,
+        size_t* out_value_length,
+        jsmntype_t* out_value_type)
 {
     jsmn_parser parser;
     jsmn_init(&parser);
@@ -82,38 +82,38 @@ _cmd_parser_code_t _parse_first_kv(
 }
 
 _cmd_parser_code_t _parse_alias(
-    tio_handler_t* handler,
-    const char* actions_array,
-    size_t actions_array_length,
-    size_t alias_index,
-    char** out_alias,
-    size_t* out_alias_length,
-    char** out_actions_array_in_alias,
-    size_t* out_actions_array_in_alias_length)
+        tio_handler_t* handler,
+        const char* actions_array,
+        size_t actions_array_length,
+        size_t alias_index,
+        char** out_alias,
+        size_t* out_alias_length,
+        char** out_actions_array_in_alias,
+        size_t* out_actions_array_in_alias_length)
 {
     char* alias;
     size_t alias_length;
     _cmd_parser_code_t res = _get_object_in_array(
-        handler->_kii._json_resource,
-        handler->_kii._cb_json_alloc,
-        handler->_kii._cb_json_free,
-        actions_array,
-        actions_array_length,
-        alias_index,
-        &alias,
-        &alias_length);
+            handler->_kii._json_resource,
+            handler->_kii._cb_json_alloc,
+            handler->_kii._cb_json_free,
+            actions_array,
+            actions_array_length,
+            alias_index,
+            &alias,
+            &alias_length);
     if (res != _CMD_PARSE_OK) {
         return res;
     }
     jsmntype_t alias_type = JSMN_OBJECT;
     res = _parse_first_kv(
-        alias,
-        alias_length,
-        out_alias,
-        out_alias_length,
-        out_actions_array_in_alias,
-        out_actions_array_in_alias_length,
-        &alias_type);
+            alias,
+            alias_length,
+            out_alias,
+            out_alias_length,
+            out_actions_array_in_alias,
+            out_actions_array_in_alias_length,
+            &alias_type);
     return res;
 }
 
@@ -128,9 +128,9 @@ int _check_double(const char* str, size_t len)
 }
 
 void _parse_primitive(
-    const char* action_value,
-    size_t action_value_length,
-    tio_action_t* out_action)
+        const char* action_value,
+        size_t action_value_length,
+        tio_action_t* out_action)
 {
     jkii_primitive_t jprim;
     jkii_parse_primitive(action_value, action_value_length, &jprim);
@@ -163,25 +163,25 @@ void _parse_primitive(
 }
 
 _cmd_parser_code_t _parse_action(
-    tio_handler_t* handler,
-    const char* alias,
-    size_t alias_length,
-    const char* actions_array_in_alias,
-    size_t actions_array_in_alias_length,
-    size_t action_index,
-    tio_action_t* out_action)
+        tio_handler_t* handler,
+        const char* alias,
+        size_t alias_length,
+        const char* actions_array_in_alias,
+        size_t actions_array_in_alias_length,
+        size_t action_index,
+        tio_action_t* out_action)
 {
     char* action_object = NULL;
     size_t action_object_length = 0;
     _cmd_parser_code_t res = _get_object_in_array(
-        handler->_kii._json_resource,
-        handler->_kii._cb_json_alloc,
-        handler->_kii._cb_json_free,
-        actions_array_in_alias,
-        actions_array_in_alias_length,
-        action_index,
-        &action_object,
-        &action_object_length);
+            handler->_kii._json_resource,
+            handler->_kii._cb_json_alloc,
+            handler->_kii._cb_json_free,
+            actions_array_in_alias,
+            actions_array_in_alias_length,
+            action_index,
+            &action_object,
+            &action_object_length);
     if (res != _CMD_PARSE_OK) {
         return res;
     }
@@ -191,13 +191,13 @@ _cmd_parser_code_t _parse_action(
     size_t action_value_length = 0;
     jsmntype_t action_type = JSMN_OBJECT;
     res = _parse_first_kv(
-        action_object,
-        action_object_length,
-        &action_name,
-        &action_name_length,
-        &action_value,
-        &action_value_length,
-        &action_type);
+            action_object,
+            action_object_length,
+            &action_name,
+            &action_name_length,
+            &action_value,
+            &action_value_length,
+            &action_type);
     if (res != _CMD_PARSE_OK) {
         return res;
     }
@@ -231,33 +231,33 @@ _cmd_parser_code_t _parse_action(
 }
 
 static tio_code_t _start_result_request(
-    tio_handler_t* handler,
-    const char* command_id)
+        tio_handler_t* handler,
+        const char* command_id)
 {
     // Start making command result request.
     char command_result_path[256];
     int path_len = snprintf(
-        command_result_path,
-        256,
-        "/thing-if/apps/%s/targets/thing:%s/commands/%s/action-results",
-        handler->_kii._app_id, handler->_kii._author.author_id, command_id);
+            command_result_path,
+            256,
+            "/thing-if/apps/%s/targets/thing:%s/commands/%s/action-results",
+            handler->_kii._app_id, handler->_kii._author.author_id, command_id);
     if (path_len >= 256) {
         return TIO_ERR_TOO_LARGE_DATA;
     }
     kii_code_t s_res = kii_api_call_start(
-        &handler->_kii,
-        "PUT",
-        command_result_path,
-        "application/json",
-        KII_TRUE);
+            &handler->_kii,
+            "PUT",
+            command_result_path,
+            "application/json",
+            KII_TRUE);
     if (s_res != KII_ERR_OK) {
         return _tio_convert_code(s_res);
     }
     const char result_start[] = "{\"actionResults\":[";
     kii_code_t a_res = kii_api_call_append_body(
-        &handler->_kii,
-        result_start,
-        strlen(result_start));
+            &handler->_kii,
+            result_start,
+            strlen(result_start));
     if (a_res != KII_ERR_OK) {
         return _tio_convert_code(s_res);
     }
@@ -265,13 +265,13 @@ static tio_code_t _start_result_request(
 }
 
 static tio_code_t _append_action_result(
-    tio_handler_t* handler,
-    size_t index,
-    tio_bool_t succeeded,
-    tio_action_t* action,
-    const char* err_message,
-    char* work_buff,
-    size_t work_buff_size)
+        tio_handler_t* handler,
+        size_t index,
+        tio_bool_t succeeded,
+        tio_action_t* action,
+        const char* err_message,
+        char* work_buff,
+        size_t work_buff_size)
 {
     char *comma = ",";
     if (index == 0)
@@ -284,9 +284,9 @@ static tio_code_t _append_action_result(
     if (succeeded == KII_TRUE)
     {
         int len = snprintf(
-            work_buff, work_buff_size,
-            "%s{\"%s\" : { \"succeeded\" : true }}",
-            comma, action_name);
+                work_buff, work_buff_size,
+                "%s{\"%s\" : { \"succeeded\" : true }}",
+                comma, action_name);
         if (len >= work_buff_size)
         {
             return TIO_ERR_TOO_LARGE_DATA;
@@ -315,9 +315,9 @@ static tio_code_t _append_action_result(
             err_part = temp_err;
         }
         int len = snprintf(
-            work_buff, work_buff_size,
-            "%s{\"%s\" : { \"succeeded\" : false %s}}",
-            comma, action_name, err_part);
+                work_buff, work_buff_size,
+                "%s{\"%s\" : { \"succeeded\" : false %s}}",
+                comma, action_name, err_part);
         if (len >= work_buff_size)
         {
             return TIO_ERR_TOO_LARGE_DATA;
@@ -338,9 +338,9 @@ static tio_code_t _append_action_result(
 //    {setTemp : {succeeded : false, message : "com err"}},
 // ]
 tio_code_t _handle_command(
-    tio_handler_t* handler,
-    const char* command,
-    size_t command_length)
+        tio_handler_t* handler,
+        const char* command,
+        size_t command_length)
 {
     jkii_field_t fields[3];
     char command_id[64];
@@ -375,38 +375,38 @@ tio_code_t _handle_command(
         char* alias = NULL;
         size_t alias_length = 0;
         _cmd_parser_code_t res = _parse_alias(
-            handler,
-            actions_array,
-            actions_array_length,
-            alias_idx,
-            &alias,
-            &alias_length,
-            &actions_array_in_alias,
-            &actions_array_in_alias_length
-        );
+                handler,
+                actions_array,
+                actions_array_length,
+                alias_idx,
+                &alias,
+                &alias_length,
+                &actions_array_in_alias,
+                &actions_array_in_alias_length
+                );
         if (res == _CMD_PARSE_OK) {
             for (size_t action_idx = 0; ; ++action_idx) {
                 _cmd_parser_code_t pa_res = _parse_action(
-                    handler,
-                    alias,
-                    alias_length,
-                    actions_array_in_alias,
-                    actions_array_in_alias_length,
-                    action_idx,
-                    &action);
+                        handler,
+                        alias,
+                        alias_length,
+                        actions_array_in_alias,
+                        actions_array_in_alias_length,
+                        action_idx,
+                        &action);
                 if (pa_res == _CMD_PARSE_OK) {
                     tio_action_err_t action_err;
                     action_err.err_message[0] = '\0';
                     tio_bool_t succeeded = handler->_cb_action(&action, &action_err, handler->_cb_action_data);
                     char work_buff[256];
                     tio_code_t app_res = _append_action_result(
-                        handler,
-                        result_counts,
-                        succeeded,
-                        &action,
-                        action_err.err_message,
-                        work_buff,
-                        sizeof(work_buff)/sizeof(work_buff[0]));
+                            handler,
+                            result_counts,
+                            succeeded,
+                            &action,
+                            action_err.err_message,
+                            work_buff,
+                            sizeof(work_buff)/sizeof(work_buff[0]));
                     if (app_res != TIO_ERR_OK) {
                         return app_res;
                     }
@@ -437,10 +437,10 @@ tio_code_t _handle_command(
 }
 
 jkii_parse_err_t _parse_json(
-    tio_handler_t* handler,
-    const char* json_string,
-    size_t json_string_size,
-    jkii_field_t* fields)
+        tio_handler_t* handler,
+        const char* json_string,
+        size_t json_string_size,
+        jkii_field_t* fields)
 {
     jkii_resource_t* resource = handler->_kii._json_resource;
     jkii_parse_err_t res = JKII_ERR_INVALID_INPUT;

--- a/tio/command_parser.h
+++ b/tio/command_parser.h
@@ -16,45 +16,45 @@ typedef enum _cmd_parser_code_t {
 } _cmd_parser_code_t;
 
 _cmd_parser_code_t _get_object_in_array(
-    jkii_resource_t* resource,
-    JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE cb_free,
-    const char* json_array,
-    size_t json_array_length,
-    size_t index,
-    char** out_object,
-    size_t* out_object_length);
+        jkii_resource_t* resource,
+        JKII_CB_RESOURCE_ALLOC cb_alloc,
+        JKII_CB_RESOURCE_FREE cb_free,
+        const char* json_array,
+        size_t json_array_length,
+        size_t index,
+        char** out_object,
+        size_t* out_object_length);
 
 // Parse first key and value in the object.
 // Command objects have only one key value.
 _cmd_parser_code_t _parse_first_kv(
-    const char* object,
-    size_t object_length,
-    char** out_key,
-    size_t* out_key_length,
-    char** out_value,
-    size_t* out_value_length,
-    jsmntype_t* out_value_type);
+        const char* object,
+        size_t object_length,
+        char** out_key,
+        size_t* out_key_length,
+        char** out_value,
+        size_t* out_value_length,
+        jsmntype_t* out_value_type);
 
 _cmd_parser_code_t _parse_action(
-    tio_handler_t* handler,
-    const char* alias,
-    size_t alias_length,
-    const char* actions_array_in_alias,
-    size_t actions_array_in_alias_length,
-    size_t action_index,
-    tio_action_t* out_action);
+        tio_handler_t* handler,
+        const char* alias,
+        size_t alias_length,
+        const char* actions_array_in_alias,
+        size_t actions_array_in_alias_length,
+        size_t action_index,
+        tio_action_t* out_action);
 
 tio_code_t _handle_command(
-    tio_handler_t* handler,
-    const char* command,
-    size_t command_length);
+        tio_handler_t* handler,
+        const char* command,
+        size_t command_length);
 
 jkii_parse_err_t _parse_json(
-    tio_handler_t* handler,
-    const char* json_string,
-    size_t json_string_size,
-    jkii_field_t* fields);
+        tio_handler_t* handler,
+        const char* json_string,
+        size_t json_string_size,
+        jkii_field_t* fields);
 
 #ifdef __cplusplus
 }

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -567,9 +567,9 @@ void tio_handler_set_json_parser_resource(tio_handler_t* handler, jkii_resource_
  * \param [in] cb_free free callback.
  */
 void tio_handler_set_cb_json_parser_resource(
-    tio_handler_t* handler,
-    JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE cb_free);
+        tio_handler_t* handler,
+        JKII_CB_RESOURCE_ALLOC cb_alloc,
+        JKII_CB_RESOURCE_FREE cb_free);
 
 /**
  * \brief Set custom memory allocator for the linked list used to constuct request headers of HTTP.
@@ -583,11 +583,11 @@ void tio_handler_set_cb_json_parser_resource(
  * \param [in] cb_free_data Context object pointer passed to cb_free.
  */
 void tio_handler_set_cb_slist_resource(
-    tio_handler_t* handler,
-    KHC_CB_SLIST_ALLOC cb_alloc,
-    KHC_CB_SLIST_FREE cb_free,
-    void* cb_alloc_data,
-    void* cb_free_data
+        tio_handler_t* handler,
+        KHC_CB_SLIST_ALLOC cb_alloc,
+        KHC_CB_SLIST_FREE cb_free,
+        void* cb_alloc_data,
+        void* cb_free_data
 );
 
 /**
@@ -610,13 +610,13 @@ void tio_handler_set_cb_slist_resource(
  * Can be NULL if you don't need them.
  */
 tio_code_t tio_handler_onboard(
-    tio_handler_t* handler,
-    const char* vendor_thing_id,
-    const char* password,
-    const char* thing_type,
-    const char* firmware_version,
-    const char* layout_position,
-    const char* thing_properties
+        tio_handler_t* handler,
+        const char* vendor_thing_id,
+        const char* password,
+        const char* thing_type,
+        const char* firmware_version,
+        const char* layout_position,
+        const char* thing_properties
 );
 
 /**
@@ -630,7 +630,7 @@ tio_code_t tio_handler_onboard(
  * You may need to copy the value of device ID and access token and store them.
  */
 const tio_author_t* tio_handler_get_author(
-    tio_handler_t* handler
+        tio_handler_t* handler
 );
 
 /**
@@ -646,10 +646,10 @@ const tio_author_t* tio_handler_get_author(
  * \param [in] userdata Context object pointer passed to cb_action.
  */
 tio_code_t tio_handler_start(
-    tio_handler_t* handler,
-    const tio_author_t* author,
-    TIO_CB_ACTION cb_action,
-    void* userdata);
+        tio_handler_t* handler,
+        const tio_author_t* author,
+        TIO_CB_ACTION cb_action,
+        void* userdata);
 
 /**
  * \brief tio_updater_t initializer.
@@ -853,9 +853,9 @@ void tio_updater_set_interval(tio_updater_t* updater, size_t update_interval_sec
 void tio_updater_set_json_parser_resource(tio_updater_t* updater, jkii_resource_t* resource);
 
 void tio_updater_set_cb_json_parser_resource(
-    tio_updater_t* updater,
-    JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE cb_free);
+        tio_updater_t* updater,
+        JKII_CB_RESOURCE_ALLOC cb_alloc,
+        JKII_CB_RESOURCE_FREE cb_free);
 
 /**
  * \brief Set custom memory allocator for the linked list used to constuct request headers of HTTP.
@@ -869,11 +869,11 @@ void tio_updater_set_cb_json_parser_resource(
  * \param [in] cb_free_data Context object pointer passed to cb_free.
  */
 void tio_updater_set_cb_slist_resource(
-    tio_updater_t* updater,
-    KHC_CB_SLIST_ALLOC cb_alloc,
-    KHC_CB_SLIST_FREE cb_free,
-    void* cb_alloc_data,
-    void* cb_free_data
+        tio_updater_t* updater,
+        KHC_CB_SLIST_ALLOC cb_alloc,
+        KHC_CB_SLIST_FREE cb_free,
+        void* cb_alloc_data,
+        void* cb_free_data
 );
 
 /**
@@ -896,13 +896,13 @@ void tio_updater_set_cb_slist_resource(
  * Can be NULL if you don't need them.
  */
 tio_code_t tio_updater_onboard(
-    tio_updater_t* updater,
-    const char* vendor_thing_id,
-    const char* password,
-    const char* thing_type,
-    const char* firmware_version,
-    const char* layout_position,
-    const char* thing_properties
+        tio_updater_t* updater,
+        const char* vendor_thing_id,
+        const char* password,
+        const char* thing_type,
+        const char* firmware_version,
+        const char* layout_position,
+        const char* thing_properties
 );
 
 /**
@@ -916,7 +916,7 @@ tio_code_t tio_updater_onboard(
  * You may need to copy the value of device ID and access token and store them.
  */
 const tio_author_t* tio_updater_get_author(
-    tio_updater_t* updater
+        tio_updater_t* updater
 );
 
 /**
@@ -935,12 +935,12 @@ const tio_author_t* tio_updater_get_author(
  * \return TIO_ERR_OK when succeeded to start task.
  */
 tio_code_t tio_updater_start(
-    tio_updater_t* updater,
-    const tio_author_t* author,
-    TIO_CB_SIZE cb_state_size,
-    void* state_size_data,
-    TIO_CB_READ cb_read_state,
-    void* read_state_data);
+        tio_updater_t* updater,
+        const tio_author_t* author,
+        TIO_CB_SIZE cb_state_size,
+        void* state_size_data,
+        TIO_CB_READ cb_read_state,
+        void* read_state_data);
 
 #ifdef __cplusplus
 }

--- a/tio/linux-sample/linux-env/task_impl.c
+++ b/tio/linux-sample/linux-env/task_impl.c
@@ -2,11 +2,11 @@
 #include <pthread.h>
 #include <unistd.h>
 
-kii_task_code_t task_create_cb
-    (const char* name,
-     KII_TASK_ENTRY entry,
-     void* param,
-     void* userdata)
+kii_task_code_t task_create_cb(
+        const char* name,
+        KII_TASK_ENTRY entry,
+        void* param,
+        void* userdata)
 {
     int ret;
     pthread_t pthid;

--- a/tio/linux-sample/sock_cb_linux.h
+++ b/tio/linux-sample/sock_cb_linux.h
@@ -28,7 +28,7 @@ khc_sock_code_t
 
 khc_sock_code_t
     sock_cb_recv(void* sock_ctx, char* buffer, size_t length_to_read,
-     size_t* out_actual_length);
+            size_t* out_actual_length);
 
 khc_sock_code_t
     sock_cb_close(void* sock_context);

--- a/tio/linux-sample/sys_cb_linux.c
+++ b/tio/linux-sample/sys_cb_linux.c
@@ -10,10 +10,10 @@ void delay_ms_cb_impl(unsigned int msec, void* userdata)
 }
 
 kii_task_code_t task_create_cb_impl(
-    const char* name,
-    KII_TASK_ENTRY entry,
-    void* param,
-    void* userdata)
+        const char* name,
+        KII_TASK_ENTRY entry,
+        void* param,
+        void* userdata)
 {
     return task_create_cb(name, entry, param, userdata);
 }

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -54,41 +54,41 @@ void tio_handler_init(tio_handler_t* handler)
 }
 
 void tio_handler_set_cb_sock_connect_http(
-    tio_handler_t* handler,
-    KHC_CB_SOCK_CONNECT cb_connect,
-    void* userdata)
+        tio_handler_t* handler,
+        KHC_CB_SOCK_CONNECT cb_connect,
+        void* userdata)
 {
     kii_set_cb_http_sock_connect(&handler->_kii, cb_connect, userdata);
 }
 
 void tio_handler_set_cb_sock_send_http(
-    tio_handler_t* handler,
-    KHC_CB_SOCK_SEND cb_send,
-    void* userdata)
+        tio_handler_t* handler,
+        KHC_CB_SOCK_SEND cb_send,
+        void* userdata)
 {
     kii_set_cb_http_sock_send(&handler->_kii, cb_send, userdata);
 }
 
 void tio_handler_set_cb_sock_recv_http(
-    tio_handler_t* handler,
-    KHC_CB_SOCK_RECV cb_recv,
-    void* userdata)
+        tio_handler_t* handler,
+        KHC_CB_SOCK_RECV cb_recv,
+        void* userdata)
 {
     kii_set_cb_http_sock_recv(&handler->_kii, cb_recv, userdata);
 }
 
 void tio_handler_set_cb_sock_close_http(
-    tio_handler_t* handler,
-    KHC_CB_SOCK_CLOSE cb_close,
-    void* userdata)
+        tio_handler_t* handler,
+        KHC_CB_SOCK_CLOSE cb_close,
+        void* userdata)
 {
     kii_set_cb_http_sock_close(&handler->_kii, cb_close, userdata);
 }
 
 void tio_handler_set_http_buff(
-    tio_handler_t* handler,
-    char* buff,
-    size_t buff_size)
+        tio_handler_t* handler,
+        char* buff,
+        size_t buff_size)
 {
     kii_set_buff(&handler->_kii, buff, buff_size);
 }
@@ -102,33 +102,33 @@ void tio_handler_set_resp_header_buff(tio_handler_t* handler, char* buff, size_t
 }
 
 void tio_handler_set_cb_sock_connect_mqtt(
-    tio_handler_t* handler,
-    KHC_CB_SOCK_CONNECT cb_connect,
-    void* userdata)
+        tio_handler_t* handler,
+        KHC_CB_SOCK_CONNECT cb_connect,
+        void* userdata)
 {
     kii_set_cb_mqtt_sock_connect(&handler->_kii, cb_connect, userdata);
 }
 
 void tio_handler_set_cb_sock_send_mqtt(
-    tio_handler_t* handler,
-    KHC_CB_SOCK_SEND cb_send,
-    void* userdata)
+        tio_handler_t* handler,
+        KHC_CB_SOCK_SEND cb_send,
+        void* userdata)
 {
     kii_set_cb_mqtt_sock_send(&handler->_kii, cb_send, userdata);
 }
 
 void tio_handler_set_cb_sock_recv_mqtt(
-    tio_handler_t* handler,
-    KHC_CB_SOCK_RECV cb_recv,
-    void* userdata)
+        tio_handler_t* handler,
+        KHC_CB_SOCK_RECV cb_recv,
+        void* userdata)
 {
     kii_set_cb_mqtt_sock_recv(&handler->_kii, cb_recv, userdata);
 }
 
 void tio_handler_set_cb_sock_close_mqtt(
-    tio_handler_t* handler,
-    KHC_CB_SOCK_CLOSE cb_close,
-    void* userdata)
+        tio_handler_t* handler,
+        KHC_CB_SOCK_CLOSE cb_close,
+        void* userdata)
 {
     kii_set_cb_mqtt_sock_close(&handler->_kii, cb_close, userdata);
 }
@@ -144,9 +144,9 @@ void tio_handler_set_mqtt_to_sock_send(tio_handler_t* handler, unsigned int to_s
 }
 
 void tio_handler_set_cb_task_create(
-    tio_handler_t* handler,
-    KII_CB_TASK_CREATE cb_task_create,
-    void* userdata)
+        tio_handler_t* handler,
+        KII_CB_TASK_CREATE cb_task_create,
+        void* userdata)
 {
     kii_set_cb_task_create(&handler->_kii, cb_task_create, userdata);
 }
@@ -164,50 +164,50 @@ void tio_handler_set_cb_task_exit(tio_handler_t* handler, KII_CB_TASK_EXIT cb_ex
 }
 
 void tio_handler_set_cb_delay_ms(
-    tio_handler_t* handler,
-    KII_CB_DELAY_MS cb_delay_ms,
-    void* userdata)
+        tio_handler_t* handler,
+        KII_CB_DELAY_MS cb_delay_ms,
+        void* userdata)
 {
     kii_set_cb_delay_ms(&handler->_kii, cb_delay_ms, userdata);
 }
 
 void tio_handler_set_cb_err(
-    tio_handler_t* handler,
-    TIO_CB_ERR cb_err,
-    void* userdata)
+        tio_handler_t* handler,
+        TIO_CB_ERR cb_err,
+        void* userdata)
 {
     handler->_cb_err = cb_err;
     handler->_cb_err_data = userdata;
 }
 
 void tio_handler_set_cb_push(
-    tio_handler_t* handler,
-    TIO_CB_PUSH cb_push,
-    void* userdata)
+        tio_handler_t* handler,
+        TIO_CB_PUSH cb_push,
+        void* userdata)
 {
     handler->_cb_push = cb_push;
     handler->_cb_push_data = userdata;
 }
 
 void tio_handler_set_mqtt_buff(
-    tio_handler_t* handler,
-    char* buff,
-    size_t buff_size)
+        tio_handler_t* handler,
+        char* buff,
+        size_t buff_size)
 {
     kii_set_mqtt_buff(&handler->_kii, buff, buff_size);
 }
 
 void tio_handler_set_keep_alive_interval(
-    tio_handler_t* handler,
-    size_t keep_alive_interval)
+        tio_handler_t* handler,
+        size_t keep_alive_interval)
 {
     handler->_keep_alive_interval = keep_alive_interval;
 }
 
 void tio_handler_set_app(
-    tio_handler_t* handler,
-    const char* app_id,
-    const char* host)
+        tio_handler_t* handler,
+        const char* app_id,
+        const char* host)
 {
     kii_set_site(&handler->_kii, host);
     kii_set_app_id(&handler->_kii, app_id);
@@ -228,48 +228,48 @@ static void _cb_receive_push(const char* payload, size_t payload_length, void* u
 }
 
 void tio_handler_set_json_parser_resource(
-    tio_handler_t* handler,
-    jkii_resource_t* resource)
+        tio_handler_t* handler,
+        jkii_resource_t* resource)
 {
     kii_set_json_parser_resource(&handler->_kii, resource);
 }
 
 void tio_handler_set_cb_json_parser_resource(
-    tio_handler_t* handler,
-    JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE cb_free)
+        tio_handler_t* handler,
+        JKII_CB_RESOURCE_ALLOC cb_alloc,
+        JKII_CB_RESOURCE_FREE cb_free)
 {
     kii_set_cb_json_parser_resource(&handler->_kii, cb_alloc, cb_free);
 }
 
 void tio_handler_set_cb_slist_resource(
-    tio_handler_t* handler,
-    KHC_CB_SLIST_ALLOC cb_alloc,
-    KHC_CB_SLIST_FREE cb_free,
-    void* cb_alloc_data,
-    void* cb_free_data)
+        tio_handler_t* handler,
+        KHC_CB_SLIST_ALLOC cb_alloc,
+        KHC_CB_SLIST_FREE cb_free,
+        void* cb_alloc_data,
+        void* cb_free_data)
 {
     kii_set_cb_slist_resource(&handler->_kii, cb_alloc, cb_free, cb_alloc_data, cb_free_data);
 }
 
 tio_code_t tio_handler_onboard(
-    tio_handler_t* handler,
-    const char* vendor_thing_id,
-    const char* password,
-    const char* thing_type,
-    const char* firmware_version,
-    const char* layout_position,
-    const char* thing_properties)
+        tio_handler_t* handler,
+        const char* vendor_thing_id,
+        const char* password,
+        const char* thing_type,
+        const char* firmware_version,
+        const char* layout_position,
+        const char* thing_properties)
 {
     kii_code_t ret =kii_ti_onboard(
-        &handler->_kii,
-        vendor_thing_id,
-        password,
-        thing_type,
-        firmware_version,
-        layout_position,
-        thing_properties
-    );
+            &handler->_kii,
+            vendor_thing_id,
+            password,
+            thing_type,
+            firmware_version,
+            layout_position,
+            thing_properties
+            );
     return _tio_convert_code(ret);
 }
 
@@ -279,20 +279,20 @@ const tio_author_t* tio_handler_get_author(tio_handler_t* handler)
 }
 
 tio_code_t tio_handler_start(
-    tio_handler_t* handler,
-    const tio_author_t* author,
-    TIO_CB_ACTION cb_action,
-    void* userdata)
+        tio_handler_t* handler,
+        const tio_author_t* author,
+        TIO_CB_ACTION cb_action,
+        void* userdata)
 {
     handler->_kii._author = *author;
 
     handler->_cb_action = cb_action;
     handler->_cb_action_data = userdata;
     kii_code_t res = kii_start_push_task(
-        &handler->_kii,
-        handler->_keep_alive_interval,
-        _cb_receive_push,
-        (void*)handler);
+            &handler->_kii,
+            handler->_keep_alive_interval,
+            _cb_receive_push,
+            (void*)handler);
     return _tio_convert_code(res);
 }
 
@@ -313,41 +313,41 @@ void tio_updater_init(tio_updater_t* updater)
 }
 
 void tio_updater_set_cb_sock_connect(
-    tio_updater_t* updater,
-    KHC_CB_SOCK_CONNECT cb_connect,
-    void* userdata)
+        tio_updater_t* updater,
+        KHC_CB_SOCK_CONNECT cb_connect,
+        void* userdata)
 {
     kii_set_cb_http_sock_connect(&updater->_kii, cb_connect, userdata);
 }
 
 void tio_updater_set_cb_sock_send(
-    tio_updater_t* updater,
-    KHC_CB_SOCK_SEND cb_send,
-    void* userdata)
+        tio_updater_t* updater,
+        KHC_CB_SOCK_SEND cb_send,
+        void* userdata)
 {
     kii_set_cb_http_sock_send(&updater->_kii, cb_send, userdata);
 }
 
 void tio_updater_set_cb_sock_recv(
-    tio_updater_t* updater,
-    KHC_CB_SOCK_RECV cb_recv,
-    void* userdata)
+        tio_updater_t* updater,
+        KHC_CB_SOCK_RECV cb_recv,
+        void* userdata)
 {
     kii_set_cb_http_sock_recv(&updater->_kii, cb_recv, userdata);
 }
 
 void tio_updater_set_cb_sock_close(
-    tio_updater_t* updater,
-    KHC_CB_SOCK_CLOSE cb_close,
-    void* userdata)
+        tio_updater_t* updater,
+        KHC_CB_SOCK_CLOSE cb_close,
+        void* userdata)
 {
     kii_set_cb_http_sock_close(&updater->_kii, cb_close, userdata);
 }
 
 void tio_updater_set_cb_task_create(
-    tio_updater_t* updater,
-    KII_CB_TASK_CREATE cb_task_create,
-    void* userdata)
+        tio_updater_t* updater,
+        KII_CB_TASK_CREATE cb_task_create,
+        void* userdata)
 {
     kii_set_cb_task_create(&updater->_kii, cb_task_create, userdata);
 }
@@ -365,26 +365,26 @@ void tio_updater_set_cb_task_exit(tio_updater_t* updater, KII_CB_TASK_EXIT cb_ex
 }
 
 void tio_updater_set_cb_delay_ms(
-    tio_updater_t* updater,
-    KII_CB_DELAY_MS cb_delay_ms,
-    void* userdata)
+        tio_updater_t* updater,
+        KII_CB_DELAY_MS cb_delay_ms,
+        void* userdata)
 {
     kii_set_cb_delay_ms(&updater->_kii, cb_delay_ms, userdata);
 }
 
 void tio_updater_set_cb_error(
-    tio_updater_t* updater,
-    TIO_CB_ERR cb_err,
-    void* userdata)
+        tio_updater_t* updater,
+        TIO_CB_ERR cb_err,
+        void* userdata)
 {
     updater->_cb_err = cb_err;
     updater->_cb_err_data = userdata;
 }
 
 void tio_updater_set_buff(
-    tio_updater_t* updater,
-    char* buff,
-    size_t buff_size)
+        tio_updater_t* updater,
+        char* buff,
+        size_t buff_size)
 {
     kii_set_buff(&updater->_kii, buff, buff_size);
 }
@@ -398,17 +398,17 @@ void tio_updater_set_resp_header_buff(tio_updater_t* updater, char* buff, size_t
 }
 
 void tio_updater_set_app(
-    tio_updater_t* updater,
-    const char* app_id,
-    const char* host)
+        tio_updater_t* updater,
+        const char* app_id,
+        const char* host)
 {
     kii_set_site(&updater->_kii, host);
     kii_set_app_id(&updater->_kii, app_id);
 }
 
 void tio_updater_set_interval(
-    tio_updater_t* updater,
-    size_t update_interval)
+        tio_updater_t* updater,
+        size_t update_interval)
 {
     updater->_update_interval = update_interval;
 }
@@ -434,12 +434,12 @@ static void* _update_state(void* data) {
             size_t state_size = updater->_cb_state_size(updater->_cb_state_size_data);
             if (state_size > 0) {
                 kii_code_t res = kii_ti_put_state(
-                    &updater->_kii,
-                    updater->_state_reader,
-                    updater->_state_reader_data,
-                    NULL,
-                    NULL,
-                    NULL);
+                        &updater->_kii,
+                        updater->_state_reader,
+                        updater->_state_reader_data,
+                        NULL,
+                        NULL,
+                        NULL);
                 if (res != KII_ERR_OK) {
                     tio_code_t code = _tio_convert_code(res);
                     if (updater->_cb_err != NULL) {
@@ -458,64 +458,64 @@ static void* _update_state(void* data) {
 }
 
 void tio_updater_set_json_parser_resource(
-    tio_updater_t* updater,
-    jkii_resource_t* resource)
+        tio_updater_t* updater,
+        jkii_resource_t* resource)
 {
     kii_set_json_parser_resource(&updater->_kii, resource);
 }
 
 void tio_updater_set_cb_json_parser_resource(
-    tio_updater_t* updater,
-    JKII_CB_RESOURCE_ALLOC cb_alloc,
-    JKII_CB_RESOURCE_FREE cb_free)
+        tio_updater_t* updater,
+        JKII_CB_RESOURCE_ALLOC cb_alloc,
+        JKII_CB_RESOURCE_FREE cb_free)
 {
     kii_set_cb_json_parser_resource(&updater->_kii, cb_alloc, cb_free);
 }
 
 void tio_updater_set_cb_slist_resource(
-    tio_updater_t* updater,
-    KHC_CB_SLIST_ALLOC cb_alloc,
-    KHC_CB_SLIST_FREE cb_free,
-    void* cb_alloc_data,
-    void* cb_free_data)
+        tio_updater_t* updater,
+        KHC_CB_SLIST_ALLOC cb_alloc,
+        KHC_CB_SLIST_FREE cb_free,
+        void* cb_alloc_data,
+        void* cb_free_data)
 {
     kii_set_cb_slist_resource(&updater->_kii, cb_alloc, cb_free, cb_alloc_data, cb_free_data);
 }
 
 tio_code_t tio_updater_onboard(
-    tio_updater_t* updater,
-    const char* vendor_thing_id,
-    const char* password,
-    const char* thing_type,
-    const char* firmware_version,
-    const char* layout_position,
-    const char* thing_properties)
+        tio_updater_t* updater,
+        const char* vendor_thing_id,
+        const char* password,
+        const char* thing_type,
+        const char* firmware_version,
+        const char* layout_position,
+        const char* thing_properties)
 {
     kii_code_t ret =kii_ti_onboard(
-        &updater->_kii,
-        vendor_thing_id,
-        password,
-        thing_type,
-        firmware_version,
-        layout_position,
-        thing_properties
-    );
+            &updater->_kii,
+            vendor_thing_id,
+            password,
+            thing_type,
+            firmware_version,
+            layout_position,
+            thing_properties
+            );
     return _tio_convert_code(ret);
 }
 
 const tio_author_t* tio_updater_get_author(
-    tio_updater_t* updater)
+        tio_updater_t* updater)
 {
     return &updater->_kii._author;
 }
 
 tio_code_t tio_updater_start(
-    tio_updater_t* updater,
-    const tio_author_t* author,
-    TIO_CB_SIZE cb_state_size,
-    void* cb_state_size_data,
-    TIO_CB_READ state_reader,
-    void* state_reader_data)
+        tio_updater_t* updater,
+        const tio_author_t* author,
+        TIO_CB_SIZE cb_state_size,
+        void* cb_state_size_data,
+        TIO_CB_READ state_reader,
+        void* state_reader_data)
 {
     updater->_kii._author = *author;
 
@@ -526,10 +526,10 @@ tio_code_t tio_updater_start(
     updater->_state_reader_data = state_reader_data;
 
     kii_task_code_t res = updater->_kii._cb_task_create(
-        TIO_TASK_NAME_UPDATE_STATE,
-        _update_state,
-        (void*)updater,
-        updater->_kii._task_create_data);
+            TIO_TASK_NAME_UPDATE_STATE,
+            _update_state,
+            (void*)updater,
+            updater->_kii._task_create_data);
 
     if (res != KII_TASKC_OK) {
         return TIO_ERR_CREATE_TASK;


### PR DESCRIPTION
インデントを修正しました。

インデントの補正は全てvimの `==` コマンドで行っています。
`tests/picojson.h` は配布のものと思われるので除外しています。
スペース以外の変更は `tio/linux-sample/linux-env/task_impl.c` のみです。

Issue: #94 