### PR TITLE
Add tests for empty payload updates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .DS_Store
 *.o
 *.dsym
-.envrc
-.envrc.*
+/.envrc
+/.env
+/.env.prod
+/.env.test
 /.vscode/
 **/ebisu_version.h

--- a/tests/large_test/kii/Makefile
+++ b/tests/large_test/kii/Makefile
@@ -29,8 +29,9 @@ CPPFLAGS += $(if $(value DEFAULT_SITE), -D_DEFAULT_SITE=$(DEFAULT_SITE), )
 CPPFLAGS += $(if $(value APP_ID), -D_APP_ID=$(APP_ID), )
 CPPFLAGS += $(if $(value SOCKET_LOG), -DSOCKET_LOG, )
 
-TESTCMD = $(if $(value MEMCHECK), valgrind --leak-check=yes $(TARGET), $(TARGET))
+TESTCMD = $(if $(value MEMCHECK), valgrind --leak-check=yes $(TARGET) -s, $(TARGET) -s)
 TESTCMD += $(if $(value JUNIT), -r junit -o $(TEST_RESULT), )
+TESTCMD += $(if $(value TEST_CASE), -c "$(TEST_CASE)", )
 
 all: clean $(TARGET)
 

--- a/tests/large_test/kii/large_test.h
+++ b/tests/large_test/kii/large_test.h
@@ -1,9 +1,13 @@
 #ifndef __large_test__
 #define __large_test__
 
+#include <string>
 #include <chrono>
 #include <functional>
+#include <picojson.h>
+#include <catch.hpp>  // Assuming you're using Catch2 for the REQUIRE macros
 #include "kii.h"
+#include "khc.h"
 #include "secure_socket_impl.h"
 #include "../test_env.h"
 
@@ -49,6 +53,29 @@ inline void init(
 inline long long current_time() {
     auto now = std::chrono::system_clock::now();
     return now.time_since_epoch().count() / 1000;
+}
+
+inline void check_error_response(
+    kii_t& kii,
+    char* buff,
+    const int res, 
+    const int expected_status_code, 
+    const std::string& expected_error_code
+    ) {
+    REQUIRE(res == KII_ERR_RESP_STATUS);
+    
+    int actual_status_code = khc_get_status_code(&kii._khc);
+    REQUIRE(actual_status_code == expected_status_code);
+    
+    picojson::value v;
+    auto err_str = picojson::parse(v, buff);
+    REQUIRE(err_str.empty());
+    REQUIRE(v.is<picojson::object>());
+    
+    picojson::object obj = v.get<picojson::object>();
+    auto errorCode = obj.at("errorCode");
+    REQUIRE(errorCode.is<std::string>());
+    REQUIRE(errorCode.get<std::string>() == expected_error_code);
 }
 
 class RWFunc {

--- a/tests/large_test/kii/large_test.h
+++ b/tests/large_test/kii/large_test.h
@@ -5,7 +5,7 @@
 #include <chrono>
 #include <functional>
 #include <picojson.h>
-#include <catch.hpp>  // Assuming you're using Catch2 for the REQUIRE macros
+#include <catch.hpp>
 #include "kii.h"
 #include "khc.h"
 #include "secure_socket_impl.h"

--- a/tests/large_test/kii/ti_test.cpp
+++ b/tests/large_test/kii/ti_test.cpp
@@ -216,22 +216,36 @@ TEST_CASE("TI Tests")
         REQUIRE( res == KII_ERR_OK );
         REQUIRE( khc_get_status_code(&kii._khc) == 204 );
     }
+}
 
