### PR TITLE
add ssl codes.

### DIFF
--- a/tio/cc3200-sample/ebisu_cc3200.c
+++ b/tio/cc3200-sample/ebisu_cc3200.c
@@ -45,45 +45,28 @@ khc_sock_code_t sock_cb_connect(
         return KHC_SOCK_FAIL;
     }
 #if CONNECT_SSL
-#if 1
     char method = SL_SO_SEC_METHOD_TLSV1_2;
     if (sl_SetSockOpt(sock, SL_SOL_SOCKET, SL_SO_SECMETHOD, &method, sizeof(method)) < 0) {
     	return KHC_SOCK_FAIL;
     }
 
-    long cipher = SL_SEC_MASK_SECURE_DEFAULT;
+    long cipher = SL_SEC_MASK_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256;
     if (sl_SetSockOpt(sock, SL_SOL_SOCKET, SL_SO_SECURE_MASK, &cipher,  sizeof(cipher)) < 0) {
     	return KHC_SOCK_FAIL;
     }
-#endif
-#if 1
     if (sl_SetSockOpt(sock, SL_SOL_SOCKET,
     		SL_SO_SECURE_FILES_CA_FILE_NAME,
 			SL_SSL_CA_CERT_FILE_NAME,
 			strlen(SL_SSL_CA_CERT_FILE_NAME)) < 0) {
         return KHC_SOCK_FAIL;
     }
-#else
-    SlSockSecureFiles_t files;
-    files.secureFiles[0] = 0;
-    files.secureFiles[1] = 0;
-    files.secureFiles[2] = 129;
-    files.secureFiles[3] = 0;
-    if (sl_SetSockOpt(sock, SL_SOL_SOCKET,
-    		SL_SO_SECURE_FILES,
-			&files,
-			sizeof(SlSockSecureFiles_t)) < 0) {
-        return KHC_SOCK_FAIL;
-    }
-#endif
-#if 0
+
     if (sl_SetSockOpt(sock, SL_SOL_SOCKET,
     		SO_SECURE_DOMAIN_NAME_VERIFICATION,
 			host,
 			strlen(host)) < 0) {
         return KHC_SOCK_FAIL;
     }
-#endif
 #endif
     int r = sl_Connect(sock, ( SlSockAddr_t *)&addr, sizeof(struct SlSockAddrIn_t));
     ASSERT_ON_ERROR(r);

--- a/tio/cc3200-sample/ebisu_cc3200.h
+++ b/tio/cc3200-sample/ebisu_cc3200.h
@@ -11,6 +11,8 @@
 #include "khc_socket_callback.h"
 #include "kii_task_callback.h"
 
+#define CONNECT_SSL 0
+
 typedef struct socket_context_t {
     int sock;
     unsigned int to_recv;

--- a/tio/cc3200-sample/ebisu_cc3200.h
+++ b/tio/cc3200-sample/ebisu_cc3200.h
@@ -11,7 +11,7 @@
 #include "khc_socket_callback.h"
 #include "kii_task_callback.h"
 
-#define CONNECT_SSL 0
+#define CONNECT_SSL 1
 
 typedef struct socket_context_t {
     int sock;

--- a/tio/cc3200-sample/main.c
+++ b/tio/cc3200-sample/main.c
@@ -683,10 +683,13 @@ void handler_init(
 
     tio_handler_set_http_buff(handler, http_buffer, http_buffer_size);
     tio_handler_set_mqtt_buff(handler, mqtt_buffer, mqtt_buffer_size);
-
+#if CONNECT_SSL
+    tio_handler_enable_insecure_http(handler, KII_FALSE);
+    tio_handler_enable_insecure_mqtt(handler, KII_FALSE);
+#else
     tio_handler_enable_insecure_http(handler, KII_TRUE);
     tio_handler_enable_insecure_mqtt(handler, KII_TRUE);
-
+#endif
     tio_handler_set_keep_alive_interval(handler, HANDLER_KEEP_ALIVE_SEC);
 
     tio_handler_set_json_parser_resource(handler, resource);


### PR DESCRIPTION
CC3200でSSLソケットを使用できるように修正しました。レビューをお願いします。
デフォルト設定ではSSLを使用しないようにしています。(CONNECT_SSLを1に設定で使用)

Issue: #114 

## Environment:
- CC3200 SDK version: 1.3.0
- Service Pack version: 1.0.1.13-2.11.0.1

## SSL/TSL設定
- Protocol: TLS1.2
- Cipher method: ECDHE_RSA_WITH_AES_128_CBC_SHA256

上記Protocol/ Cipherがサポートされていることは以下で確認
https://www.ssllabs.com/ssltest/analyze.html?d=api-jp.kii.com&hideResults=on&latest

- 接続先: api-jp.kii.com
- CA Root Certificate: Go daddyのRoot CAをFirefoxでdeveloper.kii.comから取得(der)
- Host Name Verification: 以下のコードで設定。host: api-jp.kii.com

```c
    if (sl_SetSockOpt(sock, SL_SOL_SOCKET,
    		SO_SECURE_DOMAIN_NAME_VERIFICATION,
			host,
			strlen(host)) < 0)
```

## 結果

- sl_Connect() で -155 (SL_ESEC_ASN_SIG_CONFIRM_E) が返却される

## 考察

GoDaddyのroot caをFireFoxでdownload(PEM形式)し curlで実行するとsubjectAltNameがverifyされていることがわかる。

`subjectAltName: host "api-jp.kii.com" matched cert's "*.kii.com"`

```
curl -v --cacert /Users/satoshi/Desktop/api-jp.crt --ciphers ECDHE-RSA-AES128-SHA256 'https://api-jp.kii.com/api'
*   Trying 46.51.242.243...
* TCP_NODELAY set
* Connected to api-jp.kii.com (46.51.242.243) port 443 (#0)
* ALPN, offering http/1.1
* Cipher selection: ECDHE-RSA-AES128-SHA256
* successfully set certificate verify locations:
*   CAfile: /Users/satoshi/Desktop/api-jp.crt
  CApath: none
* TLSv1.2 (OUT), TLS header, Certificate Status (22):
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-SHA256
* ALPN, server did not agree to a protocol
* Server certificate:
*  subject: OU=Domain Control Validated; CN=*.kii.com
*  start date: Sep  3 17:36:38 2016 GMT
*  expire date: Oct  4 03:54:51 2019 GMT
*  subjectAltName: host "api-jp.kii.com" matched cert's "*.kii.com"
*  issuer: C=US; ST=Arizona; L=Scottsdale; O=GoDaddy.com, Inc.; OU=http://certs.godaddy.com/repository/; CN=Go Daddy Secure Certificate Authority - G2
*  SSL certificate verify ok.
```

SimpleLinkのSSL/TLSライブラリがsubjectAltNameをverifyできない可能性がある。

[TIのマニュアル](http://www.ti.com/lit/ug/swru368b/swru368b.pdf) では `Set Domain Name for Verification and SNI` のセクションがあるが `subjectAltName` については記述がない。