### PR TITLE
add init target for non-default app

### DIFF
--- a/tests/large_test/kii/Makefile
+++ b/tests/large_test/kii/Makefile
@@ -56,6 +56,15 @@ test: $(TARGET)
 	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH):$(KII_BUILD_DIR)/usr/local/lib \
 	$(TESTCMD)
 
+initapp:
+	# get app admin token
+	$(eval ADMIN_TOKEN := $(shell curl -v -X POST -H 'X-Kii-AppID: $(APP_ID)' -H 'X-Kii-AppKey: dummy' -H 'Content-Type: application/json' https://$(DEFAULT_SITE)/api/oauth2/token -d '{"client_id":"$(CLIENT_ID)","client_secret":"$(CLIENT_SECRET)"}' | jq -r .access_token))
+	# create app scope topic
+	curl -v -X PUT -H 'X-Kii-AppID: $(APP_ID)' -H 'X-Kii-AppKey: dummy' -H 'Authorization: Bearer $(ADMIN_TOKEN)' https://$(DEFAULT_SITE)/api/apps/$(APP_ID)/topics/test_topic
+	# deploy server code
+	$(eval CODE_VERSION := $(shell curl -v -X POST -H 'X-Kii-AppID: $(APP_ID)' -H 'X-Kii-AppKey: dummy' -H 'Authorization: Bearer $(ADMIN_TOKEN)' -H 'Content-Type: application/javascript' https://$(DEFAULT_SITE)/api/apps/$(APP_ID)/server-code -d 'function echo(params, context) { return params.message; }' | jq -r .versionID))
+	curl -v -X PUT -H 'X-Kii-AppID: $(APP_ID)' -H 'X-Kii-AppKey: dummy' -H 'Authorization: Bearer $(ADMIN_TOKEN)' -H 'Content-Type: text/plain' https://$(DEFAULT_SITE)/api/apps/$(APP_ID)/server-code/versions/current -d '$(CODE_VERSION)'
+
 clean:
 	touch $(TARGET)
 	rm $(TARGET)

--- a/tests/large_test/kii/Makefile
+++ b/tests/large_test/kii/Makefile
@@ -71,5 +71,5 @@ clean:
 	rm -f *.o
 	rm -rf $(KII_BUILD_DIR)
 
-.PHONY: all clean copy kii
+.PHONY: all clean copy kii initapp
 

--- a/tests/large_test/kii/README.mkd
+++ b/tests/large_test/kii/README.mkd
@@ -31,6 +31,7 @@ You can tweak the `make test` behavior by environemnt vars:
 - DEFAULT_HOST : specify the API hostname used for the test.
 
 ## using non-defualt app
+
 To run this test against the different app-id, you should preapare the followings,
 
 - create a user with login name `test1` and password `1234`.
@@ -43,4 +44,13 @@ To run this test against the different app-id, you should preapare the following
 function echo(params, context) {
   return params.message;
 }
+```
+
+You can do them by
+```
+DEFAULT_SITE="${DEFAULT_SITE}" \
+APP_ID="${APP_ID}" \
+CLIENT_ID="${CLIENT_ID}" \
+CLIENT_SECRET="${CLIENT_SECRET}" \
+make initapp
 ```

--- a/tests/large_test/kii/README.mkd
+++ b/tests/large_test/kii/README.mkd
@@ -28,15 +28,13 @@ You can tweak the `make test` behavior by environemnt vars:
 
 - APP_ID : specify the app-id used for the test.
 
-- DEFAULT_HOST : specify the API hostname used for the test.
+- DEFAULT_SITE : specify the API hostname used for the test.
 
 ## using non-defualt app
 
 To run this test against the different app-id, you should preapare the followings,
 
-- create a user with login name `test1` and password `1234`.
-
-- create a app scope topic `test-topic`.
+- create a app scope topic `test_topic`.
 
 - upload and enable the following server code.
 


### PR DESCRIPTION
新規アプリを用意して以下のようにするとテストに必要なリソースを作ってくれるスクリプトを追加しました
```
$ cd tests/large_test/kii/

$ DEFAULT_SITE="${DEFAULT_SITE}" \
APP_ID="${APP_ID}" \
CLIENT_ID="${CLIENT_ID}" \
CLIENT_SECRET="${CLIENT_SECRET}" \
make initapp
```