+TEST_CASE("Empty request payloads") {
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    size_t buff_size = 4096;
+    char buff[buff_size];
+    kii_t kii;
+    ebisu::ltest::ssl::SSLData http_ssl_ctx;
+    ebisu::ltest::ssl::SSLData mqtt_ssl_ctx;
+
+    jkii_token_t tokens[256];
+    jkii_resource_t resource = {tokens, 256};
+
+    kiiltest::init(&kii, buff, buff_size, &http_ssl_ctx, &mqtt_ssl_ctx, &resource);
+
+    std::ostringstream oss;
+    oss << "ltest_vid_" << std::time(NULL);
+    std::string vid = oss.str();
+    const char password[] = "1234";
+    const char thing_type[] = "ltest_thing_type";
+    const char firmware_version[] = "ltest_firmware_version";
+    kii_code_t res = kii_ti_onboard(&kii, vid.c_str(), password, thing_type, firmware_version, NULL, NULL);
+
+    REQUIRE( res == KII_ERR_OK );
+    REQUIRE( khc_get_status_code(&kii._khc) == 200 );
+    REQUIRE( std::string(kii._author.author_id).length() > 0 );
+    REQUIRE( std::string(kii._author.access_token).length() > 0 );
 
     SECTION("Put bulk states with empty callback")
     {
-        std::ostringstream oss;
-        oss << "ltest_vid_" << std::time(NULL);
-        std::string vid = oss.str();
-        const char password[] = "1234";
-        const char thing_type[] = "ltest_thing_type";
-        const char firmware_version[] = "ltest_firmware_version";
-        kii_code_t res = kii_ti_onboard(&kii, vid.c_str(), password, thing_type, firmware_version, NULL, NULL);
-
-        REQUIRE( res == KII_ERR_OK );
-        REQUIRE( khc_get_status_code(&kii._khc) == 200 );
-        REQUIRE( std::string(kii._author.author_id).length() > 0 );
-        REQUIRE( std::string(kii._author.access_token).length() > 0 );
 
         std::function<size_t(char *buffer, size_t size, void *userdata)>
             on_read = [] (char *buffer, size_t size, void *userdata)
@@ -244,47 +258,37 @@ TEST_CASE("TI Tests")
         int status_code =  khc_get_status_code(&kii._khc);
         INFO("Status code is: " << status_code);
         REQUIRE( res == KII_ERR_RESP_STATUS );
-        REQUIRE((status_code == 400 || status_code == 422));
+        REQUIRE(status_code == 400);
+        picojson::value v;
+        auto err_str = picojson::parse(v, buff);
+        REQUIRE ( err_str.empty() );
+        REQUIRE ( v.is<picojson::object>() );
+        picojson::object obj = v.get<picojson::object>();
+        auto errorCode = obj.at("errorCode");
+        REQUIRE ( errorCode.is<std::string>() );
+        REQUIRE ( errorCode.get<std::string>() == std::string("BAD_REQUEST") );
     }
 
     SECTION("Put bulk states with no callback")
     {
-        std::ostringstream oss;
-        oss << "ltest_vid_" << std::time(NULL);
-        std::string vid = oss.str();
-        const char password[] = "1234";
-        const char thing_type[] = "ltest_thing_type";
-        const char firmware_version[] = "ltest_firmware_version";
-        kii_code_t res = kii_ti_onboard(&kii, vid.c_str(), password, thing_type, firmware_version, NULL, NULL);
-
-        REQUIRE( res == KII_ERR_OK );
-        REQUIRE( khc_get_status_code(&kii._khc) == 200 );
-        REQUIRE( std::string(kii._author.author_id).length() > 0 );
-        REQUIRE( std::string(kii._author.access_token).length() > 0 );
 
         res = kii_ti_put_bulk_states(&kii, NULL, NULL, NULL, NULL, NULL);
         int status_code =  khc_get_status_code(&kii._khc);
         INFO("Status code is: " << status_code);
         REQUIRE( res == KII_ERR_RESP_STATUS );
-        REQUIRE((status_code == 400 || status_code == 422));
+        REQUIRE(status_code == 400);
+        picojson::value v;
+        auto err_str = picojson::parse(v, buff);
+        REQUIRE ( err_str.empty() );
+        REQUIRE ( v.is<picojson::object>() );
+        picojson::object obj = v.get<picojson::object>();
+        auto errorCode = obj.at("errorCode");
+        REQUIRE ( errorCode.is<std::string>() );
+        REQUIRE ( errorCode.get<std::string>() == std::string("EMPTY_BODY") );
     }
 
     SECTION("Patch bulk states with empty callback")
     {
-        std::ostringstream oss;
-        oss << "ltest_vid_" << std::time(NULL);
-        std::string vid = oss.str();
-        std::time_t t = std::time(NULL);
-
-        const char password[] = "1234";
-        const char thing_type[] = "ltest_thing_type";
-        const char firmware_version[] = "ltest_firmware_version";
-        kii_code_t res = kii_ti_onboard(&kii, vid.c_str(), password, thing_type, firmware_version, NULL, NULL);
-
-        REQUIRE( res == KII_ERR_OK );
-        REQUIRE( khc_get_status_code(&kii._khc) == 200 );
-        REQUIRE( std::string(kii._author.author_id).length() > 0 );
-        REQUIRE( std::string(kii._author.access_token).length() > 0 );
 
         std::function<size_t(char *buffer, size_t size, void *userdata)>
             on_read = [](char *buffer, size_t size, void *userdata)
@@ -297,31 +301,73 @@ TEST_CASE("TI Tests")
         int status_code =  khc_get_status_code(&kii._khc);
         INFO("Status code is: " << status_code);
         REQUIRE( res == KII_ERR_RESP_STATUS );
-        REQUIRE((status_code == 400 || status_code == 422));
+        REQUIRE(status_code == 400);
+        picojson::value v;
+        auto err_str = picojson::parse(v, buff);
+        REQUIRE ( err_str.empty() );
+        REQUIRE ( v.is<picojson::object>() );
+        picojson::object obj = v.get<picojson::object>();
+        auto errorCode = obj.at("errorCode");
+        REQUIRE ( errorCode.is<std::string>() );
+        REQUIRE ( errorCode.get<std::string>() == std::string("BAD_REQUEST") );
     }
 
     SECTION("Patch bulk states with null callback")
     {
-        std::ostringstream oss;
-        oss << "ltest_vid_" << std::time(NULL);
-        std::string vid = oss.str();
-        std::time_t t = std::time(NULL);
-
-        const char password[] = "1234";
-        const char thing_type[] = "ltest_thing_type";
-        const char firmware_version[] = "ltest_firmware_version";
-        kii_code_t res = kii_ti_onboard(&kii, vid.c_str(), password, thing_type, firmware_version, NULL, NULL);
-
-        REQUIRE( res == KII_ERR_OK );
-        REQUIRE( khc_get_status_code(&kii._khc) == 200 );
-        REQUIRE( std::string(kii._author.author_id).length() > 0 );
-        REQUIRE( std::string(kii._author.access_token).length() > 0 );
-
-
         res = kii_ti_patch_bulk_states(&kii, NULL, NULL, NULL, NULL, NULL);
         int status_code =  khc_get_status_code(&kii._khc);
         INFO("Status code is: " << status_code);
         REQUIRE( res == KII_ERR_RESP_STATUS );
-        REQUIRE((status_code == 400 || status_code == 422));
+        REQUIRE((status_code == 400));
+        picojson::value v;
+        auto err_str = picojson::parse(v, buff);
+        REQUIRE ( err_str.empty() );
+        REQUIRE ( v.is<picojson::object>() );
+        picojson::object obj = v.get<picojson::object>();
+        auto errorCode = obj.at("errorCode");
+        REQUIRE ( errorCode.is<std::string>() );
+        REQUIRE ( errorCode.get<std::string>() == std::string("EMPTY_BODY") );
+    }
+
+    SECTION("Patch state with empty callback")
+    {
+        std::function<size_t(char *buffer, size_t size, void *userdata)>
+            on_read = [](char *buffer, size_t size, void *userdata)
+            {
+                return 0;
+            };
+        kiiltest::RWFunc ctx;
+        ctx.on_read = on_read;
+        res = kii_ti_patch_state(&kii, kiiltest::read_cb, &ctx, NULL, NULL, NULL);
+        int status_code =  khc_get_status_code(&kii._khc);
+        INFO("Status code is: " << status_code);
+        REQUIRE( res == KII_ERR_RESP_STATUS );
+        REQUIRE((status_code == 400));
+        picojson::value v;
+        auto err_str = picojson::parse(v, buff);
+        REQUIRE ( err_str.empty() );
+        REQUIRE ( v.is<picojson::object>() );
+        picojson::object obj = v.get<picojson::object>();
+        auto errorCode = obj.at("errorCode");
+        REQUIRE ( errorCode.is<std::string>() );
+        REQUIRE ( errorCode.get<std::string>() == std::string("BAD_REQUEST") );
+    }
+
+   SECTION("Patch state with null callback")
+    {
+        res = kii_ti_patch_state(&kii, NULL, NULL, NULL, NULL, NULL);
+        int status_code =  khc_get_status_code(&kii._khc);
+        INFO("Status code is: " << status_code);
+        REQUIRE( res == KII_ERR_RESP_STATUS );
+        REQUIRE((status_code == 400));
+
+        picojson::value v;
+        auto err_str = picojson::parse(v, buff);
+        REQUIRE ( err_str.empty() );
+        REQUIRE ( v.is<picojson::object>() );
+        picojson::object obj = v.get<picojson::object>();
+        auto errorCode = obj.at("errorCode");
+        REQUIRE ( errorCode.is<std::string>() );
+        REQUIRE ( errorCode.get<std::string>() == std::string("EMPTY_BODY") );
     }
 }

