### PR TITLE
Free allocated resource in finished state

### DIFF
--- a/khc/src/khc.c
+++ b/khc/src/khc.c
@@ -17,29 +17,26 @@ void khc_set_stream_buff(khc* khc, char* buffer, size_t buff_size) {
 
 khc_code khc_perform(khc* khc) {
     khc->_state = KHC_STATE_IDLE;
+    khc->_result = KHC_ERR_OK;
 
     // malloc the necessary resources
     if (khc->_resp_header_buff == NULL) {
         char* buff = malloc(DEFAULT_RESP_HEADER_BUFF_SIZE);
         if (buff == NULL) {
-            khc->_state = KHC_STATE_FINISHED;
-            khc->_result = KHC_ERR_ALLOCATION;
-        } else {
-            khc->_resp_header_buff = buff;
-            khc->_resp_header_buff_allocated = 1;
-            khc->_resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
+            return  KHC_ERR_ALLOCATION;
         }
+        khc->_resp_header_buff = buff;
+        khc->_resp_header_buff_allocated = 1;
+        khc->_resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
     }
     if (khc->_stream_buff == NULL) {
         char* buff = malloc(DEFAULT_STREAM_BUFF_SIZE);
         if (buff == NULL) {
-            khc->_state = KHC_STATE_FINISHED;
-            khc->_result = KHC_ERR_ALLOCATION;
-        } else {
-            khc->_stream_buff = buff;
-            khc->_stream_buff_allocated = 1;
-            khc->_stream_buff_size = DEFAULT_STREAM_BUFF_SIZE;
+            return KHC_ERR_ALLOCATION;
         }
+        khc->_stream_buff = buff;
+        khc->_stream_buff_allocated = 1;
+        khc->_stream_buff_size = DEFAULT_STREAM_BUFF_SIZE;
     }
 
     while(khc->_state != KHC_STATE_FINISHED) {

--- a/khc/src/khc.c
+++ b/khc/src/khc.c
@@ -20,6 +20,10 @@ khc_code khc_perform(khc* khc) {
     while(khc->_state != KHC_STATE_FINISHED) {
         state_handlers[khc->_state](khc);
     }
+
+    // handle KHC_STATE_FINISHED to free resource allocated in KHC_STATE_IDLE
+    state_handlers[khc->_state](khc);
+
     khc_code res = khc->_result;
     khc->_state = KHC_STATE_IDLE;
     khc->_result = KHC_ERR_OK;

--- a/khc/src/khc.c
+++ b/khc/src/khc.c
@@ -17,9 +17,49 @@ void khc_set_stream_buff(khc* khc, char* buffer, size_t buff_size) {
 
 khc_code khc_perform(khc* khc) {
     khc->_state = KHC_STATE_IDLE;
+
+    // malloc the necessary resources
+    if (khc->_resp_header_buff == NULL) {
+        char* buff = malloc(DEFAULT_RESP_HEADER_BUFF_SIZE);
+        if (buff == NULL) {
+            khc->_state = KHC_STATE_FINISHED;
+            khc->_result = KHC_ERR_ALLOCATION;
+        } else {
+            khc->_resp_header_buff = buff;
+            khc->_resp_header_buff_allocated = 1;
+            khc->_resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
+        }
+    }
+    if (khc->_stream_buff == NULL) {
+        char* buff = malloc(DEFAULT_STREAM_BUFF_SIZE);
+        if (buff == NULL) {
+            khc->_state = KHC_STATE_FINISHED;
+            khc->_result = KHC_ERR_ALLOCATION;
+        } else {
+            khc->_stream_buff = buff;
+            khc->_stream_buff_allocated = 1;
+            khc->_stream_buff_size = DEFAULT_STREAM_BUFF_SIZE;
+        }
+    }
+
     while(khc->_state != KHC_STATE_FINISHED) {
         state_handlers[khc->_state](khc);
     }
+
+    // free the allocated resource
+    if (khc->_stream_buff_allocated == 1) {
+        free(khc->_stream_buff);
+        khc->_stream_buff = NULL;
+        khc->_stream_buff_size = 0;
+        khc->_stream_buff_allocated = 0;
+    }
+    if (khc->_resp_header_buff_allocated == 1) {
+        free(khc->_resp_header_buff);
+        khc->_resp_header_buff = NULL;
+        khc->_resp_header_buff_size = 0;
+        khc->_resp_header_buff_allocated = 0;
+    }
+
     khc_code res = khc->_result;
     khc->_state = KHC_STATE_IDLE;
     khc->_result = KHC_ERR_OK;

--- a/khc/src/khc.c
+++ b/khc/src/khc.c
@@ -20,10 +20,6 @@ khc_code khc_perform(khc* khc) {
     while(khc->_state != KHC_STATE_FINISHED) {
         state_handlers[khc->_state](khc);
     }
-
-    // handle KHC_STATE_FINISHED to free resource allocated in KHC_STATE_IDLE
-    state_handlers[khc->_state](khc);
-
     khc_code res = khc->_result;
     khc->_state = KHC_STATE_IDLE;
     khc->_result = KHC_ERR_OK;

--- a/khc/src/khc_state_impl.c
+++ b/khc/src/khc_state_impl.c
@@ -120,28 +120,6 @@ void khc_state_idle(khc* khc) {
         // Fallback to GET.
         strncpy(khc->_method, "GET", sizeof(khc->_method));
     }
-    if (khc->_resp_header_buff == NULL) {
-        char* buff = malloc(DEFAULT_RESP_HEADER_BUFF_SIZE);
-        if (buff == NULL) {
-            khc->_state = KHC_STATE_FINISHED;
-            khc->_result = KHC_ERR_ALLOCATION;
-            return;
-        }
-        khc->_resp_header_buff = buff;
-        khc->_resp_header_buff_allocated = 1;
-        khc->_resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
-    }
-    if (khc->_stream_buff == NULL) {
-        char* buff = malloc(DEFAULT_STREAM_BUFF_SIZE);
-        if (buff == NULL) {
-            khc->_state = KHC_STATE_FINISHED;
-            khc->_result = KHC_ERR_ALLOCATION;
-            return;
-        }
-        khc->_stream_buff = buff;
-        khc->_stream_buff_allocated = 1;
-        khc->_stream_buff_size = DEFAULT_STREAM_BUFF_SIZE;
-    }
     khc->_state = KHC_STATE_CONNECT;
     return;
 }
@@ -916,18 +894,6 @@ void khc_state_resp_body_skip_trailers(khc* khc) {
 }
 
 void khc_state_close(khc* khc) {
-    if (khc->_stream_buff_allocated == 1) {
-        free(khc->_stream_buff);
-        khc->_stream_buff = NULL;
-        khc->_stream_buff_size = 0;
-        khc->_stream_buff_allocated = 0;
-    }
-    if (khc->_resp_header_buff_allocated == 1) {
-        free(khc->_resp_header_buff);
-        khc->_resp_header_buff = NULL;
-        khc->_resp_header_buff_size = 0;
-        khc->_resp_header_buff_allocated = 0;
-    }
     khc_sock_code_t close_res = khc->_cb_sock_close(khc->_sock_ctx_close);
     if (close_res == KHC_SOCK_OK) {
         khc->_state = KHC_STATE_FINISHED;

--- a/khc/src/khc_state_impl.c
+++ b/khc/src/khc_state_impl.c
@@ -916,6 +916,18 @@ void khc_state_resp_body_skip_trailers(khc* khc) {
 }
 
 void khc_state_close(khc* khc) {
+    if (khc->_stream_buff_allocated == 1) {
+        free(khc->_stream_buff);
+        khc->_stream_buff = NULL;
+        khc->_stream_buff_size = 0;
+        khc->_stream_buff_allocated = 0;
+    }
+    if (khc->_resp_header_buff_allocated == 1) {
+        free(khc->_resp_header_buff);
+        khc->_resp_header_buff = NULL;
+        khc->_resp_header_buff_size = 0;
+        khc->_resp_header_buff_allocated = 0;
+    }
     khc_sock_code_t close_res = khc->_cb_sock_close(khc->_sock_ctx_close);
     if (close_res == KHC_SOCK_OK) {
         khc->_state = KHC_STATE_FINISHED;
@@ -928,21 +940,6 @@ void khc_state_close(khc* khc) {
         khc->_state = KHC_STATE_FINISHED;
         khc->_result = KHC_ERR_SOCK_CLOSE;
         return;
-    }
-}
-
-void khc_state_finished(khc* khc) {
-    if (khc->_stream_buff_allocated == 1) {
-        free(khc->_stream_buff);
-        khc->_stream_buff = NULL;
-        khc->_stream_buff_size = 0;
-        khc->_stream_buff_allocated = 0;
-    }
-    if (khc->_resp_header_buff_allocated == 1) {
-        free(khc->_resp_header_buff);
-        khc->_resp_header_buff = NULL;
-        khc->_resp_header_buff_size = 0;
-        khc->_resp_header_buff_allocated = 0;
     }
 }
 

--- a/khc/src/khc_state_impl.c
+++ b/khc/src/khc_state_impl.c
@@ -916,18 +916,6 @@ void khc_state_resp_body_skip_trailers(khc* khc) {
 }
 
 void khc_state_close(khc* khc) {
-    if (khc->_stream_buff_allocated == 1) {
-        free(khc->_stream_buff);
-        khc->_stream_buff = NULL;
-        khc->_stream_buff_size = 0;
-        khc->_stream_buff_allocated = 0;
-    }
-    if (khc->_resp_header_buff_allocated == 1) {
-        free(khc->_resp_header_buff);
-        khc->_resp_header_buff = NULL;
-        khc->_resp_header_buff_size = 0;
-        khc->_resp_header_buff_allocated = 0;
-    }
     khc_sock_code_t close_res = khc->_cb_sock_close(khc->_sock_ctx_close);
     if (close_res == KHC_SOCK_OK) {
         khc->_state = KHC_STATE_FINISHED;
@@ -940,6 +928,21 @@ void khc_state_close(khc* khc) {
         khc->_state = KHC_STATE_FINISHED;
         khc->_result = KHC_ERR_SOCK_CLOSE;
         return;
+    }
+}
+
+void khc_state_finished(khc* khc) {
+    if (khc->_stream_buff_allocated == 1) {
+        free(khc->_stream_buff);
+        khc->_stream_buff = NULL;
+        khc->_stream_buff_size = 0;
+        khc->_stream_buff_allocated = 0;
+    }
+    if (khc->_resp_header_buff_allocated == 1) {
+        free(khc->_resp_header_buff);
+        khc->_resp_header_buff = NULL;
+        khc->_resp_header_buff_size = 0;
+        khc->_resp_header_buff_allocated = 0;
     }
 }
 

--- a/khc/src/khc_state_impl.h
+++ b/khc/src/khc_state_impl.h
@@ -44,7 +44,6 @@ void khc_state_resp_body_skip_chunk_body_crlf(khc* khc);
 void khc_state_resp_body_skip_trailers(khc* khc);
 
 void khc_state_close(khc* khc);
-void khc_state_finished(khc* khc);
 
 typedef void (*KHC_STATE_HANDLER)(khc* khc);
 

--- a/khc/src/khc_state_impl.h
+++ b/khc/src/khc_state_impl.h
@@ -44,6 +44,7 @@ void khc_state_resp_body_skip_chunk_body_crlf(khc* khc);
 void khc_state_resp_body_skip_trailers(khc* khc);
 
 void khc_state_close(khc* khc);
+void khc_state_finished(khc* khc);
 
 typedef void (*KHC_STATE_HANDLER)(khc* khc);
 

--- a/tests/small_test/khc/state_trans_test.cpp
+++ b/tests/small_test/khc/state_trans_test.cpp
@@ -8,42 +8,16 @@
 #include "test_callbacks.h"
 #include <sstream>
 
-void initialAllocation(khc *http) {
-    char* buff = (char *)malloc(DEFAULT_RESP_HEADER_BUFF_SIZE);
-    REQUIRE(buff != NULL);
-    http->_resp_header_buff = buff;
-    http->_resp_header_buff_allocated = 1;
-    http->_resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
-
-    char* stream_buff = (char *)malloc(DEFAULT_STREAM_BUFF_SIZE);
-    REQUIRE(stream_buff != NULL);
-    http->_stream_buff = stream_buff;
-    http->_stream_buff_allocated = 1;
-    http->_stream_buff_size = DEFAULT_STREAM_BUFF_SIZE;
-}
-
-void freeMemory(khc *http) {
-    // free the allocated resource
-    if (http->_stream_buff_allocated == 1) {
-        free(http->_stream_buff);
-        http->_stream_buff = NULL;
-        http->_stream_buff_size = 0;
-        http->_stream_buff_allocated = 0;
-    }
-    if (http->_resp_header_buff_allocated == 1) {
-        free(http->_resp_header_buff);
-        http->_resp_header_buff = NULL;
-        http->_resp_header_buff_size = 0;
-        http->_resp_header_buff_allocated = 0;
-    }
-}
 TEST_CASE( "HTTP minimal" ) {
     khc http;
     khc_init(&http);
     const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
     const size_t resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
 
-    initialAllocation(&http);
+    char stream_buff[buff_size];
+    char resp_header_buff[resp_header_buff_size];
+    khc_set_stream_buff(&http, stream_buff, buff_size);
+    khc_set_resp_header_buff(&http, resp_header_buff, resp_header_buff_size);
 
     khct::http::Resp resp;
     resp.headers = { "HTTP/1.0 200 OK" };
@@ -199,7 +173,6 @@ TEST_CASE( "HTTP minimal" ) {
     REQUIRE( http._state == KHC_STATE_FINISHED );
     REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-    freeMemory(&http);
 }
 
 TEST_CASE( "HTTP 1.1 chunked minimal" ) {
@@ -208,7 +181,10 @@ TEST_CASE( "HTTP 1.1 chunked minimal" ) {
     const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
     const size_t resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
 
-    initialAllocation(&http);
+    char stream_buff[buff_size];
+    char resp_header_buff[resp_header_buff_size];
+    khc_set_stream_buff(&http, stream_buff, buff_size);
+    khc_set_resp_header_buff(&http, resp_header_buff, resp_header_buff_size);
 
     khct::http::Resp resp;
     resp.headers = {
@@ -516,7 +492,6 @@ TEST_CASE( "HTTP 1.1 chunked minimal" ) {
     REQUIRE( http._state == KHC_STATE_FINISHED );
     REQUIRE( http._result == KHC_ERR_OK );
     REQUIRE( called );
-    freeMemory(&http);
 }
 
 TEST_CASE( "Socket send partial" ) {
@@ -525,7 +500,10 @@ TEST_CASE( "Socket send partial" ) {
     const size_t buff_size = DEFAULT_STREAM_BUFF_SIZE;
     const size_t resp_header_buff_size = DEFAULT_RESP_HEADER_BUFF_SIZE;
 
-    initialAllocation(&http);
+    char stream_buff[buff_size];
+    char resp_header_buff[resp_header_buff_size];
+    khc_set_stream_buff(&http, stream_buff, buff_size);
+    khc_set_resp_header_buff(&http, resp_header_buff, resp_header_buff_size);
 
     khct::http::Resp resp;
     resp.headers = { "HTTP/1.0 200 OK" };
@@ -914,7 +892,6 @@ TEST_CASE( "Socket send partial" ) {
     REQUIRE( called );
 
     khc_slist_free_all(req_headers);
-    freeMemory(&http);
 }
 
 TEST_CASE( "state abnormal tests." ) {


### PR DESCRIPTION
#134 
We decided to move the allocation and free logic to `khc_perform` so that it can become easy to maintain. 
