### PR TITLE
fix thingProperties type to Object.

### DIFF
--- a/kii/kii_ti_impl.c
+++ b/kii/kii_ti_impl.c
@@ -178,7 +178,7 @@ kii_code_t _onboard(
         content_len += snprintf(
                 &kii->_rw_buff[content_len],
                 kii->_rw_buff_size - content_len,
-                ",\"thingProperties\":\"%s\"",
+                ",\"thingProperties\":%s",
                 esc);
         if (content_len >= kii->_rw_buff_size) {
             _req_headers_free_all(kii);


### PR DESCRIPTION
Issue: #151 

送信の `thingProperties` が文字列になっていたのでObjectで送信されるように修正しました。