--- a/tests/large_test/kii/ti_test.cpp
+++ b/tests/large_test/kii/ti_test.cpp
@@ -218,7 +218,7 @@ TEST_CASE("TI Tests")
     }
 }
 
-TEST_CASE("Empty request payloads") {
+TEST_CASE("Empty request payloads", "[empty-request]") {
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     size_t buff_size = 4096;
     char buff[buff_size];
@@ -255,7 +255,7 @@ TEST_CASE("Empty request payloads") {
         kiiltest::RWFunc ctx;
         ctx.on_read = on_read;
         res = kii_ti_put_bulk_states(&kii, kiiltest::read_cb, &ctx, NULL, NULL, NULL);
-        kiiltest::check_error_response(kii, buff, res, 400, "BAD_REQUEST");
+        kiiltest::check_error_response(kii, buff, res, 400, "EMPTY_BODY");
     }
 
     SECTION("Put bulk states with no callback")
@@ -275,7 +275,7 @@ TEST_CASE("Empty request payloads") {
         kiiltest::RWFunc ctx;
         ctx.on_read = on_read;
         res = kii_ti_patch_bulk_states(&kii, kiiltest::read_cb, &ctx, NULL, NULL, NULL);
-        kiiltest::check_error_response(kii, buff, res, 400, "BAD_REQUEST");
+        kiiltest::check_error_response(kii, buff, res, 400, "EMPTY_BODY");
     }
 
     SECTION("Patch bulk states with null callback")
@@ -294,7 +294,7 @@ TEST_CASE("Empty request payloads") {
         kiiltest::RWFunc ctx;
         ctx.on_read = on_read;
         res = kii_ti_patch_state(&kii, kiiltest::read_cb, &ctx, NULL, NULL, NULL);
-        kiiltest::check_error_response(kii, buff, res, 400, "BAD_REQUEST");
+        kiiltest::check_error_response(kii, buff, res, 400, "EMPTY_BODY");
     }
 
     SECTION("Patch state with null callback")
@@ -313,7 +313,7 @@ TEST_CASE("Empty request payloads") {
         kiiltest::RWFunc ctx;
         ctx.on_read = on_read;
         res = kii_ti_put_state(&kii, kiiltest::read_cb, &ctx, NULL, NULL, NULL);
-        kiiltest::check_error_response(kii, buff, res, 400, "BAD_REQUEST");
+        kiiltest::check_error_response(kii, buff, res, 400, "EMPTY_BODY");
     }
 
     SECTION("Put state with null callback")

--- a/tests/large_test/kii/ti_test.cpp
+++ b/tests/large_test/kii/ti_test.cpp
@@ -297,9 +297,28 @@ TEST_CASE("Empty request payloads") {
         kiiltest::check_error_response(kii, buff, res, 400, "BAD_REQUEST");
     }
 
-   SECTION("Patch state with null callback")
+    SECTION("Patch state with null callback")
     {
         res = kii_ti_patch_state(&kii, NULL, NULL, NULL, NULL, NULL);
+        kiiltest::check_error_response(kii, buff, res, 400, "EMPTY_BODY");
+    }
+
+    SECTION("Put state with empty callback")
+    {
+        std::function<size_t(char *buffer, size_t size, void *userdata)>
+            on_read = [](char *buffer, size_t size, void *userdata)
+            {
+                return 0;
+            };
+        kiiltest::RWFunc ctx;
+        ctx.on_read = on_read;
+        res = kii_ti_put_state(&kii, kiiltest::read_cb, &ctx, NULL, NULL, NULL);
+        kiiltest::check_error_response(kii, buff, res, 400, "BAD_REQUEST");
+    }
+
+    SECTION("Put state with null callback")
+    {
+        res = kii_ti_put_state(&kii, NULL, NULL, NULL, NULL, NULL);
         kiiltest::check_error_response(kii, buff, res, 400, "EMPTY_BODY");
     }
 }

--- a/tests/large_test/kii/ti_test.cpp
+++ b/tests/large_test/kii/ti_test.cpp
@@ -268,4 +268,60 @@ TEST_CASE("TI Tests")
         REQUIRE( res == KII_ERR_RESP_STATUS );
         REQUIRE((status_code == 400 || status_code == 422));
     }
