### PR TITLE
Impl action result data

### DIFF
--- a/jkii/include/jkii_utils.h
+++ b/jkii/include/jkii_utils.h
@@ -32,6 +32,17 @@ jkii_primitive_err_t jkii_parse_primitive(
 
 int jkii_escape_str(const char* str, char* buff, size_t buff_size);
 
+jkii_parse_err_t jkii_validate_root_object(
+        const char* json_string,
+        size_t json_string_len,
+        jkii_resource_t* resource);
+
+jkii_parse_err_t jkii_validate_root_object_with_allocator(
+        const char* json_string,
+        size_t json_string_len,
+        JKII_CB_RESOURCE_ALLOC cb_alloc,
+        JKII_CB_RESOURCE_FREE cb_free);
+
 #ifdef __cplusplus
 }
 #endif

--- a/jkii/src/jkii.c
+++ b/jkii/src/jkii.c
@@ -879,7 +879,9 @@ jkii_parse_err_t jkii_parse(
     if (type != JSMN_ARRAY && type != JSMN_OBJECT) {
         return JKII_ERR_INVALID_INPUT;
     }
-    res = _jkii_parse_fields(json_string, json_string_len, fields, resource);
+    if (fields != NULL) {
+        res = _jkii_parse_fields(json_string, json_string_len, fields, resource);
+    }
 
     return res;
 }
@@ -919,7 +921,9 @@ jkii_parse_err_t jkii_parse_with_allocator(
         cb_free(resource);
         return JKII_ERR_INVALID_INPUT;
     }
-    res = _jkii_parse_fields(json_string, json_string_len, fields, resource);
+    if (fields != NULL) {
+        res = _jkii_parse_fields(json_string, json_string_len, fields, resource);
+    }
 
     cb_free(resource);
     return res;

--- a/tio/cc3200-sample/main.c
+++ b/tio/cc3200-sample/main.c
@@ -692,7 +692,7 @@ void handler_init(
     tio_handler_set_json_parser_resource(handler, resource);
 }
 
