### PR TITLE
added macro var to override app-id and api host

### DIFF
--- a/tests/large_test/kii/Makefile
+++ b/tests/large_test/kii/Makefile
@@ -26,6 +26,12 @@ TEST_RESULT=$(TEST_RESULT_DIR)/test-result.xml
 ifdef PLAIN_HTTP
 	CPPFLAGS += -DPLAIN_HTTP
 endif
+ifdef DEFAULT_SITE
+	CPPFLAGS += -D_DEFAULT_SITE=$(DEFAULT_SITE)
+endif
+ifdef APP_ID
+	CPPFLAGS += -D_APP_ID=$(APP_ID)
+endif
 ifdef MEMCHECK
 TESTCMD=valgrind --leak-check=yes $(TARGET)
 else

--- a/tests/large_test/kii/Makefile
+++ b/tests/large_test/kii/Makefile
@@ -23,24 +23,13 @@ INCLUDES = -I$(LTEST_ROOT_DIR) -I$(TEST_ROOT_DIR) -I$(KII_BUILD_DIR)/usr/local/i
 TEST_RESULT_DIR=test-results/junit
 TEST_RESULT=$(TEST_RESULT_DIR)/test-result.xml
 
-ifdef PLAIN_HTTP
-	CPPFLAGS += -DPLAIN_HTTP
-endif
-ifdef DEFAULT_SITE
-	CPPFLAGS += -D_DEFAULT_SITE=$(DEFAULT_SITE)
-endif
-ifdef APP_ID
-	CPPFLAGS += -D_APP_ID=$(APP_ID)
-endif
-ifdef MEMCHECK
-TESTCMD=valgrind --leak-check=yes $(TARGET)
-else
-TESTCMD=$(TARGET)
-endif
+# only work with GNU make
+CPPFLAGS += $(if $(value PLAIN_HTTP), -DPLAIN_HTTP, )
+CPPFLAGS += $(if $(value DEFAULT_SITE), -D_DEFAULT_SITE=$(DEFAULT_SITE), )
+CPPFLAGS += $(if $(value APP_ID), -D_APP_ID=$(APP_ID), )
 
-ifdef JUNIT
-TESTCMD+= -r junit -o $(TEST_RESULT)
-endif
+TESTCMD = $(if $(value MEMCHECK), valgrind --leak-check=yes $(TARGET), $(TARGET))
+TESTCMD += $(if $(value JUNIT), -r junit -o $(TEST_RESULT), )
 
 all: clean $(TARGET)
 

--- a/tests/large_test/kii/README.mkd
+++ b/tests/large_test/kii/README.mkd
@@ -12,3 +12,35 @@ following command.
 ```
 ./testapp
 ```
+
+You can do them once by
+```
+make test
+```
+
+You can tweak the `make test` behavior by environemnt vars:
+
+- JUNIT : if defined, it will generate junit-sylte test report under `test-result` directory.
+
+- MEMCHECK : if defined, run test under valgrind
+
+- PLAIN_HTTP : if defined, use raw HTTP instead of HTTPS, useful for packet capturing.
+
+- APP_ID : specify the app-id used for the test.
+
+- DEFAULT_HOST : specify the API hostname used for the test.
+
+## using non-defualt app
+To run this test against the different app-id, you should preapare the followings,
+
+- create a user with login name `test1` and password `1234`.
+
+- create a app scope topic `test-topic`.
+
+- upload and enable the following server code.
+
+```
+function echo(params, context) {
+  return params.message;
+}
+```

--- a/tests/large_test/kii/api_call_test.cpp
+++ b/tests/large_test/kii/api_call_test.cpp
@@ -30,9 +30,9 @@ TEST_CASE("API call tests")
 
     SECTION("API call") {
         // POST object
-        char path[128];
-        int path_len = snprintf(path, 128, "/api/apps/%s/buckets/test_bucket/objects", kii._app_id);
-        REQUIRE(path_len <= 128);
+        char path[256];
+        int path_len = snprintf(path, 256, "/api/apps/%s/buckets/test_bucket/objects", kii._app_id);
+        REQUIRE(path_len <= 256);
         const char content_type[] = "application/json";
 
         kii_code_t start_res = kii_api_call_start(&kii, "POST", path, content_type, KII_TRUE);

--- a/tests/large_test/kii/api_call_test.cpp
+++ b/tests/large_test/kii/api_call_test.cpp
@@ -30,9 +30,9 @@ TEST_CASE("API call tests")
 
     SECTION("API call") {
         // POST object
-        char path[256];
-        int path_len = snprintf(path, 256, "/api/apps/%s/buckets/test_bucket/objects", kii._app_id);
-        REQUIRE(path_len <= 256);
+        char path[128];
+        int path_len = snprintf(path, 128, "/api/apps/%s/buckets/test_bucket/objects", kii._app_id);
+        REQUIRE(path_len <= 128);
         const char content_type[] = "application/json";
 
         kii_code_t start_res = kii_api_call_start(&kii, "POST", path, content_type, KII_TRUE);

--- a/tests/large_test/kii/large_test.h
+++ b/tests/large_test/kii/large_test.h
@@ -8,9 +8,22 @@
 
 namespace kiiltest {
 
+// stringify the macro value
+// ref. https://gcc.gnu.org/onlinedocs/gcc-4.8.5/cpp/Stringification.html
+#define XSTR(x) STR(x)
+#define STR(x) #x
+
+#ifndef _DEFAULT_SITE
 const char DEFAULT_SITE[] = "api-jp.kii.com";
+#else
+const char DEFAULT_SITE[] = XSTR(_DEFAULT_SITE);
+#endif
+#ifndef _APP_ID
 // APP Owner: satoshi.kumano@kii.com
 const char APP_ID[] = "b6t9ai81zb3s";
+#else
+const char APP_ID[] = XSTR(_APP_ID);
+#endif
 
 inline void init(
         kii_t* kii,


### PR DESCRIPTION
QA team wants to run large test for ensuring varnish-to-openresty transition is OK for ebisu.