+
+    SECTION("Patch bulk states with empty callback")
+    {
+        std::ostringstream oss;
+        oss << "ltest_vid_" << std::time(NULL);
+        std::string vid = oss.str();
+        std::time_t t = std::time(NULL);
+
+        const char password[] = "1234";
+        const char thing_type[] = "ltest_thing_type";
+        const char firmware_version[] = "ltest_firmware_version";
+        kii_code_t res = kii_ti_onboard(&kii, vid.c_str(), password, thing_type, firmware_version, NULL, NULL);
+
+        REQUIRE( res == KII_ERR_OK );
+        REQUIRE( khc_get_status_code(&kii._khc) == 200 );
+        REQUIRE( std::string(kii._author.author_id).length() > 0 );
+        REQUIRE( std::string(kii._author.access_token).length() > 0 );
+
+        std::function<size_t(char *buffer, size_t size, void *userdata)>
+            on_read = [](char *buffer, size_t size, void *userdata)
+            {
+                return 0;
+            };
+        kiiltest::RWFunc ctx;
+        ctx.on_read = on_read;
+        res = kii_ti_patch_bulk_states(&kii, kiiltest::read_cb, &ctx, NULL, NULL, NULL);
+        int status_code =  khc_get_status_code(&kii._khc);
+        INFO("Status code is: " << status_code);
+        REQUIRE( res == KII_ERR_RESP_STATUS );
+        REQUIRE((status_code == 400 || status_code == 422));
+    }
+
+    SECTION("Patch bulk states with null callback")
+    {
+        std::ostringstream oss;
+        oss << "ltest_vid_" << std::time(NULL);
+        std::string vid = oss.str();
+        std::time_t t = std::time(NULL);
+
+        const char password[] = "1234";
+        const char thing_type[] = "ltest_thing_type";
+        const char firmware_version[] = "ltest_firmware_version";
+        kii_code_t res = kii_ti_onboard(&kii, vid.c_str(), password, thing_type, firmware_version, NULL, NULL);
+
+        REQUIRE( res == KII_ERR_OK );
+        REQUIRE( khc_get_status_code(&kii._khc) == 200 );
+        REQUIRE( std::string(kii._author.author_id).length() > 0 );
+        REQUIRE( std::string(kii._author.access_token).length() > 0 );
+
+
+        res = kii_ti_patch_bulk_states(&kii, NULL, NULL, NULL, NULL, NULL);
+        int status_code =  khc_get_status_code(&kii._khc);
+        INFO("Status code is: " << status_code);
+        REQUIRE( res == KII_ERR_RESP_STATUS );
+        REQUIRE((status_code == 400 || status_code == 422));
+    }
 }