-tio_bool_t tio_action_handler(tio_action_t* action, tio_action_err_t* err, void* userdata)
+tio_bool_t tio_action_handler(tio_action_t* action, tio_action_err_t* err, tio_action_result_data_t* data, void* userdata)
 {
     UART_PRINT("tio_action_handler called\n");
     UART_PRINT("%.*s: %.*s\n", (int)action->alias_length, action->alias,(int)action->action_name_length, action->action_name);

--- a/tio/command_parser.c
+++ b/tio/command_parser.c
@@ -291,10 +291,10 @@ static tio_code_t _append_action_result(
         char* work_buff,
         size_t work_buff_size)
 {
-    int json_len = strlen(json_data);
-    if (json_len > 0) {
+    int json_data_len = strlen(json_data);
+    if (json_data_len > 0) {
         // Validate json_data.
-        jkii_parse_err_t json_res = _validate_json(handler, json_data, json_len);
+        jkii_parse_err_t json_res = _validate_json(handler, json_data, json_data_len);
         if (json_res != JKII_ERR_OK) {
             return TIO_ERR_PARSE_JSON;
         }
@@ -318,8 +318,8 @@ static tio_code_t _append_action_result(
         {
             return TIO_ERR_TOO_LARGE_DATA;
         }
-        if (json_len > 0) {
-            len += json_len + 8;
+        if (json_data_len > 0) {
+            len += json_data_len + 8;
             if (len >= work_buff_size)
             {
                 return TIO_ERR_TOO_LARGE_DATA;
@@ -360,8 +360,8 @@ static tio_code_t _append_action_result(
         {
             return TIO_ERR_TOO_LARGE_DATA;
         }
-        if (json_len > 0) {
-            len += json_len + 8;
+        if (json_data_len > 0) {
+            len += json_data_len + 8;
             if (len >= work_buff_size)
             {
                 return TIO_ERR_TOO_LARGE_DATA;

--- a/tio/command_parser.c
+++ b/tio/command_parser.c
@@ -274,6 +274,14 @@ static tio_code_t _append_action_result(
         char* work_buff,
         size_t work_buff_size)
 {
+    int json_len = strlen(json_data);
+    if (json_len > 0) {
+        // Validate json_data.
+        jkii_parse_err_t json_res = _parse_json(handler, json_data, json_len, NULL);
+        if (json_res != JKII_ERR_OK) {
+            return TIO_ERR_PARSE_JSON;
+        }
+    }
     char *comma = ",";
     if (index == 0)
     {
@@ -293,8 +301,8 @@ static tio_code_t _append_action_result(
         {
             return TIO_ERR_TOO_LARGE_DATA;
         }
-        if (json_data != NULL) {
-            len += strlen(json_data) + 8;
+        if (json_len > 0) {
+            len += json_len + 8;
             if (len >= work_buff_size)
             {
                 return TIO_ERR_TOO_LARGE_DATA;
@@ -335,8 +343,8 @@ static tio_code_t _append_action_result(
         {
             return TIO_ERR_TOO_LARGE_DATA;
         }
-        if (json_data != NULL) {
-            len += strlen(json_data) + 8;
+        if (json_len > 0) {
+            len += json_len + 8;
             if (len >= work_buff_size)
             {
                 return TIO_ERR_TOO_LARGE_DATA;

--- a/tio/command_parser.c
+++ b/tio/command_parser.c
@@ -264,6 +264,23 @@ static tio_code_t _start_result_request(
     return TIO_ERR_OK;
 }
 
+jkii_parse_err_t _validate_json(
+        tio_handler_t* handler,
+        const char* json_string,
+        size_t json_string_size)
+{
+    jkii_resource_t* resource = handler->_kii._json_resource;
+    jkii_parse_err_t res = JKII_ERR_INVALID_INPUT;
+    if (resource != NULL) {
+        res = jkii_validate_root_object(json_string, json_string_size, resource);
+    } else {
+        JKII_CB_RESOURCE_ALLOC cb_alloc = handler->_kii._cb_json_alloc;
+        JKII_CB_RESOURCE_FREE cb_free = handler->_kii._cb_json_free;
+        res = jkii_validate_root_object_with_allocator(json_string, json_string_size, cb_alloc, cb_free);
+    }
+    return res;
+}
+
 static tio_code_t _append_action_result(
         tio_handler_t* handler,
         size_t index,
@@ -277,7 +294,7 @@ static tio_code_t _append_action_result(
     int json_len = strlen(json_data);
     if (json_len > 0) {
         // Validate json_data.
-        jkii_parse_err_t json_res = _parse_json(handler, json_data, json_len, NULL);
+        jkii_parse_err_t json_res = _validate_json(handler, json_data, json_len);
         if (json_res != JKII_ERR_OK) {
             return TIO_ERR_PARSE_JSON;
         }

--- a/tio/gt202-sample/tio_demo.c
+++ b/tio/gt202-sample/tio_demo.c
@@ -183,7 +183,7 @@ void handler_init(
 #endif
 }
 
-tio_bool_t tio_action_handler(tio_action_t* action, tio_action_err_t* err, void* userdata)
+tio_bool_t tio_action_handler(tio_action_t* action, tio_action_err_t* err, tio_action_result_data_t* data, void* userdata)
 {
     printf("tio_action_handler called\n");
     printf("%.*s: %.*s\n", (int)action->alias_length, action->alias,(int)action->action_name_length, action->action_name);

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -123,6 +123,13 @@ typedef struct tio_action_err_t {
 } tio_action_err_t;
 
 /**
+ * \brief Represents action result data.
+ */
+typedef struct tio_action_result_data_t {
+    char json[128]; /**< \brief json string (null terminated). */
+} tio_action_err_t;
+
+/**
  * \brief Callback asks for size of the state to be uploaded.
  *
  * \param [in,out] userdata Context object pointer passed to tio_updater_start().
@@ -150,10 +157,11 @@ typedef size_t (*TIO_CB_READ)(char *buffer, size_t size, void *userdata);
  *
  * \param [in] action Includes alias_name, action_name and action value.
  * \param [out] err Implementation can set error when the given action is failed to execute.
+ * \param [out] data Implementation can set data as json string.
  * Reported error is recoreded in cloud. When succeeded, the argument can be ignored.
  * \param [in,out] userdata Context object pointer given to tio_handler_start().
  */
-typedef tio_bool_t (*TIO_CB_ACTION)(tio_action_t* action, tio_action_err_t* err, void* userdata);
+typedef tio_bool_t (*TIO_CB_ACTION)(tio_action_t* action, tio_action_err_t* err, tio_action_result_data_t* data, void* userdata);
 /**
  * \brief Callback propagates error information.
  *

--- a/tio/include/tio.h
+++ b/tio/include/tio.h
@@ -127,7 +127,7 @@ typedef struct tio_action_err_t {
  */
 typedef struct tio_action_result_data_t {
     char json[128]; /**< \brief json string (null terminated). */
-} tio_action_err_t;
+} tio_action_result_data_t;
 
 /**
  * \brief Callback asks for size of the state to be uploaded.

--- a/tio/linux-sample/example.c
+++ b/tio/linux-sample/example.c
@@ -190,7 +190,7 @@ void handler_init(
     tio_handler_set_cb_task_exit(handler, _handler_exit, NULL);
 }
 
-tio_bool_t tio_action_handler(tio_action_t* action, tio_action_err_t* err, void* userdata)
+tio_bool_t tio_action_handler(tio_action_t* action, tio_action_err_t* err, tio_action_result_data_t* data, void* userdata)
 {
     printf("tio_action_handler called\n");
     printf("%.*s: %.*s\n", (int)action->alias_length, action->alias,(int)action->action_name_length, action->action_name);

--- a/tio/tio.c
+++ b/tio/tio.c
@@ -572,5 +572,5 @@ tio_code_t tio_handler_parse_command(
         TIO_CB_PARSED_ACTION cb_parsed_action,
         void* userdata)
 {
-    _parse_command(handler, command, command_length, cb_parsed_action, userdata);
+    return _parse_command(handler, command, command_length, cb_parsed_action, userdata);
 }

--- a/tio/wiced-sample/tio_demo.c
+++ b/tio/wiced-sample/tio_demo.c
@@ -168,7 +168,7 @@ void handler_init(
 #endif
 }
 
-tio_bool_t tio_action_handler(tio_action_t* action, tio_action_err_t* err, void* userdata)
+tio_bool_t tio_action_handler(tio_action_t* action, tio_action_err_t* err, tio_action_result_data_t* data, void* userdata)
 {
     wiced_log_printf("tio_action_handler called\n");
     wiced_log_printf("%.*s: %.*s\n", (int)action->alias_length, action->alias,(int)action->action_name_length, action->action_name);


### PR DESCRIPTION
TIO_CB_ACTIONでaction_resultのdataを設定できるように修正しました。レビューをお願いします。

`_parse_command` 呼び出しの所は警告が出てたので一緒に直しています。

Issue: #123 