--- a/tests/large_test/kii/ti_test.cpp
+++ b/tests/large_test/kii/ti_test.cpp
@@ -216,4 +216,56 @@ TEST_CASE("TI Tests")
         REQUIRE( res == KII_ERR_OK );
         REQUIRE( khc_get_status_code(&kii._khc) == 204 );
     }
+
+
+    SECTION("Put bulk states with empty callback")
+    {
+        std::ostringstream oss;
+        oss << "ltest_vid_" << std::time(NULL);
+        std::string vid = oss.str();
+        const char password[] = "1234";
+        const char thing_type[] = "ltest_thing_type";
+        const char firmware_version[] = "ltest_firmware_version";
+        kii_code_t res = kii_ti_onboard(&kii, vid.c_str(), password, thing_type, firmware_version, NULL, NULL);
+
+        REQUIRE( res == KII_ERR_OK );
+        REQUIRE( khc_get_status_code(&kii._khc) == 200 );
+        REQUIRE( std::string(kii._author.author_id).length() > 0 );
+        REQUIRE( std::string(kii._author.access_token).length() > 0 );
+
+        std::function<size_t(char *buffer, size_t size, void *userdata)>
+            on_read = [] (char *buffer, size_t size, void *userdata)
+            {
+                return 0;
+            };
+        kiiltest::RWFunc ctx;
+        ctx.on_read = on_read;
+        res = kii_ti_put_bulk_states(&kii, kiiltest::read_cb, &ctx, NULL, NULL, NULL);
+        int status_code =  khc_get_status_code(&kii._khc);
+        INFO("Status code is: " << status_code);
+        REQUIRE( res == KII_ERR_RESP_STATUS );
+        REQUIRE((status_code == 400 || status_code == 422));
+    }
+
+    SECTION("Put bulk states with no callback")
+    {
+        std::ostringstream oss;
+        oss << "ltest_vid_" << std::time(NULL);
+        std::string vid = oss.str();
+        const char password[] = "1234";
+        const char thing_type[] = "ltest_thing_type";
+        const char firmware_version[] = "ltest_firmware_version";
+        kii_code_t res = kii_ti_onboard(&kii, vid.c_str(), password, thing_type, firmware_version, NULL, NULL);
+
+        REQUIRE( res == KII_ERR_OK );
+        REQUIRE( khc_get_status_code(&kii._khc) == 200 );
+        REQUIRE( std::string(kii._author.author_id).length() > 0 );
+        REQUIRE( std::string(kii._author.access_token).length() > 0 );
+
+        res = kii_ti_put_bulk_states(&kii, NULL, NULL, NULL, NULL, NULL);
+        int status_code =  khc_get_status_code(&kii._khc);
+        INFO("Status code is: " << status_code);
+        REQUIRE( res == KII_ERR_RESP_STATUS );
+        REQUIRE((status_code == 400 || status_code == 422));
+    }
 }

--- a/tests/large_test/kii/ti_test.cpp
+++ b/tests/large_test/kii/ti_test.cpp
@@ -255,36 +255,13 @@ TEST_CASE("Empty request payloads") {
         kiiltest::RWFunc ctx;
         ctx.on_read = on_read;
         res = kii_ti_put_bulk_states(&kii, kiiltest::read_cb, &ctx, NULL, NULL, NULL);
-        int status_code =  khc_get_status_code(&kii._khc);
-        INFO("Status code is: " << status_code);
-        REQUIRE( res == KII_ERR_RESP_STATUS );
-        REQUIRE(status_code == 400);
-        picojson::value v;
-        auto err_str = picojson::parse(v, buff);
-        REQUIRE ( err_str.empty() );
-        REQUIRE ( v.is<picojson::object>() );
-        picojson::object obj = v.get<picojson::object>();
-        auto errorCode = obj.at("errorCode");
-        REQUIRE ( errorCode.is<std::string>() );
-        REQUIRE ( errorCode.get<std::string>() == std::string("BAD_REQUEST") );
+        kiiltest::check_error_response(kii, buff, res, 400, "BAD_REQUEST");
     }
 
     SECTION("Put bulk states with no callback")
     {
-
         res = kii_ti_put_bulk_states(&kii, NULL, NULL, NULL, NULL, NULL);
-        int status_code =  khc_get_status_code(&kii._khc);
-        INFO("Status code is: " << status_code);
-        REQUIRE( res == KII_ERR_RESP_STATUS );
-        REQUIRE(status_code == 400);
-        picojson::value v;
-        auto err_str = picojson::parse(v, buff);
-        REQUIRE ( err_str.empty() );
-        REQUIRE ( v.is<picojson::object>() );
-        picojson::object obj = v.get<picojson::object>();
-        auto errorCode = obj.at("errorCode");
-        REQUIRE ( errorCode.is<std::string>() );
-        REQUIRE ( errorCode.get<std::string>() == std::string("EMPTY_BODY") );
+        kiiltest::check_error_response(kii, buff, res, 400, "EMPTY_BODY");
     }
 
     SECTION("Patch bulk states with empty callback")
@@ -298,35 +275,13 @@ TEST_CASE("Empty request payloads") {
         kiiltest::RWFunc ctx;
         ctx.on_read = on_read;
         res = kii_ti_patch_bulk_states(&kii, kiiltest::read_cb, &ctx, NULL, NULL, NULL);
-        int status_code =  khc_get_status_code(&kii._khc);
-        INFO("Status code is: " << status_code);
-        REQUIRE( res == KII_ERR_RESP_STATUS );
-        REQUIRE(status_code == 400);
-        picojson::value v;
-        auto err_str = picojson::parse(v, buff);
-        REQUIRE ( err_str.empty() );
-        REQUIRE ( v.is<picojson::object>() );
-        picojson::object obj = v.get<picojson::object>();
-        auto errorCode = obj.at("errorCode");
-        REQUIRE ( errorCode.is<std::string>() );
-        REQUIRE ( errorCode.get<std::string>() == std::string("BAD_REQUEST") );
+        kiiltest::check_error_response(kii, buff, res, 400, "BAD_REQUEST");
     }
 
     SECTION("Patch bulk states with null callback")
     {
         res = kii_ti_patch_bulk_states(&kii, NULL, NULL, NULL, NULL, NULL);
-        int status_code =  khc_get_status_code(&kii._khc);
-        INFO("Status code is: " << status_code);
-        REQUIRE( res == KII_ERR_RESP_STATUS );
-        REQUIRE((status_code == 400));
-        picojson::value v;
-        auto err_str = picojson::parse(v, buff);
-        REQUIRE ( err_str.empty() );
-        REQUIRE ( v.is<picojson::object>() );
-        picojson::object obj = v.get<picojson::object>();
-        auto errorCode = obj.at("errorCode");
-        REQUIRE ( errorCode.is<std::string>() );
-        REQUIRE ( errorCode.get<std::string>() == std::string("EMPTY_BODY") );
+        kiiltest::check_error_response(kii, buff, res, 400, "EMPTY_BODY");
     }
 
     SECTION("Patch state with empty callback")
@@ -339,35 +294,12 @@ TEST_CASE("Empty request payloads") {
         kiiltest::RWFunc ctx;
         ctx.on_read = on_read;
         res = kii_ti_patch_state(&kii, kiiltest::read_cb, &ctx, NULL, NULL, NULL);
-        int status_code =  khc_get_status_code(&kii._khc);
-        INFO("Status code is: " << status_code);
-        REQUIRE( res == KII_ERR_RESP_STATUS );
-        REQUIRE((status_code == 400));
-        picojson::value v;
-        auto err_str = picojson::parse(v, buff);
-        REQUIRE ( err_str.empty() );
-        REQUIRE ( v.is<picojson::object>() );
-        picojson::object obj = v.get<picojson::object>();
-        auto errorCode = obj.at("errorCode");
-        REQUIRE ( errorCode.is<std::string>() );
-        REQUIRE ( errorCode.get<std::string>() == std::string("BAD_REQUEST") );
+        kiiltest::check_error_response(kii, buff, res, 400, "BAD_REQUEST");
     }
 
    SECTION("Patch state with null callback")
     {
         res = kii_ti_patch_state(&kii, NULL, NULL, NULL, NULL, NULL);
-        int status_code =  khc_get_status_code(&kii._khc);
-        INFO("Status code is: " << status_code);
-        REQUIRE( res == KII_ERR_RESP_STATUS );
-        REQUIRE((status_code == 400));
-
-        picojson::value v;
-        auto err_str = picojson::parse(v, buff);
-        REQUIRE ( err_str.empty() );
-        REQUIRE ( v.is<picojson::object>() );
-        picojson::object obj = v.get<picojson::object>();
-        auto errorCode = obj.at("errorCode");
-        REQUIRE ( errorCode.is<std::string>() );
-        REQUIRE ( errorCode.get<std::string>() == std::string("EMPTY_BODY") );
+        kiiltest::check_error_response(kii, buff, res, 400, "EMPTY_BODY");
     }
 }


### PR DESCRIPTION
It's been observed that in some scenarios the SDK sends empty uploads.

Those scenarios are:
- callback preparing request returns 0 right away in the first call.
  (In this case, 'transfer-encoding:chunked' is used, with a 0-byte
  chunk.)
- callback itself is null.
  (In this case, 'content-length:0' is used instead.)

This just adds tests covering these behaviors and harnessing them.

<details><summary>null callback</summary>
<p>

```
POST https://api-jp.kii.com/thing-if/apps/xxxxxxx/targets/thing:th.93c969f6ffe0-8efa-fe11-9166-xxxxx/states-bulk HTTP/1.1
>HOST: api-jp.kii.com
>Authorization: Bearer xxxxxxx
>Content-Type: application/vnd.kii.StateBulkUploadRequest+json
>Content-Length: 0
>Connection: Close
>
>HTTP/1.1 400 Bad Request
<Date: Thu, 29 Aug 2024 15:15:44 GMT
<Content-Type: application/json;charset=UTF-8
<Content-Length: 98
<Connection: close
<Cache-Control: max-age=0, no-cache, no-store
<Access-Control-Expose-Headers: Content-Type, Authorization, Content-Length, X-Requested-With, ETag, X-Step-Count, X-Environment-version, X-HTTP-Status-Code
<Access-Control-Allow-Origin: *
<
<{  "errorCode": "BAD_REQUEST",  "message": "The request cannot be fulfilled due to bad syntax"}* close = 0
```

</p>
</details> 

<details><summary>empty result callback</summary>
<p>

```
POST https://api-jp.kii.com/thing-if/apps/xxxxxx/targets/thing:th.f8acfa8ec9a0-43a9-fe11-9166-xxxxx/states-bulk HTTP/1.1
>HOST: api-jp.kii.com
>Authorization: Bearer xxxxx
>Content-Type: application/vnd.kii.StateBulkUploadRequest+json
>Transfer-Encoding: chunked
>Connection: Close
>
>0
>
>HTTP/1.1 400 Bad Request
<Date: Thu, 29 Aug 2024 15:15:39 GMT
<Content-Type: application/json;charset=UTF-8
<Content-Length: 98
<Connection: close
<Cache-Control: max-age=0, no-cache, no-store
<Access-Control-Expose-Headers: Content-Type, Authorization, Content-Length, X-Requested-With, ETag, X-Step-Count, X-Environment-version, X-HTTP-Status-Code
<Access-Control-Allow-Origin: *
<
<{  "errorCode": "BAD_REQUEST",  "message": "The request cannot be fulfilled due to bad syntax"}* close = 0
* connect = 0
```

</p>
</details> 
